### PR TITLE
Align branch 2.2.2 to Casper node v2.2.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casper-rust-wasm-sdk"
-version = "2.1.1"
+version = "2.2.2"
 edition = "2021"
 description = "Casper Rust Wasm Web SDK"
 repository = "https://github.com/casper-ecosystem/casper-rust-wasm-sdk"
@@ -20,11 +20,11 @@ exclude = [
 ]
 
 [dependencies]
-casper-types = { version = "7.0.0", default-features = false, features = [
+casper-types = { version = "7.1.1", default-features = false, features = [
   "datasize",
 ] }
 casper-client = { version = "5", default-features = false }
-casper-binary-port = { version = "1.1.1" }
+casper-binary-port = { version = "1.2.1" }
 casper-binary-port-access = { version = "0.1.0" }
 rand = { version = "0.9.2", default-features = false, features = [
   "thread_rng",
@@ -75,6 +75,6 @@ dotenvy = "0.15.7"
 
 [patch.crates-io]
 casper-client = { version = "5", git = "https://github.com/casper-ecosystem/casper-client-rs", branch = "dev" }
-casper-types = { git = "https://github.com/casper-network/casper-node", branch = "dev" }
-casper-binary-port = { git = "https://github.com/casper-network/casper-node", branch = "dev" }
-casper-binary-port-access = { git = "https://github.com/gRoussac/casper-binary-port-client", branch = "casper_2.2.0" }
+casper-types = { git = "https://github.com/casper-network/casper-node", tag = "v2.2.2" }
+casper-binary-port = { git = "https://github.com/casper-network/casper-node", tag = "v2.2.2" }
+casper-binary-port-access = { git = "https://github.com/gRoussac/casper-binary-port-client", branch = "casper_2.2.2" }

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,7 +23,7 @@ Add the SDK as a dependency of your project:
 > Cargo.toml
 
 ```toml
-casper-rust-wasm-sdk = { version = "2.1.1", git = "https://github.com/casper-ecosystem/casper-rust-wasm-sdk.git" }
+casper-rust-wasm-sdk = { version = "2.2.2", git = "https://github.com/casper-ecosystem/casper-rust-wasm-sdk.git" }
 ```
 
 ## Usage

--- a/examples/desktop/electron/package-lock.json
+++ b/examples/desktop/electron/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "casper-webclient",
-  "version": "2.1.1",
+  "version": "2.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "casper-webclient",
-      "version": "2.1.1",
+      "version": "2.2.2",
       "license": "ISC",
       "dependencies": {
         "ws": "^8.21.0"

--- a/examples/desktop/electron/package.json
+++ b/examples/desktop/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "casper-webclient",
-  "version": "2.1.1",
+  "version": "2.2.2",
   "description": "Casper Client Demo app",
   "main": "index.js",
   "scripts": {

--- a/examples/desktop/node/package-lock.json
+++ b/examples/desktop/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "casper",
-  "version": "2.1.1",
+  "version": "2.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "casper",
-      "version": "2.1.1",
+      "version": "2.2.2",
       "license": "ISC",
       "dependencies": {
         "casper-rust-wasm-sdk": "file:../../../pkg-nodejs"
@@ -18,7 +18,7 @@
     },
     "../../../pkg-nodejs": {
       "name": "casper-rust-wasm-sdk",
-      "version": "2.1.1",
+      "version": "2.2.2",
       "license": "Apache-2.0"
     },
     "node_modules/@types/node": {

--- a/examples/desktop/node/package.json
+++ b/examples/desktop/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "casper",
-  "version": "2.1.1",
+  "version": "2.2.2",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/examples/frontend/angular/package-lock.json
+++ b/examples/frontend/angular/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "casper-webclient",
-  "version": "2.1.1",
+  "version": "2.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "casper-webclient",
-      "version": "2.1.1",
+      "version": "2.2.2",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "~21.2.15",
@@ -65,7 +65,7 @@
     },
     "../../../pkg": {
       "name": "casper-rust-wasm-sdk",
-      "version": "2.1.1",
+      "version": "2.2.2",
       "license": "Apache-2.0"
     },
     "node_modules/@algolia/abtesting": {

--- a/examples/frontend/angular/package.json
+++ b/examples/frontend/angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "casper-webclient",
-  "version": "2.1.1",
+  "version": "2.2.2",
   "license": "MIT",
   "scripts": {
     "build-proxy-conf": "node build-proxy-conf.js",

--- a/examples/frontend/angular/src/app/health/health.component.spec.ts
+++ b/examples/frontend/angular/src/app/health/health.component.spec.ts
@@ -19,7 +19,7 @@ describe('HealthComponent', () => {
     const component = fixture.componentInstance;
     expect(component.healthResult.status).toBe('healthy');
     expect(component.healthResult.service).toBe('Casper Webclient');
-    expect(component.healthResult.version).toBe('2.1.1');
+    expect(component.healthResult.version).toBe('2.2.2');
   });
 });
 
@@ -28,6 +28,6 @@ describe('buildHealthResult', () => {
     const result = buildHealthResult();
     expect(result.status).toBe('healthy');
     expect(result.service).toBe('Casper Webclient');
-    expect(result.version).toBe('2.1.1');
+    expect(result.version).toBe('2.2.2');
   });
 });

--- a/examples/frontend/angular/src/app/health/health.component.ts
+++ b/examples/frontend/angular/src/app/health/health.component.ts
@@ -7,7 +7,7 @@ export interface HealthResult {
   version: string;
 }
 
-const VERSION = '2.1.1';
+const VERSION = '2.2.2';
 
 export function buildHealthResult(): HealthResult {
   return {

--- a/pkg-nodejs/README.md
+++ b/pkg-nodejs/README.md
@@ -23,7 +23,7 @@ Add the SDK as a dependency of your project:
 > Cargo.toml
 
 ```toml
-casper-rust-wasm-sdk = { version = "2.1.1", git = "https://github.com/casper-ecosystem/casper-rust-wasm-sdk.git" }
+casper-rust-wasm-sdk = { version = "2.2.2", git = "https://github.com/casper-ecosystem/casper-rust-wasm-sdk.git" }
 ```
 
 ## Usage

--- a/pkg-nodejs/package.json
+++ b/pkg-nodejs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "casper-rust-wasm-sdk",
   "description": "Casper Rust Wasm Web SDK",
-  "version": "2.1.1",
+  "version": "2.2.2",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/pkg/README.md
+++ b/pkg/README.md
@@ -23,7 +23,7 @@ Add the SDK as a dependency of your project:
 > Cargo.toml
 
 ```toml
-casper-rust-wasm-sdk = { version = "2.1.1", git = "https://github.com/casper-ecosystem/casper-rust-wasm-sdk.git" }
+casper-rust-wasm-sdk = { version = "2.2.2", git = "https://github.com/casper-ecosystem/casper-rust-wasm-sdk.git" }
 ```
 
 ## Usage

--- a/pkg/package.json
+++ b/pkg/package.json
@@ -2,7 +2,7 @@
   "name": "casper-rust-wasm-sdk",
   "type": "module",
   "description": "Casper Rust Wasm Web SDK",
-  "version": "2.1.1",
+  "version": "2.2.2",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/tests/e2e/package-lock.json
+++ b/tests/e2e/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "e2e",
-  "version": "2.1.1",
+  "version": "2.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "e2e",
-      "version": "2.1.1",
+      "version": "2.2.2",
       "license": "ISC",
       "dependencies": {
         "casper-rust-wasm-sdk": "file:../../pkg-nodejs",
@@ -23,7 +23,7 @@
     },
     "../../pkg-nodejs": {
       "name": "casper-rust-wasm-sdk",
-      "version": "2.1.1",
+      "version": "2.2.2",
       "license": "Apache-2.0"
     },
     "node_modules/@babel/code-frame": {

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -1,6 +1,6 @@
 {
   "name": "e2e",
-  "version": "2.1.1",
+  "version": "2.2.2",
   "description": "e2e tests",
   "main": "index.js",
   "scripts": {

--- a/tests/integration/rust/Cargo.toml
+++ b/tests/integration/rust/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "sdk_tests"
-version = "2.1.1"
+version = "2.2.2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-casper-rust-wasm-sdk = { path = "../../../", version = "2.1.1" }
+casper-rust-wasm-sdk = { path = "../../../", version = "2.2.2" }
 tokio = { version = "1", features = ["full"] }
 once_cell = "*"
 chrono = "0.4"
@@ -24,6 +24,6 @@ path = "src/lib.rs"
 
 [patch.crates-io]
 casper-client = { version = "5", git = "https://github.com/casper-ecosystem/casper-client-rs", branch = "dev" }
-casper-types = { git = "https://github.com/casper-network/casper-node", branch = "dev" }
-casper-binary-port = { git = "https://github.com/casper-network/casper-node", branch = "dev" }
-casper-binary-port-access = { git = "https://github.com/gRoussac/casper-binary-port-client", branch = "casper_2.2.0" }
+casper-types = { git = "https://github.com/casper-network/casper-node", tag = "v2.2.2" }
+casper-binary-port = { git = "https://github.com/casper-network/casper-node", tag = "v2.2.2" }
+casper-binary-port-access = { git = "https://github.com/gRoussac/casper-binary-port-client", branch = "casper_2.2.2" }


### PR DESCRIPTION
Pin casper-types/binary-port to node tag v2.2.2, binary-port-access to casper_2.2.2, bump declared floors to 7.1.1/1.2.1, and set package version to 2.2.2.