### PR TITLE
Align branch 2.1.1 to Casper node v2.1.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ ctor = "*"
 dotenvy = "0.15.7"
 
 [patch.crates-io]
-casper-client = { version = "5", git = "https://github.com/casper-ecosystem/casper-client-rs", branch = "dev" }
-casper-types = { git = "https://github.com/casper-network/casper-node", branch = "dev" }
-casper-binary-port = { git = "https://github.com/casper-network/casper-node", branch = "dev" }
+casper-client = { version = "5", git = "https://github.com/casper-ecosystem/casper-client-rs", branch = "release-5.0.0" }
+casper-types = { git = "https://github.com/casper-network/casper-node", tag = "v2.1.1" }
+casper-binary-port = { git = "https://github.com/casper-network/casper-node", tag = "v2.1.1" }
 casper-binary-port-access = { git = "https://github.com/gRoussac/casper-binary-port-client", branch = "casper_1.1.1" }

--- a/src/sdk/rpcs/query_global_state.rs
+++ b/src/sdk/rpcs/query_global_state.rs
@@ -339,7 +339,7 @@ impl SDK {
                 random_id,
                 &self.get_rpc_address(rpc_address),
                 self.get_verbosity(verbosity).into(),
-                Some(maybe_global_state_identifier.into()),
+                maybe_global_state_identifier.into(),
                 key.unwrap().into(),
                 path,
             )

--- a/tests/integration/rust/Cargo.toml
+++ b/tests/integration/rust/Cargo.toml
@@ -23,7 +23,7 @@ name = "sdk_tests"
 path = "src/lib.rs"
 
 [patch.crates-io]
-casper-client = { version = "5", git = "https://github.com/casper-ecosystem/casper-client-rs", branch = "dev" }
-# # casper-types = { git = "https://github.com/casper-network/casper-node", branch = "dev" }
-# casper-binary-port = { git = "https://github.com/casper-network/casper-node", branch = "dev" }
+casper-client = { version = "5", git = "https://github.com/casper-ecosystem/casper-client-rs", branch = "release-5.0.0" }
+casper-types = { git = "https://github.com/casper-network/casper-node", tag = "v2.1.1" }
+casper-binary-port = { git = "https://github.com/casper-network/casper-node", tag = "v2.1.1" }
 casper-binary-port-access = { git = "https://github.com/gRoussac/casper-binary-port-client", branch = "casper_1.1.1" }


### PR DESCRIPTION
Pin casper-types/binary-port to node tag v2.1.1 and casper-client to release-5.0.0 so the branch no longer pulls node/client dev (types 7.x). Keep binary-port-access on casper_1.1.1.