### PR TITLE
Add casper-rust-wasm-sdk MCP sidecar (stdio + HTTP :8790)

### DIFF
--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -1,0 +1,17 @@
+{
+  "mcpServers": {
+    "casper-rust-wasm-sdk-http": {
+      "url": "http://127.0.0.1:8790/mcp"
+    },
+    "casper-rust-wasm-sdk-stdio-cargo": {
+      "command": "cargo",
+      "args": ["run", "-p", "casper-rust-wasm-sdk-mcp", "--quiet", "--"],
+      "cwd": "${workspaceFolder}",
+      "env": {
+        "RUST_LOG": "warn",
+        "CASPER_RPC_URL": "http://127.0.0.1:11101",
+        "CASPER_NODE_URL": "127.0.0.1:28101"
+      }
+    }
+  }
+}

--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -1,17 +1,26 @@
 {
   "mcpServers": {
-    "casper-rust-wasm-sdk-http": {
+    "casper-rust-wasm-sdk": {
       "url": "http://127.0.0.1:8790/mcp"
     },
-    "casper-rust-wasm-sdk-stdio-cargo": {
-      "command": "cargo",
-      "args": ["run", "-p", "casper-rust-wasm-sdk-mcp", "--quiet", "--"],
-      "cwd": "${workspaceFolder}",
-      "env": {
-        "RUST_LOG": "warn",
-        "CASPER_RPC_URL": "http://127.0.0.1:11101",
-        "CASPER_NODE_URL": "127.0.0.1:28101"
-      }
+    "casper-rust-wasm-sdk-stdio-docker": {
+      "command": "docker",
+      "args": [
+        "run",
+        "--rm",
+        "-i",
+        "--add-host",
+        "host.docker.internal:host-gateway",
+        "-e",
+        "CASPER_RPC_URL=http://host.docker.internal:11101",
+        "-e",
+        "CASPER_NODE_URL=host.docker.internal:28101",
+        "-e",
+        "RUST_LOG=warn",
+        "--entrypoint",
+        "casper-rust-wasm-sdk-mcp",
+        "casper-rust-wasm-sdk-mcp:2.2.2"
+      ]
     }
   }
 }

--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -19,7 +19,7 @@
         "RUST_LOG=warn",
         "--entrypoint",
         "casper-rust-wasm-sdk-mcp",
-        "casper-rust-wasm-sdk-mcp:2.2.2"
+        "interchouette/casper-rust-wasm-sdk-mcp:2.2.2-mcp"
       ]
     }
   }

--- a/.cursor/rules/sdk-use-mcp-nctl.mdc
+++ b/.cursor/rules/sdk-use-mcp-nctl.mdc
@@ -1,0 +1,19 @@
+---
+description: Prefer MCP tools to talk to NCTL / Casper nodes — no ad-hoc curl or docker exec for chain queries
+alwaysApply: true
+---
+
+# Use MCP for NCTL / chain access
+
+When this workspace needs a live Casper / NCTL node:
+
+1. **Chain / SDK calls** — use **casper-rust-wasm-sdk** MCP (`:8790`, tools `sdk_*`). Prefer `sdk_help`, `sdk_get_node_status`, `sdk_get_block`, `sdk_query_balance`, etc. Start with `make mcp-http` or host `make run-mcp-http`.
+2. **NCTL lifecycle** (start/stop/assets/logs) — use **casper-nctl-2-docker** MCP (`:8788`) when that server is configured; do not reinvent `docker compose` / `make start` via shell unless MCP is unavailable.
+3. **Do not** probe NCTL with raw `curl` to `:11101`, `docker exec` into `casper-nctl-*`, or one-off SDK binaries for agent work when the SDK MCP is up.
+
+```text
+❌ curl -d '{"method":"info_get_status"...}' http://127.0.0.1:11101/rpc
+✅ CallMcpTool → sdk_get_node_status (casper-rust-wasm-sdk MCP)
+```
+
+Defaults: `CASPER_RPC_URL=http://127.0.0.1:11101`, `CASPER_NODE_URL=127.0.0.1:28101`. Config: `mcp/mcp.json.example` → `.cursor/mcp.json`.

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,19 @@
+# Keep MCP image builds lean (context = repo root).
+# `tests/integration/rust` is required: root Cargo.toml has a path dep on `sdk_tests`.
+.git
+.github
+target
+**/target
+examples
+pkg
+pkg-nodejs
+docs
+docker
+*.md
+!mcp/README.md
+.env
+.cursor
+node_modules
+**/*.wasm
+tests/e2e
+tests/integration/rust/target

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,7 @@
+[workspace]
+members = [".", "mcp"]
+resolver = "2"
+
 [package]
 name = "casper-rust-wasm-sdk"
 version = "2.2.0"

--- a/Makefile
+++ b/Makefile
@@ -107,8 +107,40 @@ docker-deploy-prod:
 
 # --- MCP sidecar (mcp/ — path-depends on casper-rust-wasm-sdk) ---
 
+MCP_NAME ?= casper-rust-wasm-sdk-mcp
+MCP_VERSION ?= 2.2.2
+MCP_IMAGE ?= $(MCP_NAME):$(MCP_VERSION)
+MCP_HUB_IMAGE ?= interchouette/$(MCP_NAME)
+COMPOSE_MCP ?= docker/docker-compose.mcp.yml
+DOCKER_BUILDKIT ?= 1
+
 mcp-build:
 	cargo build -p casper-rust-wasm-sdk-mcp --release
+
+mcp-docker-build:
+	DOCKER_BUILDKIT=$(DOCKER_BUILDKIT) docker build --network=host \
+		-t $(MCP_IMAGE) \
+		-t $(MCP_NAME):latest \
+		-t $(MCP_HUB_IMAGE):$(MCP_VERSION) \
+		-f mcp/Dockerfile \
+		.
+
+# Prefer local/Hub image; build if missing.
+mcp-http:
+	@if ! docker image inspect $(MCP_IMAGE) >/dev/null 2>&1 \
+		&& ! docker image inspect $(MCP_HUB_IMAGE):$(MCP_VERSION) >/dev/null 2>&1; then \
+		echo "MCP image missing; building locally…"; \
+		$(MAKE) mcp-docker-build; \
+	fi
+	CASPER_SDK_MCP_IMAGE=$$(docker image inspect $(MCP_HUB_IMAGE):$(MCP_VERSION) >/dev/null 2>&1 \
+		&& echo $(MCP_HUB_IMAGE):$(MCP_VERSION) \
+		|| echo $(MCP_IMAGE)) \
+		docker compose -f $(COMPOSE_MCP) up -d --force-recreate
+
+mcp-http-stop:
+	-docker compose -f $(COMPOSE_MCP) down --remove-orphans
+	-docker stop casper-rust-wasm-sdk-mcp 2>/dev/null
+	-docker rm casper-rust-wasm-sdk-mcp 2>/dev/null
 
 run-mcp:
 	cargo run -p casper-rust-wasm-sdk-mcp --quiet --
@@ -116,10 +148,12 @@ run-mcp:
 run-mcp-http:
 	cargo run -p casper-rust-wasm-sdk-mcp --quiet -- --http --listen 127.0.0.1:8790
 
-# Alias for family parity (host HTTP; no Docker image in this phase).
-mcp-http: run-mcp-http
-
 mcp-test:
 	cargo test -p casper-rust-wasm-sdk-mcp
 
-.PHONY: mcp-build run-mcp run-mcp-http mcp-http mcp-test
+mcp-test-live:
+	CASPER_RPC_URL=$${CASPER_RPC_URL:-http://127.0.0.1:11101} \
+	CASPER_NODE_URL=$${CASPER_NODE_URL:-127.0.0.1:28101} \
+		cargo test -p casper-rust-wasm-sdk-mcp --lib -- --ignored --nocapture
+
+.PHONY: mcp-build mcp-docker-build mcp-http mcp-http-stop run-mcp run-mcp-http mcp-test mcp-test-live

--- a/Makefile
+++ b/Makefile
@@ -108,9 +108,11 @@ docker-deploy-prod:
 # --- MCP sidecar (mcp/ — path-depends on casper-rust-wasm-sdk) ---
 
 MCP_NAME ?= casper-rust-wasm-sdk-mcp
-MCP_VERSION ?= 2.2.2
+MCP_VERSION ?= 2.2.2-mcp
 MCP_IMAGE ?= $(MCP_NAME):$(MCP_VERSION)
 MCP_HUB_IMAGE ?= interchouette/$(MCP_NAME)
+MCP_GHCR_PERSONAL_IMAGE ?= ghcr.io/groussac/$(MCP_NAME)
+MCP_GHCR_ORG_IMAGE ?= ghcr.io/interchouette-itc/$(MCP_NAME)
 COMPOSE_MCP ?= docker/docker-compose.mcp.yml
 DOCKER_BUILDKIT ?= 1
 
@@ -122,13 +124,33 @@ mcp-docker-build:
 		-t $(MCP_IMAGE) \
 		-t $(MCP_NAME):latest \
 		-t $(MCP_HUB_IMAGE):$(MCP_VERSION) \
+		-t $(MCP_HUB_IMAGE):latest \
 		-f mcp/Dockerfile \
 		.
 
+mcp-docker-push-hub:
+	docker push $(MCP_HUB_IMAGE):$(MCP_VERSION)
+	docker push $(MCP_HUB_IMAGE):latest
+
+mcp-docker-push-ghcr-personal:
+	docker tag $(MCP_HUB_IMAGE):$(MCP_VERSION) $(MCP_GHCR_PERSONAL_IMAGE):$(MCP_VERSION)
+	docker tag $(MCP_HUB_IMAGE):latest $(MCP_GHCR_PERSONAL_IMAGE):latest
+	docker push $(MCP_GHCR_PERSONAL_IMAGE):$(MCP_VERSION)
+	docker push $(MCP_GHCR_PERSONAL_IMAGE):latest
+
+mcp-docker-push-ghcr-itc:
+	docker tag $(MCP_HUB_IMAGE):$(MCP_VERSION) $(MCP_GHCR_ORG_IMAGE):$(MCP_VERSION)
+	docker tag $(MCP_HUB_IMAGE):latest $(MCP_GHCR_ORG_IMAGE):latest
+	docker push $(MCP_GHCR_ORG_IMAGE):$(MCP_VERSION)
+	docker push $(MCP_GHCR_ORG_IMAGE):latest
+
+mcp-docker-push: mcp-docker-push-hub mcp-docker-push-ghcr-personal mcp-docker-push-ghcr-itc
+
 # Prefer local/Hub image; build if missing.
 mcp-http:
-	@if ! docker image inspect $(MCP_IMAGE) >/dev/null 2>&1 \
-		&& ! docker image inspect $(MCP_HUB_IMAGE):$(MCP_VERSION) >/dev/null 2>&1; then \
+	-docker pull $(MCP_HUB_IMAGE):$(MCP_VERSION)
+	@if ! docker image inspect $(MCP_HUB_IMAGE):$(MCP_VERSION) >/dev/null 2>&1 \
+		&& ! docker image inspect $(MCP_IMAGE) >/dev/null 2>&1; then \
 		echo "MCP image missing; building locally…"; \
 		$(MAKE) mcp-docker-build; \
 	fi
@@ -156,9 +178,10 @@ mcp-test-live:
 	CASPER_NODE_URL=$${CASPER_NODE_URL:-127.0.0.1:28101} \
 		cargo test -p casper-rust-wasm-sdk-mcp --lib -- --ignored --nocapture
 
-.PHONY: mcp-build mcp-docker-build mcp-http mcp-http-stop run-mcp run-mcp-http mcp-test mcp-test-live
 # HTTP (compose) + Docker stdio against live NCTL. Requires: make mcp-http, NCTL up.
 mcp-smoke:
 	bash mcp/scripts/smoke_transports.sh
 
-.PHONY: mcp-smoke
+.PHONY: mcp-build mcp-docker-build mcp-docker-push-hub mcp-docker-push-ghcr-personal \
+	mcp-docker-push-ghcr-itc mcp-docker-push mcp-http mcp-http-stop \
+	run-mcp run-mcp-http mcp-test mcp-test-live mcp-smoke

--- a/Makefile
+++ b/Makefile
@@ -104,3 +104,22 @@ docker-deploy-prod:
 	ssh ubuntu@casper-box "sudo docker compose -f /home/ubuntu/webclient/docker-compose.yml up -d --force-recreate"
 
 .PHONY: docker-build docker-start docker-stop docker-start-prod docker-stop-prod
+
+# --- MCP sidecar (mcp/ — path-depends on casper-rust-wasm-sdk) ---
+
+mcp-build:
+	cargo build -p casper-rust-wasm-sdk-mcp --release
+
+run-mcp:
+	cargo run -p casper-rust-wasm-sdk-mcp --quiet --
+
+run-mcp-http:
+	cargo run -p casper-rust-wasm-sdk-mcp --quiet -- --http --listen 127.0.0.1:8790
+
+# Alias for family parity (host HTTP; no Docker image in this phase).
+mcp-http: run-mcp-http
+
+mcp-test:
+	cargo test -p casper-rust-wasm-sdk-mcp
+
+.PHONY: mcp-build run-mcp run-mcp-http mcp-http mcp-test

--- a/Makefile
+++ b/Makefile
@@ -157,3 +157,8 @@ mcp-test-live:
 		cargo test -p casper-rust-wasm-sdk-mcp --lib -- --ignored --nocapture
 
 .PHONY: mcp-build mcp-docker-build mcp-http mcp-http-stop run-mcp run-mcp-http mcp-test mcp-test-live
+# HTTP (compose) + Docker stdio against live NCTL. Requires: make mcp-http, NCTL up.
+mcp-smoke:
+	bash mcp/scripts/smoke_transports.sh
+
+.PHONY: mcp-smoke

--- a/docker/docker-compose.mcp.yml
+++ b/docker/docker-compose.mcp.yml
@@ -3,7 +3,7 @@
 # Build context is the repo root (SDK path dep + [patch.crates-io]).
 services:
   sdk-mcp:
-    image: ${CASPER_SDK_MCP_IMAGE:-casper-rust-wasm-sdk-mcp:2.2.2}
+    image: ${CASPER_SDK_MCP_IMAGE:-interchouette/casper-rust-wasm-sdk-mcp:2.2.2-mcp}
     container_name: casper-rust-wasm-sdk-mcp
     build:
       context: ..

--- a/docker/docker-compose.mcp.yml
+++ b/docker/docker-compose.mcp.yml
@@ -1,0 +1,21 @@
+# Slim MCP sidecar (Streamable HTTP on :8790).
+# Use: make mcp-http / make mcp-http-stop
+# Build context is the repo root (SDK path dep + [patch.crates-io]).
+services:
+  sdk-mcp:
+    image: ${CASPER_SDK_MCP_IMAGE:-casper-rust-wasm-sdk-mcp:2.2.2}
+    container_name: casper-rust-wasm-sdk-mcp
+    build:
+      context: ..
+      dockerfile: mcp/Dockerfile
+    ports:
+      - "8790:8790"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    environment:
+      CASPER_SDK_MCP_HTTP: "1"
+      CASPER_SDK_MCP_ADDR: "0.0.0.0:8790"
+      CASPER_RPC_URL: ${CASPER_RPC_URL:-http://host.docker.internal:11101}
+      CASPER_NODE_URL: ${CASPER_NODE_URL:-host.docker.internal:28101}
+      CASPER_VERBOSITY: ${CASPER_VERBOSITY:-low}
+      RUST_LOG: ${RUST_LOG:-warn}

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,9 +16,10 @@ This page covers different examples of using the SDK.
 The workspace package [`mcp/`](../mcp/) (`casper-rust-wasm-sdk-mcp`) exposes the native Rust SDK as [MCP](https://modelcontextprotocol.io/) tools for Cursor and other agents (stdio or Streamable HTTP on **8790**).
 
 ```bash
-make run-mcp      # stdio
-make mcp-http     # http://127.0.0.1:8790/mcp
+make run-mcp      # stdio (host)
+make mcp-http     # Docker → http://127.0.0.1:8790/mcp
 make mcp-test
+make mcp-test-live  # against live NCTL
 ```
 
 See [`mcp/README.md`](../mcp/README.md), tool inventory [`mcp/TOOLS.md`](../mcp/TOOLS.md), and Cursor sample [`mcp/mcp.json.example`](../mcp/mcp.json.example).

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,18 @@ This page covers different examples of using the SDK.
 
 ⚠ WARNING: This application is for testing and development purposes. Do NOT use private keys or perform real transactions on the testnet/mainnet unless you fully understand the security risks.
 
+## MCP sidecar
+
+The workspace package [`mcp/`](../mcp/) (`casper-rust-wasm-sdk-mcp`) exposes the native Rust SDK as [MCP](https://modelcontextprotocol.io/) tools for Cursor and other agents (stdio or Streamable HTTP on **8790**).
+
+```bash
+make run-mcp      # stdio
+make mcp-http     # http://127.0.0.1:8790/mcp
+make mcp-test
+```
+
+See [`mcp/README.md`](../mcp/README.md), tool inventory [`mcp/TOOLS.md`](../mcp/TOOLS.md), and Cursor sample [`mcp/mcp.json.example`](../mcp/mcp.json.example).
+
 ## Install
 
 <details>

--- a/mcp/Cargo.toml
+++ b/mcp/Cargo.toml
@@ -39,9 +39,11 @@ write = []
 [dependencies]
 anyhow = "1"
 casper-rust-wasm-sdk = { path = ".." }
+casper-types = { version = "7.1.1", default-features = false, features = ["datasize"] }
 clap = { version = "4", features = ["derive", "env"] }
 mcpkit = "0.7"
 mcpkit-axum = "0.7"
+serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 tracing = "0.1"

--- a/mcp/Cargo.toml
+++ b/mcp/Cargo.toml
@@ -39,8 +39,11 @@ write = []
 [dependencies]
 anyhow = "1"
 casper-rust-wasm-sdk = { path = ".." }
-casper-types = { version = "7.1.1", default-features = false, features = ["datasize"] }
+casper-types = { version = "7.1.1", default-features = false, features = [
+  "datasize",
+] }
 clap = { version = "4", features = ["derive", "env"] }
+hex = "0.4"
 mcpkit = "0.7"
 mcpkit-axum = "0.7"
 serde = { version = "1", features = ["derive"] }

--- a/mcp/Cargo.toml
+++ b/mcp/Cargo.toml
@@ -39,7 +39,7 @@ write = []
 [dependencies]
 anyhow = "1"
 casper-rust-wasm-sdk = { path = ".." }
-casper-types = { version = "7.1.1", default-features = false, features = [
+casper-types = { version = "7.0.0", default-features = false, features = [
   "datasize",
 ] }
 clap = { version = "4", features = ["derive", "env"] }

--- a/mcp/Cargo.toml
+++ b/mcp/Cargo.toml
@@ -1,0 +1,48 @@
+[package]
+name = "casper-rust-wasm-sdk-mcp"
+version = "2.2.2"
+edition = "2021"
+rust-version = "1.85"
+license = "Apache-2.0"
+description = "MCP server for casper-rust-wasm-sdk (stdio + Streamable HTTP)"
+readme = "README.md"
+repository = "https://github.com/casper-ecosystem/casper-rust-wasm-sdk"
+authors = ["gRoussac"]
+
+[[bin]]
+name = "casper-rust-wasm-sdk-mcp"
+path = "src/main.rs"
+
+[lib]
+name = "casper_rust_wasm_sdk_mcp"
+path = "src/lib.rs"
+
+[features]
+default = ["full"]
+full = [
+  "rpc",
+  "binary-port",
+  "transaction",
+  "deploy",
+  "contract",
+  "helpers",
+  "write",
+]
+rpc = []
+binary-port = []
+transaction = []
+deploy = []
+contract = []
+helpers = []
+write = []
+
+[dependencies]
+anyhow = "1"
+casper-rust-wasm-sdk = { path = ".." }
+clap = { version = "4", features = ["derive", "env"] }
+mcpkit = "0.7"
+mcpkit-axum = "0.7"
+serde_json = "1"
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/mcp/Dockerfile
+++ b/mcp/Dockerfile
@@ -34,8 +34,7 @@ RUN apt-get update \
 
 COPY --from=builder /casper-rust-wasm-sdk-mcp /usr/local/bin/casper-rust-wasm-sdk-mcp
 
-ENV CASPER_SDK_MCP_HTTP=1 \
-    CASPER_SDK_MCP_ADDR=0.0.0.0:8790 \
+ENV CASPER_SDK_MCP_ADDR=0.0.0.0:8790 \
     CASPER_RPC_URL=http://host.docker.internal:11101 \
     CASPER_NODE_URL=host.docker.internal:28101 \
     RUST_LOG=warn \
@@ -43,5 +42,7 @@ ENV CASPER_SDK_MCP_HTTP=1 \
 
 EXPOSE 8790
 
+# Default CMD is HTTP (compose). For Cursor stdio, override command to just the binary
+# and do NOT set CASPER_SDK_MCP_HTTP (clap would force HTTP and break stdio).
 ENTRYPOINT ["casper-rust-wasm-sdk-mcp"]
 CMD ["--http", "--listen", "0.0.0.0:8790"]

--- a/mcp/Dockerfile
+++ b/mcp/Dockerfile
@@ -1,0 +1,47 @@
+# casper-rust-wasm-sdk-mcp — Streamable HTTP on :8790
+# Build context: repository root (path-depends on the SDK crate + workspace patches).
+#   docker build -f mcp/Dockerfile -t casper-rust-wasm-sdk-mcp:2.2.2 .
+
+ARG RUST_IMAGE=rust:slim-bookworm
+ARG RUNTIME_IMAGE=debian:bookworm-slim
+
+FROM ${RUST_IMAGE} AS builder
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    pkg-config \
+    libssl-dev \
+    git \
+    binutils \
+  && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /src
+COPY Cargo.toml Cargo.lock ./
+COPY src ./src
+COPY mcp ./mcp
+COPY tests/integration/rust ./tests/integration/rust
+
+RUN cargo build -p casper-rust-wasm-sdk-mcp --release \
+  && strip -s target/release/casper-rust-wasm-sdk-mcp \
+  && cp target/release/casper-rust-wasm-sdk-mcp /casper-rust-wasm-sdk-mcp
+
+FROM ${RUNTIME_IMAGE} AS runtime
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /casper-rust-wasm-sdk-mcp /usr/local/bin/casper-rust-wasm-sdk-mcp
+
+ENV CASPER_SDK_MCP_HTTP=1 \
+    CASPER_SDK_MCP_ADDR=0.0.0.0:8790 \
+    CASPER_RPC_URL=http://host.docker.internal:11101 \
+    CASPER_NODE_URL=host.docker.internal:28101 \
+    RUST_LOG=warn \
+    SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
+
+EXPOSE 8790
+
+ENTRYPOINT ["casper-rust-wasm-sdk-mcp"]
+CMD ["--http", "--listen", "0.0.0.0:8790"]

--- a/mcp/PATTERNS.md
+++ b/mcp/PATTERNS.md
@@ -1,0 +1,148 @@
+# Phase 0 — MCP patterns to copy
+
+Primary templates: **kms-secp256k1-api/mcp** (best overall) + **casper-nctl-2-docker/mcp**.
+tvscreener-rs = in-crate MCP; use it only for path-dep-on-lib style of tool bodies.
+
+---
+
+## Layout (sidecar)
+
+```
+mcp/
+  Cargo.toml
+  README.md
+  mcp.json.example
+  TOOLS.md              # Phase 0 checklist
+  PATTERNS.md           # this file
+  src/
+    main.rs             # clap + init_logging + run/run_http
+    lib.rs              # mods + re-exports
+    server.rs           # #[mcp_server] + handlers + version test
+    sdk_handle.rs       # SDK::new from env
+    format.rs           # Result → ToolOutput
+    tools/              # feature-gated tool modules
+```
+
+Keep mcpkit **out** of the root wasm SDK `Cargo.toml`.
+
+---
+
+## Cargo.toml
+
+```toml
+edition = "2021"
+rust-version = "1.85"
+
+anyhow = "1"
+clap = { version = "4", features = ["derive", "env"] }
+mcpkit = "0.7"
+mcpkit-axum = "0.7"
+serde_json = "1"
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+
+casper-rust-wasm-sdk = { path = ".." }
+```
+
+Features: `default = ["full"]`, `full = ["rpc", "binary-port", "transaction", "deploy", "contract", "helpers", "write"]`.
+
+Release profile (family): `lto`, `codegen-units=1`, `panic=abort`, `strip=symbols`, `opt-level=s`.
+
+**Workspace:** root must be a workspace with `members = [".", "mcp"]` so `[patch.crates-io]` applies.
+
+---
+
+## CLI + env
+
+| Flag       | Env                   | Default        |
+| ---------- | --------------------- | -------------- |
+| `--http`   | `CASPER_SDK_MCP_HTTP` | false (stdio)  |
+| `--listen` | `CASPER_SDK_MCP_ADDR` | `0.0.0.0:8790` |
+
+SDK env: `CASPER_RPC_URL`, `CASPER_NODE_URL`, `CASPER_VERBOSITY`, `RUST_LOG`.
+
+Ports in family: 8787 tvs / 8788 nctl / 8789 kms / **8790 sdk**.
+
+---
+
+## Logging (copy kms)
+
+- Writer: **stderr**
+- Default filter: **warn** (`RUST_LOG` override)
+- `with_ansi(false)` — Cursor treats stderr noise as `[error]`
+
+---
+
+## Transports
+
+```rust
+pub async fn run() -> Result<(), McpError> {
+    let transport = StdioTransport::new();
+    let server = ServerBuilder::new(Handle)
+        .with_tools(Handle)
+        .build();
+    server.serve(transport).await
+}
+
+pub async fn run_http(addr: &str) -> std::io::Result<()> {
+    McpRouter::new(Handle).serve(addr).await
+}
+```
+
+Stub empty `ResourceHandler` / `PromptHandler` (`invalid_params` on unknown).
+
+---
+
+## Version sync test (prefer kms needle)
+
+```rust
+let needle = format!(
+    r#"#[mcp_server(name = "casper-rust-wasm-sdk", version = "{}")]"#,
+    env!("CARGO_PKG_VERSION")
+);
+assert!(include_str!("server.rs").contains(&needle));
+```
+
+---
+
+## Makefile targets (Phase 6)
+
+| Target                      | Role                                     |
+| --------------------------- | ---------------------------------------- |
+| `mcp-build`                 | release build of mcp package             |
+| `run-mcp`                   | stdio                                    |
+| `run-mcp-http` / `mcp-http` | HTTP :8790                               |
+| `mcp-test`                  | `cargo test -p casper-rust-wasm-sdk-mcp` |
+
+---
+
+## mcp.json.example shape
+
+```json
+{
+  "mcpServers": {
+    "casper-rust-wasm-sdk-http": {
+      "url": "http://127.0.0.1:8790/mcp"
+    },
+    "casper-rust-wasm-sdk-stdio-cargo": {
+      "command": "cargo",
+      "args": ["run", "-p", "casper-rust-wasm-sdk-mcp", "--quiet", "--"],
+      "cwd": "${workspaceFolder}",
+      "env": { "RUST_LOG": "warn" }
+    }
+  }
+}
+```
+
+---
+
+## Copy vs differ
+
+| Copy from kms/nctl                           | Differ for rustSDK                         |
+| -------------------------------------------- | ------------------------------------------ |
+| Separate `mcp/` crate, mcpkit 0.7            | Path-dep on SDK lib (in-process)           |
+| clap `--http` / `--listen`                   | No Make/Docker lifecycle tools (Phase 1–7) |
+| stderr warn logging                          | No HTTP client to wrap an API              |
+| `run` / `run_http` + empty resources/prompts | Port 8790                                  |
+| Version sync test                            | Keep mcpkit off wasm root crate            |

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -1,0 +1,29 @@
+# MCP server for casper-rust-wasm-sdk
+
+Rust **mcpkit** sidecar (`casper-rust-wasm-sdk-mcp`) exposing the SDK as MCP tools.
+
+> Phase 1: workspace stub that path-depends on the SDK. Stdio / HTTP server and tools land in later phases.
+
+See [TOOLS.md](TOOLS.md) and [PATTERNS.md](PATTERNS.md).
+
+## Build
+
+From the repo root (workspace):
+
+```bash
+cargo build -p casper-rust-wasm-sdk-mcp
+cargo run -p casper-rust-wasm-sdk-mcp
+```
+
+Slim feature set:
+
+```bash
+cargo build -p casper-rust-wasm-sdk-mcp --no-default-features --features "rpc,helpers"
+```
+
+## Planned transports (Phase 2+)
+
+| Mode      | Command                       | Use                |
+| --------- | ----------------------------- | ------------------ |
+| **stdio** | `casper-rust-wasm-sdk-mcp`    | Local Cursor spawn |
+| **HTTP**  | `--http` on **8790** → `/mcp` | Streamable HTTP    |

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -35,7 +35,14 @@ Slim feature set:
 cargo build -p casper-rust-wasm-sdk-mcp --no-default-features --features "rpc,helpers"
 ```
 
-## Tools (Phase 2)
+## Tools (Phase 3)
 
-Always on: `sdk_help`, `sdk_get_endpoints`, `sdk_set_endpoints`.  
-Feature groups (`helpers`, `rpc`, …) land in Phases 3–5 — see TOOLS.md.
+Always on: `sdk_help`, `sdk_get_endpoints`, `sdk_set_endpoints`.
+
+**helpers** (18): timestamp, blake2b, dictionary key, CEP-18 base64 keys, TTL/gas, keygen, hex, motes, JSON/CLValue helpers.
+
+**rpc** (22): node status, peers, chainspec, blocks, balances, entity/account, transaction/deploy lookups, dictionary/global state, speculative exec, `list_rpcs`.
+
+Later phases: binary-port, transaction builders, deploy, contract, write.
+
+> Note: mcpkit registers helper/rpc tools in the binary even when those Cargo features are off; `sdk_help` lists only enabled feature groups. Domain modules for Phase 3 are always compiled so feature splits stay buildable.

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -35,7 +35,7 @@ Slim feature set:
 cargo build -p casper-rust-wasm-sdk-mcp --no-default-features --features "rpc,helpers"
 ```
 
-## Tools (Phase 3–4)
+## Tools (Phase 3–5)
 
 Always on: `sdk_help`, `sdk_get_endpoints`, `sdk_set_endpoints`.
 
@@ -43,8 +43,14 @@ Always on: `sdk_help`, `sdk_get_endpoints`, `sdk_set_endpoints`.
 
 **rpc** (22): node status, peers, chainspec, blocks, balances, entity/account, transaction/deploy lookups, dictionary/global state, speculative exec, `list_rpcs`.
 
-**binary-port** (33): headers/blocks, peers/status/uptime, rewards, global state, speculative execution, protocol version (needs `CASPER_NODE_URL`). `try_accept` is Phase 5 (`write`).
+**binary-port** (33): headers/blocks, peers/status/uptime, rewards, global state, speculative execution, protocol version (needs `CASPER_NODE_URL`).
 
-Later phases: transaction builders, deploy, contract, write.
+**transaction** (4): make / make_transfer / speculative builders.
 
-> Note: mcpkit registers helper/rpc tools in the binary even when those Cargo features are off; `sdk_help` lists only enabled feature groups. Domain modules for Phase 3 are always compiled so feature splits stay buildable.
+**deploy** (4): legacy make / speculative builders.
+
+**contract** (2): `query_contract_dict`, `query_contract_key`.
+
+**write** (13): sign/put/submit transaction & deploy, install, call_entrypoint, binary `try_accept`.
+
+Complex inputs use JSON strings — see `mcp/TOOLS.md` and `tools/params.rs` (`transaction_params_json`, `builder_params_json`, …).

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -6,12 +6,12 @@ Inventory: [TOOLS.md](TOOLS.md). Patterns: [PATTERNS.md](PATTERNS.md). Cursor co
 
 ## Transports
 
-| Mode | Command | Use |
-| --- | --- | --- |
-| **stdio (Docker)** | see [mcp.json.example](mcp.json.example) `…-stdio` | Cursor spawn via image |
-| **stdio (host)** | `make run-mcp` | Local Cursor spawn |
-| **HTTP (Docker)** | `make mcp-http` | Streamable HTTP on **8790** |
-| **HTTP (host)** | `make run-mcp-http` | Same URL without Docker |
+| Mode               | Command                                            | Use                         |
+| ------------------ | -------------------------------------------------- | --------------------------- |
+| **stdio (Docker)** | see [mcp.json.example](mcp.json.example) `…-stdio` | Cursor spawn via image      |
+| **stdio (host)**   | `make run-mcp`                                     | Local Cursor spawn          |
+| **HTTP (Docker)**  | `make mcp-http`                                    | Streamable HTTP on **8790** |
+| **HTTP (host)**    | `make run-mcp-http`                                | Same URL without Docker     |
 
 ```bash
 make mcp-docker-build   # image casper-rust-wasm-sdk-mcp:2.2.2
@@ -27,30 +27,30 @@ Family ports: 8787 tvs / 8788 nctl / 8789 kms / **8790 sdk**.
 
 ## Env
 
-| Variable | Role | Default |
-| --- | --- | --- |
-| `CASPER_SDK_MCP_HTTP` | Use HTTP transport | off (host) / on (image) |
-| `CASPER_SDK_MCP_ADDR` | HTTP bind | `0.0.0.0:8790` |
-| `CASPER_RPC_URL` | JSON-RPC | `http://127.0.0.1:11101` |
-| `CASPER_NODE_URL` | Binary port | `127.0.0.1:28101` |
-| `CASPER_VERBOSITY` | `low` / `medium` / `high` | `low` |
-| `RUST_LOG` | tracing filter (stderr, no ANSI) | `warn` |
+| Variable              | Role                             | Default                  |
+| --------------------- | -------------------------------- | ------------------------ |
+| `CASPER_SDK_MCP_HTTP` | Use HTTP transport               | off (host) / on (image)  |
+| `CASPER_SDK_MCP_ADDR` | HTTP bind                        | `0.0.0.0:8790`           |
+| `CASPER_RPC_URL`      | JSON-RPC                         | `http://127.0.0.1:11101` |
+| `CASPER_NODE_URL`     | Binary port                      | `127.0.0.1:28101`        |
+| `CASPER_VERBOSITY`    | `low` / `medium` / `high`        | `low`                    |
+| `RUST_LOG`            | tracing filter (stderr, no ANSI) | `warn`                   |
 
 Docker containers reach host NCTL via `host.docker.internal` (compose sets `extra_hosts`).
 
 ## Features
 
-| Feature | Tools |
-| --- | --- |
-| *(always)* | `sdk_help`, `sdk_get_endpoints`, `sdk_set_endpoints` |
-| `helpers` | utilities (keys, blake2b, motes, …) |
-| `rpc` | JSON-RPC reads + speculative RPC |
-| `binary-port` | binary-port queries (needs `CASPER_NODE_URL`) |
-| `transaction` | make / speculative transaction builders |
-| `deploy` | legacy make / speculative deploy builders |
-| `contract` | `query_contract_dict`, `query_contract_key` |
-| `write` | sign/put/submit, install, call_entrypoint, `try_accept` |
-| `full` (default) | all of the above |
+| Feature          | Tools                                                   |
+| ---------------- | ------------------------------------------------------- |
+| _(always)_       | `sdk_help`, `sdk_get_endpoints`, `sdk_set_endpoints`    |
+| `helpers`        | utilities (keys, blake2b, motes, …)                     |
+| `rpc`            | JSON-RPC reads + speculative RPC                        |
+| `binary-port`    | binary-port queries (needs `CASPER_NODE_URL`)           |
+| `transaction`    | make / speculative transaction builders                 |
+| `deploy`         | legacy make / speculative deploy builders               |
+| `contract`       | `query_contract_dict`, `query_contract_key`             |
+| `write`          | sign/put/submit, install, call_entrypoint, `try_accept` |
+| `full` (default) | all of the above                                        |
 
 ```bash
 cargo build -p casper-rust-wasm-sdk-mcp
@@ -69,10 +69,10 @@ Complex inputs use JSON strings — see [TOOLS.md](TOOLS.md) and `tools/params.r
 
 **Active** [`.cursor/mcp.json`](../.cursor/mcp.json):
 
-| Server | Transport | Backing |
-| --- | --- | --- |
-| `casper-rust-wasm-sdk` | HTTP `:8790/mcp` | Docker image via `make mcp-http` |
-| `casper-rust-wasm-sdk-stdio-docker` | stdio | Same image (`docker run -i …`) |
+| Server                              | Transport        | Backing                          |
+| ----------------------------------- | ---------------- | -------------------------------- |
+| `casper-rust-wasm-sdk`              | HTTP `:8790/mcp` | Docker image via `make mcp-http` |
+| `casper-rust-wasm-sdk-stdio-docker` | stdio            | Same image (`docker run -i …`)   |
 
 Both use image `casper-rust-wasm-sdk-mcp:2.2.2`. Cargo stdio is optional in [mcp.json.example](mcp.json.example) only (slow cold start).
 
@@ -82,11 +82,11 @@ Agents must use MCP for NCTL/chain access (`.cursor/rules/sdk-use-mcp-nctl.mdc`)
 
 ## Smoke
 
-| Check | Result |
-| --- | --- |
-| Feature-matrix builds + unit tests | pass (Phase 7) |
-| HTTP `initialize` on `:8790/mcp` | pass |
+| Check                                             | Result                          |
+| ------------------------------------------------- | ------------------------------- |
+| Feature-matrix builds + unit tests                | pass (Phase 7)                  |
+| HTTP `initialize` on `:8790/mcp`                  | pass                            |
 | Live NCTL `sdk_get_node_status` / `sdk_get_peers` | **pass** (NCTL 2.2 on `:11101`) |
-| Docker HTTP `make mcp-http` + `tools/call` | **pass** |
-| Docker stdio `docker run -i` initialize | **pass** |
-| Host / cargo stdio initialize | **pass** |
+| Docker HTTP `make mcp-http` + `tools/call`        | **pass**                        |
+| Docker stdio `docker run -i` initialize           | **pass**                        |
+| Host / cargo stdio initialize                     | **pass**                        |

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -1,56 +1,69 @@
 # MCP server for casper-rust-wasm-sdk
 
-Rust **mcpkit** sidecar (`casper-rust-wasm-sdk-mcp`) exposing the SDK as MCP tools.
+Rust **mcpkit** sidecar (`casper-rust-wasm-sdk-mcp`) exposing the native SDK API as MCP tools (in-process path dependency — not an HTTP proxy of the SDK).
 
-See [TOOLS.md](TOOLS.md) and [PATTERNS.md](PATTERNS.md).
+Inventory: [TOOLS.md](TOOLS.md). Patterns: [PATTERNS.md](PATTERNS.md). Cursor config sample: [mcp.json.example](mcp.json.example).
 
 ## Transports
 
-| Mode      | Command                                           | Use                                  |
-| --------- | ------------------------------------------------- | ------------------------------------ |
-| **stdio** | `cargo run -p casper-rust-wasm-sdk-mcp`           | Local Cursor spawn                   |
-| **HTTP**  | `cargo run -p casper-rust-wasm-sdk-mcp -- --http` | Streamable HTTP on **8790** → `/mcp` |
+| Mode | Command | Use |
+| --- | --- | --- |
+| **stdio** | `make run-mcp` | Local Cursor spawn |
+| **HTTP** | `make mcp-http` / `make run-mcp-http` | Streamable HTTP on **8790** → `http://127.0.0.1:8790/mcp` |
+
+```bash
+make mcp-build          # release binary → target/release/casper-rust-wasm-sdk-mcp
+make run-mcp            # stdio
+make mcp-http           # HTTP :8790
+make mcp-test
+```
+
+Family ports: 8787 tvs / 8788 nctl / 8789 kms / **8790 sdk**.
 
 ## Env
 
-| Variable              | Role                      | Default                  |
-| --------------------- | ------------------------- | ------------------------ |
-| `CASPER_SDK_MCP_HTTP` | Use HTTP transport        | off                      |
-| `CASPER_SDK_MCP_ADDR` | HTTP bind                 | `0.0.0.0:8790`           |
-| `CASPER_RPC_URL`      | JSON-RPC                  | `http://127.0.0.1:11101` |
-| `CASPER_NODE_URL`     | Binary port               | `127.0.0.1:28101`        |
-| `CASPER_VERBOSITY`    | `low` / `medium` / `high` | `low`                    |
-| `RUST_LOG`            | tracing filter            | `warn`                   |
+| Variable | Role | Default |
+| --- | --- | --- |
+| `CASPER_SDK_MCP_HTTP` | Use HTTP transport | off |
+| `CASPER_SDK_MCP_ADDR` | HTTP bind | `0.0.0.0:8790` |
+| `CASPER_RPC_URL` | JSON-RPC | `http://127.0.0.1:11101` |
+| `CASPER_NODE_URL` | Binary port | `127.0.0.1:28101` |
+| `CASPER_VERBOSITY` | `low` / `medium` / `high` | `low` |
+| `RUST_LOG` | tracing filter (stderr, no ANSI) | `warn` |
 
-## Build
+## Features
+
+| Feature | Tools |
+| --- | --- |
+| *(always)* | `sdk_help`, `sdk_get_endpoints`, `sdk_set_endpoints` |
+| `helpers` | utilities (keys, blake2b, motes, …) |
+| `rpc` | JSON-RPC reads + speculative RPC |
+| `binary-port` | binary-port queries (needs `CASPER_NODE_URL`) |
+| `transaction` | make / speculative transaction builders |
+| `deploy` | legacy make / speculative deploy builders |
+| `contract` | `query_contract_dict`, `query_contract_key` |
+| `write` | sign/put/submit, install, call_entrypoint, `try_accept` |
+| `full` (default) | all of the above |
 
 ```bash
 cargo build -p casper-rust-wasm-sdk-mcp
-cargo run -p casper-rust-wasm-sdk-mcp -- --help
-```
-
-Slim feature set:
-
-```bash
 cargo build -p casper-rust-wasm-sdk-mcp --no-default-features --features "rpc,helpers"
 ```
 
-## Tools (Phase 3–5)
+> mcpkit may still compile tool handlers when a feature is off; `sdk_help` lists only enabled groups.
 
-Always on: `sdk_help`, `sdk_get_endpoints`, `sdk_set_endpoints`.
+## Tools
 
-**helpers** (18): timestamp, blake2b, dictionary key, CEP-18 base64 keys, TTL/gas, keygen, hex, motes, JSON/CLValue helpers.
+**helpers** (18) · **rpc** (22) · **binary-port** (33) · **transaction** (4) · **deploy** (4) · **contract** (2) · **write** (13).
 
-**rpc** (22): node status, peers, chainspec, blocks, balances, entity/account, transaction/deploy lookups, dictionary/global state, speculative exec, `list_rpcs`.
+Complex inputs use JSON strings — see [TOOLS.md](TOOLS.md) and `tools/params.rs` (`transaction_params_json`, `builder_params_json`, …).
 
-**binary-port** (33): headers/blocks, peers/status/uptime, rewards, global state, speculative execution, protocol version (needs `CASPER_NODE_URL`).
+## Cursor
 
-**transaction** (4): make / make_transfer / speculative builders.
+Copy an entry from [mcp.json.example](mcp.json.example) into `.cursor/mcp.json`:
 
-**deploy** (4): legacy make / speculative builders.
+1. Start HTTP with `make mcp-http`, then use the `…-http` URL entry; **or**
+2. Use `…-stdio-cargo` for spawn-from-source; **or**
+3. `make mcp-build` then `…-stdio-host` for the release binary.
 
-**contract** (2): `query_contract_dict`, `query_contract_key`.
-
-**write** (13): sign/put/submit transaction & deploy, install, call_entrypoint, binary `try_accept`.
-
-Complex inputs use JSON strings — see `mcp/TOOLS.md` and `tools/params.rs` (`transaction_params_json`, `builder_params_json`, …).
+Point `CASPER_RPC_URL` / `CASPER_NODE_URL` at NCTL (or another node). Compose with **casper-nctl-2-docker** MCP (:8788) for network lifecycle and **kms-secp256k1-api** MCP (:8789) for KMS signing if needed — this sidecar owns SDK calls only.

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -2,17 +2,31 @@
 
 Rust **mcpkit** sidecar (`casper-rust-wasm-sdk-mcp`) exposing the SDK as MCP tools.
 
-> Phase 1: workspace stub that path-depends on the SDK. Stdio / HTTP server and tools land in later phases.
-
 See [TOOLS.md](TOOLS.md) and [PATTERNS.md](PATTERNS.md).
+
+## Transports
+
+| Mode | Command | Use |
+| --- | --- | --- |
+| **stdio** | `cargo run -p casper-rust-wasm-sdk-mcp` | Local Cursor spawn |
+| **HTTP** | `cargo run -p casper-rust-wasm-sdk-mcp -- --http` | Streamable HTTP on **8790** → `/mcp` |
+
+## Env
+
+| Variable | Role | Default |
+| --- | --- | --- |
+| `CASPER_SDK_MCP_HTTP` | Use HTTP transport | off |
+| `CASPER_SDK_MCP_ADDR` | HTTP bind | `0.0.0.0:8790` |
+| `CASPER_RPC_URL` | JSON-RPC | `http://127.0.0.1:11101` |
+| `CASPER_NODE_URL` | Binary port | `127.0.0.1:28101` |
+| `CASPER_VERBOSITY` | `low` / `medium` / `high` | `low` |
+| `RUST_LOG` | tracing filter | `warn` |
 
 ## Build
 
-From the repo root (workspace):
-
 ```bash
 cargo build -p casper-rust-wasm-sdk-mcp
-cargo run -p casper-rust-wasm-sdk-mcp
+cargo run -p casper-rust-wasm-sdk-mcp -- --help
 ```
 
 Slim feature set:
@@ -21,9 +35,7 @@ Slim feature set:
 cargo build -p casper-rust-wasm-sdk-mcp --no-default-features --features "rpc,helpers"
 ```
 
-## Planned transports (Phase 2+)
+## Tools (Phase 2)
 
-| Mode      | Command                       | Use                |
-| --------- | ----------------------------- | ------------------ |
-| **stdio** | `casper-rust-wasm-sdk-mcp`    | Local Cursor spawn |
-| **HTTP**  | `--http` on **8790** → `/mcp` | Streamable HTTP    |
+Always on: `sdk_help`, `sdk_get_endpoints`, `sdk_set_endpoints`.  
+Feature groups (`helpers`, `rpc`, …) land in Phases 3–5 — see TOOLS.md.

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -6,10 +6,10 @@ Inventory: [TOOLS.md](TOOLS.md). Patterns: [PATTERNS.md](PATTERNS.md). Cursor co
 
 ## Transports
 
-| Mode | Command | Use |
-| --- | --- | --- |
-| **stdio** | `make run-mcp` | Local Cursor spawn |
-| **HTTP** | `make mcp-http` / `make run-mcp-http` | Streamable HTTP on **8790** → `http://127.0.0.1:8790/mcp` |
+| Mode      | Command                               | Use                                                       |
+| --------- | ------------------------------------- | --------------------------------------------------------- |
+| **stdio** | `make run-mcp`                        | Local Cursor spawn                                        |
+| **HTTP**  | `make mcp-http` / `make run-mcp-http` | Streamable HTTP on **8790** → `http://127.0.0.1:8790/mcp` |
 
 ```bash
 make mcp-build          # release binary → target/release/casper-rust-wasm-sdk-mcp
@@ -22,28 +22,28 @@ Family ports: 8787 tvs / 8788 nctl / 8789 kms / **8790 sdk**.
 
 ## Env
 
-| Variable | Role | Default |
-| --- | --- | --- |
-| `CASPER_SDK_MCP_HTTP` | Use HTTP transport | off |
-| `CASPER_SDK_MCP_ADDR` | HTTP bind | `0.0.0.0:8790` |
-| `CASPER_RPC_URL` | JSON-RPC | `http://127.0.0.1:11101` |
-| `CASPER_NODE_URL` | Binary port | `127.0.0.1:28101` |
-| `CASPER_VERBOSITY` | `low` / `medium` / `high` | `low` |
-| `RUST_LOG` | tracing filter (stderr, no ANSI) | `warn` |
+| Variable              | Role                             | Default                  |
+| --------------------- | -------------------------------- | ------------------------ |
+| `CASPER_SDK_MCP_HTTP` | Use HTTP transport               | off                      |
+| `CASPER_SDK_MCP_ADDR` | HTTP bind                        | `0.0.0.0:8790`           |
+| `CASPER_RPC_URL`      | JSON-RPC                         | `http://127.0.0.1:11101` |
+| `CASPER_NODE_URL`     | Binary port                      | `127.0.0.1:28101`        |
+| `CASPER_VERBOSITY`    | `low` / `medium` / `high`        | `low`                    |
+| `RUST_LOG`            | tracing filter (stderr, no ANSI) | `warn`                   |
 
 ## Features
 
-| Feature | Tools |
-| --- | --- |
-| *(always)* | `sdk_help`, `sdk_get_endpoints`, `sdk_set_endpoints` |
-| `helpers` | utilities (keys, blake2b, motes, …) |
-| `rpc` | JSON-RPC reads + speculative RPC |
-| `binary-port` | binary-port queries (needs `CASPER_NODE_URL`) |
-| `transaction` | make / speculative transaction builders |
-| `deploy` | legacy make / speculative deploy builders |
-| `contract` | `query_contract_dict`, `query_contract_key` |
-| `write` | sign/put/submit, install, call_entrypoint, `try_accept` |
-| `full` (default) | all of the above |
+| Feature          | Tools                                                   |
+| ---------------- | ------------------------------------------------------- |
+| _(always)_       | `sdk_help`, `sdk_get_endpoints`, `sdk_set_endpoints`    |
+| `helpers`        | utilities (keys, blake2b, motes, …)                     |
+| `rpc`            | JSON-RPC reads + speculative RPC                        |
+| `binary-port`    | binary-port queries (needs `CASPER_NODE_URL`)           |
+| `transaction`    | make / speculative transaction builders                 |
+| `deploy`         | legacy make / speculative deploy builders               |
+| `contract`       | `query_contract_dict`, `query_contract_key`             |
+| `write`          | sign/put/submit, install, call_entrypoint, `try_accept` |
+| `full` (default) | all of the above                                        |
 
 ```bash
 cargo build -p casper-rust-wasm-sdk-mcp
@@ -67,3 +67,17 @@ Copy an entry from [mcp.json.example](mcp.json.example) into `.cursor/mcp.json`:
 3. `make mcp-build` then `…-stdio-host` for the release binary.
 
 Point `CASPER_RPC_URL` / `CASPER_NODE_URL` at NCTL (or another node). Compose with **casper-nctl-2-docker** MCP (:8788) for network lifecycle and **kms-secp256k1-api** MCP (:8789) for KMS signing if needed — this sidecar owns SDK calls only.
+
+## Smoke (Phase 7)
+
+Verified on `feat/mcp-sidecar`:
+
+| Check | Result |
+| --- | --- |
+| `cargo build -p casper-rust-wasm-sdk-mcp` (full) | pass |
+| `--no-default-features --features "rpc,helpers"` | pass |
+| `--no-default-features --features "binary-port"` | pass |
+| `--no-default-features --features "transaction,write"` | pass |
+| `make mcp-test` / `cargo test -p casper-rust-wasm-sdk-mcp` | pass (14 unit tests) |
+| HTTP bind `127.0.0.1:8790/mcp` initialize | pass (HTTP 200) |
+| Live NCTL / RPC (`11101` / `7777`) | **skipped** (no local node) |

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -6,21 +6,21 @@ See [TOOLS.md](TOOLS.md) and [PATTERNS.md](PATTERNS.md).
 
 ## Transports
 
-| Mode | Command | Use |
-| --- | --- | --- |
-| **stdio** | `cargo run -p casper-rust-wasm-sdk-mcp` | Local Cursor spawn |
-| **HTTP** | `cargo run -p casper-rust-wasm-sdk-mcp -- --http` | Streamable HTTP on **8790** → `/mcp` |
+| Mode      | Command                                           | Use                                  |
+| --------- | ------------------------------------------------- | ------------------------------------ |
+| **stdio** | `cargo run -p casper-rust-wasm-sdk-mcp`           | Local Cursor spawn                   |
+| **HTTP**  | `cargo run -p casper-rust-wasm-sdk-mcp -- --http` | Streamable HTTP on **8790** → `/mcp` |
 
 ## Env
 
-| Variable | Role | Default |
-| --- | --- | --- |
-| `CASPER_SDK_MCP_HTTP` | Use HTTP transport | off |
-| `CASPER_SDK_MCP_ADDR` | HTTP bind | `0.0.0.0:8790` |
-| `CASPER_RPC_URL` | JSON-RPC | `http://127.0.0.1:11101` |
-| `CASPER_NODE_URL` | Binary port | `127.0.0.1:28101` |
-| `CASPER_VERBOSITY` | `low` / `medium` / `high` | `low` |
-| `RUST_LOG` | tracing filter | `warn` |
+| Variable              | Role                      | Default                  |
+| --------------------- | ------------------------- | ------------------------ |
+| `CASPER_SDK_MCP_HTTP` | Use HTTP transport        | off                      |
+| `CASPER_SDK_MCP_ADDR` | HTTP bind                 | `0.0.0.0:8790`           |
+| `CASPER_RPC_URL`      | JSON-RPC                  | `http://127.0.0.1:11101` |
+| `CASPER_NODE_URL`     | Binary port               | `127.0.0.1:28101`        |
+| `CASPER_VERBOSITY`    | `low` / `medium` / `high` | `low`                    |
+| `RUST_LOG`            | tracing filter            | `warn`                   |
 
 ## Build
 
@@ -35,7 +35,7 @@ Slim feature set:
 cargo build -p casper-rust-wasm-sdk-mcp --no-default-features --features "rpc,helpers"
 ```
 
-## Tools (Phase 3)
+## Tools (Phase 3–4)
 
 Always on: `sdk_help`, `sdk_get_endpoints`, `sdk_set_endpoints`.
 
@@ -43,6 +43,8 @@ Always on: `sdk_help`, `sdk_get_endpoints`, `sdk_set_endpoints`.
 
 **rpc** (22): node status, peers, chainspec, blocks, balances, entity/account, transaction/deploy lookups, dictionary/global state, speculative exec, `list_rpcs`.
 
-Later phases: binary-port, transaction builders, deploy, contract, write.
+**binary-port** (33): headers/blocks, peers/status/uptime, rewards, global state, speculative execution, protocol version (needs `CASPER_NODE_URL`). `try_accept` is Phase 5 (`write`).
+
+Later phases: transaction builders, deploy, contract, write.
 
 > Note: mcpkit registers helper/rpc tools in the binary even when those Cargo features are off; `sdk_help` lists only enabled feature groups. Domain modules for Phase 3 are always compiled so feature splits stay buildable.

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -14,7 +14,8 @@ Inventory: [TOOLS.md](TOOLS.md). Patterns: [PATTERNS.md](PATTERNS.md). Cursor co
 | **HTTP (host)**    | `make run-mcp-http`                                | Same URL without Docker     |
 
 ```bash
-make mcp-docker-build   # image casper-rust-wasm-sdk-mcp:2.2.2
+make mcp-docker-build   # image …:2.2.2-mcp (+ Hub tags)
+make mcp-docker-push    # Hub + GHCR
 make mcp-http           # docker compose → http://127.0.0.1:8790/mcp
 make mcp-http-stop
 make run-mcp            # stdio (host)
@@ -74,7 +75,7 @@ Complex inputs use JSON strings — see [TOOLS.md](TOOLS.md) and `tools/params.r
 | `casper-rust-wasm-sdk`              | HTTP `:8790/mcp` | Docker image via `make mcp-http` |
 | `casper-rust-wasm-sdk-stdio-docker` | stdio            | Same image (`docker run -i …`)   |
 
-Both use image `casper-rust-wasm-sdk-mcp:2.2.2`. Cargo stdio is optional in [mcp.json.example](mcp.json.example) only (slow cold start).
+Both use image `interchouette/casper-rust-wasm-sdk-mcp:2.2.2-mcp`. Cargo stdio is optional in [mcp.json.example](mcp.json.example) only (slow cold start).
 
 Prerequisite: `make mcp-docker-build` once; keep HTTP up with `make mcp-http`.
 

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -6,44 +6,51 @@ Inventory: [TOOLS.md](TOOLS.md). Patterns: [PATTERNS.md](PATTERNS.md). Cursor co
 
 ## Transports
 
-| Mode      | Command                               | Use                                                       |
-| --------- | ------------------------------------- | --------------------------------------------------------- |
-| **stdio** | `make run-mcp`                        | Local Cursor spawn                                        |
-| **HTTP**  | `make mcp-http` / `make run-mcp-http` | Streamable HTTP on **8790** → `http://127.0.0.1:8790/mcp` |
+| Mode | Command | Use |
+| --- | --- | --- |
+| **stdio (Docker)** | see [mcp.json.example](mcp.json.example) `…-stdio` | Cursor spawn via image |
+| **stdio (host)** | `make run-mcp` | Local Cursor spawn |
+| **HTTP (Docker)** | `make mcp-http` | Streamable HTTP on **8790** |
+| **HTTP (host)** | `make run-mcp-http` | Same URL without Docker |
 
 ```bash
-make mcp-build          # release binary → target/release/casper-rust-wasm-sdk-mcp
-make run-mcp            # stdio
-make mcp-http           # HTTP :8790
+make mcp-docker-build   # image casper-rust-wasm-sdk-mcp:2.2.2
+make mcp-http           # docker compose → http://127.0.0.1:8790/mcp
+make mcp-http-stop
+make run-mcp            # stdio (host)
+make run-mcp-http       # HTTP host
 make mcp-test
+make mcp-test-live      # ignored tests vs live NCTL (CASPER_RPC_URL)
 ```
 
 Family ports: 8787 tvs / 8788 nctl / 8789 kms / **8790 sdk**.
 
 ## Env
 
-| Variable              | Role                             | Default                  |
-| --------------------- | -------------------------------- | ------------------------ |
-| `CASPER_SDK_MCP_HTTP` | Use HTTP transport               | off                      |
-| `CASPER_SDK_MCP_ADDR` | HTTP bind                        | `0.0.0.0:8790`           |
-| `CASPER_RPC_URL`      | JSON-RPC                         | `http://127.0.0.1:11101` |
-| `CASPER_NODE_URL`     | Binary port                      | `127.0.0.1:28101`        |
-| `CASPER_VERBOSITY`    | `low` / `medium` / `high`        | `low`                    |
-| `RUST_LOG`            | tracing filter (stderr, no ANSI) | `warn`                   |
+| Variable | Role | Default |
+| --- | --- | --- |
+| `CASPER_SDK_MCP_HTTP` | Use HTTP transport | off (host) / on (image) |
+| `CASPER_SDK_MCP_ADDR` | HTTP bind | `0.0.0.0:8790` |
+| `CASPER_RPC_URL` | JSON-RPC | `http://127.0.0.1:11101` |
+| `CASPER_NODE_URL` | Binary port | `127.0.0.1:28101` |
+| `CASPER_VERBOSITY` | `low` / `medium` / `high` | `low` |
+| `RUST_LOG` | tracing filter (stderr, no ANSI) | `warn` |
+
+Docker containers reach host NCTL via `host.docker.internal` (compose sets `extra_hosts`).
 
 ## Features
 
-| Feature          | Tools                                                   |
-| ---------------- | ------------------------------------------------------- |
-| _(always)_       | `sdk_help`, `sdk_get_endpoints`, `sdk_set_endpoints`    |
-| `helpers`        | utilities (keys, blake2b, motes, …)                     |
-| `rpc`            | JSON-RPC reads + speculative RPC                        |
-| `binary-port`    | binary-port queries (needs `CASPER_NODE_URL`)           |
-| `transaction`    | make / speculative transaction builders                 |
-| `deploy`         | legacy make / speculative deploy builders               |
-| `contract`       | `query_contract_dict`, `query_contract_key`             |
-| `write`          | sign/put/submit, install, call_entrypoint, `try_accept` |
-| `full` (default) | all of the above                                        |
+| Feature | Tools |
+| --- | --- |
+| *(always)* | `sdk_help`, `sdk_get_endpoints`, `sdk_set_endpoints` |
+| `helpers` | utilities (keys, blake2b, motes, …) |
+| `rpc` | JSON-RPC reads + speculative RPC |
+| `binary-port` | binary-port queries (needs `CASPER_NODE_URL`) |
+| `transaction` | make / speculative transaction builders |
+| `deploy` | legacy make / speculative deploy builders |
+| `contract` | `query_contract_dict`, `query_contract_key` |
+| `write` | sign/put/submit, install, call_entrypoint, `try_accept` |
+| `full` (default) | all of the above |
 
 ```bash
 cargo build -p casper-rust-wasm-sdk-mcp
@@ -56,28 +63,21 @@ cargo build -p casper-rust-wasm-sdk-mcp --no-default-features --features "rpc,he
 
 **helpers** (18) · **rpc** (22) · **binary-port** (33) · **transaction** (4) · **deploy** (4) · **contract** (2) · **write** (13).
 
-Complex inputs use JSON strings — see [TOOLS.md](TOOLS.md) and `tools/params.rs` (`transaction_params_json`, `builder_params_json`, …).
+Complex inputs use JSON strings — see [TOOLS.md](TOOLS.md) and `tools/params.rs`.
 
 ## Cursor
 
-Copy an entry from [mcp.json.example](mcp.json.example) into `.cursor/mcp.json`:
+Copy an entry from [mcp.json.example](mcp.json.example) into [`.cursor/mcp.json`](../.cursor/mcp.json) (a starter file is committed). Prefer HTTP after `make mcp-http`, or stdio-cargo while developing.
 
-1. Start HTTP with `make mcp-http`, then use the `…-http` URL entry; **or**
-2. Use `…-stdio-cargo` for spawn-from-source; **or**
-3. `make mcp-build` then `…-stdio-host` for the release binary.
+Agents in this repo must use MCP tools for NCTL/chain access (see `.cursor/rules/sdk-use-mcp-nctl.mdc`).
 
-Point `CASPER_RPC_URL` / `CASPER_NODE_URL` at NCTL (or another node). Compose with **casper-nctl-2-docker** MCP (:8788) for network lifecycle and **kms-secp256k1-api** MCP (:8789) for KMS signing if needed — this sidecar owns SDK calls only.
+Compose with **casper-nctl-2-docker** MCP (:8788) for network lifecycle and **kms-secp256k1-api** MCP (:8789) for KMS signing — this sidecar owns SDK calls only.
 
-## Smoke (Phase 7)
-
-Verified on `feat/mcp-sidecar`:
+## Smoke
 
 | Check | Result |
 | --- | --- |
-| `cargo build -p casper-rust-wasm-sdk-mcp` (full) | pass |
-| `--no-default-features --features "rpc,helpers"` | pass |
-| `--no-default-features --features "binary-port"` | pass |
-| `--no-default-features --features "transaction,write"` | pass |
-| `make mcp-test` / `cargo test -p casper-rust-wasm-sdk-mcp` | pass (14 unit tests) |
-| HTTP bind `127.0.0.1:8790/mcp` initialize | pass (HTTP 200) |
-| Live NCTL / RPC (`11101` / `7777`) | **skipped** (no local node) |
+| Feature-matrix builds + unit tests | pass (Phase 7) |
+| HTTP `initialize` on `:8790/mcp` | pass |
+| Live NCTL `sdk_get_node_status` / `sdk_get_peers` | **pass** (NCTL 2.2 on `:11101`) |
+| Docker image / `make mcp-http` + `tools/call` | **pass** (`casper-rust-wasm-sdk-mcp:2.2.2` → NCTL via `host.docker.internal`) |

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -67,11 +67,18 @@ Complex inputs use JSON strings — see [TOOLS.md](TOOLS.md) and `tools/params.r
 
 ## Cursor
 
-Copy an entry from [mcp.json.example](mcp.json.example) into [`.cursor/mcp.json`](../.cursor/mcp.json) (a starter file is committed). Prefer HTTP after `make mcp-http`, or stdio-cargo while developing.
+**Active** [`.cursor/mcp.json`](../.cursor/mcp.json):
 
-Agents in this repo must use MCP tools for NCTL/chain access (see `.cursor/rules/sdk-use-mcp-nctl.mdc`).
+| Server | Transport | Backing |
+| --- | --- | --- |
+| `casper-rust-wasm-sdk` | HTTP `:8790/mcp` | Docker image via `make mcp-http` |
+| `casper-rust-wasm-sdk-stdio-docker` | stdio | Same image (`docker run -i …`) |
 
-Compose with **casper-nctl-2-docker** MCP (:8788) for network lifecycle and **kms-secp256k1-api** MCP (:8789) for KMS signing — this sidecar owns SDK calls only.
+Both use image `casper-rust-wasm-sdk-mcp:2.2.2`. Cargo stdio is optional in [mcp.json.example](mcp.json.example) only (slow cold start).
+
+Prerequisite: `make mcp-docker-build` once; keep HTTP up with `make mcp-http`.
+
+Agents must use MCP for NCTL/chain access (`.cursor/rules/sdk-use-mcp-nctl.mdc`).
 
 ## Smoke
 
@@ -80,4 +87,6 @@ Compose with **casper-nctl-2-docker** MCP (:8788) for network lifecycle and **km
 | Feature-matrix builds + unit tests | pass (Phase 7) |
 | HTTP `initialize` on `:8790/mcp` | pass |
 | Live NCTL `sdk_get_node_status` / `sdk_get_peers` | **pass** (NCTL 2.2 on `:11101`) |
-| Docker image / `make mcp-http` + `tools/call` | **pass** (`casper-rust-wasm-sdk-mcp:2.2.2` → NCTL via `host.docker.internal`) |
+| Docker HTTP `make mcp-http` + `tools/call` | **pass** |
+| Docker stdio `docker run -i` initialize | **pass** |
+| Host / cargo stdio initialize | **pass** |

--- a/mcp/TOOLS.md
+++ b/mcp/TOOLS.md
@@ -1,0 +1,218 @@
+# Phase 0 — Native Rust API → MCP tool checklist
+
+**Branch:** `feat/mcp-sidecar`
+**Scope:** `casper-rust-wasm-sdk` native-callable methods under `src/sdk` and `src/helpers`.
+
+**Include:** `impl SDK` + public helpers that compile on non-`wasm32`.
+**Exclude:** `*_js_alias`, `*_options` taking `JsValue`, `CasperWallet`, Watcher streams, `binary_port/wasm32.rs`, wasm-only RPC protocol aliases returning `JsError`.
+
+**Features:** proposed MCP crate gates (`helpers` | `rpc` | `binary-port` | `transaction` | `deploy` | `contract` | `write`). Paths relative to `src/`.
+
+**Legend:** `write` = submit on-chain, sign with secret, or binary accept. Local `make_*` builders are not write. Speculative exec is not write.
+
+---
+
+## Exclusions
+
+| Category                | Examples                                                    |
+| ----------------------- | ----------------------------------------------------------- |
+| JS aliases              | `*_js_alias`, `transfer_transactionjs_alias`                |
+| JsValue options         | `get_*_options`, `query_*_options`                          |
+| Wallet                  | `src/js/wallet.rs` (`CasperWallet`)                         |
+| Watcher                 | `sdk/watcher/*`                                             |
+| wasm32 binary bindings  | `sdk/binary_port/wasm32.rs`                                 |
+| wasm32 RPC name aliases | `info_get_*`, `chain_get_*`, `state_get_*`, `account_put_*` |
+
+---
+
+## meta — always on
+
+| Method             | Path         | MCP tool               | Args                                          | write? |
+| ------------------ | ------------ | ---------------------- | --------------------------------------------- | ------ |
+| `SDK::new`         | `sdk/mod.rs` | `sdk_new` / env init   | `{ rpc_address?, node_address?, verbosity? }` | no     |
+| `get_rpc_address`  | `sdk/mod.rs` | `sdk_get_rpc_address`  | `{ rpc_address? }`                            | no     |
+| `set_rpc_address`  | `sdk/mod.rs` | `sdk_set_rpc_address`  | `{ rpc_address? }`                            | config |
+| `get_node_address` | `sdk/mod.rs` | `sdk_get_node_address` | `{ node_address? }`                           | no     |
+| `set_node_address` | `sdk/mod.rs` | `sdk_set_node_address` | `{ node_address? }`                           | config |
+| `get_verbosity`    | `sdk/mod.rs` | `sdk_get_verbosity`    | `{ verbosity? }`                              | no     |
+| `set_verbosity`    | `sdk/mod.rs` | `sdk_set_verbosity`    | `{ verbosity? }`                              | config |
+| —                  | —            | `sdk_help`             | `{}`                                          | no     |
+
+Env defaults: `CASPER_RPC_URL`, `CASPER_NODE_URL`, `CASPER_VERBOSITY`.
+
+---
+
+## helpers — feature `helpers`
+
+| Method                             | MCP tool                               | Args                    | write?       |
+| ---------------------------------- | -------------------------------------- | ----------------------- | ------------ |
+| `cl_value_to_json`                 | `sdk_cl_value_to_json`                 | `{ cl_value }`          | no           |
+| `get_current_timestamp`            | `sdk_get_current_timestamp`            | `{ timestamp? }`        | no           |
+| `get_blake2b_hash`                 | `sdk_get_blake2b_hash`                 | `{ meta_data }`         | no           |
+| `make_dictionary_item_key`         | `sdk_make_dictionary_item_key`         | `{ key, value }`        | no           |
+| `get_base64_key_from_account_hash` | `sdk_get_base64_key_from_account_hash` | `{ account_hash }`      | no           |
+| `get_base64_key_from_key_hash`     | `sdk_get_base64_key_from_key_hash`     | `{ formatted_hash }`    | no           |
+| `get_ttl_or_default`               | `sdk_get_ttl_or_default`               | `{ ttl? }`              | no           |
+| `parse_timestamp`                  | `sdk_parse_timestamp`                  | `{ value }`             | no           |
+| `parse_ttl`                        | `sdk_parse_ttl`                        | `{ value }`             | no           |
+| `get_gas_price_or_default`         | `sdk_get_gas_price_or_default`         | `{ gas_price? }`        | no           |
+| `secret_key_generate`              | `sdk_secret_key_generate`              | `{}`                    | local keygen |
+| `secret_key_secp256k1_generate`    | `sdk_secret_key_secp256k1_generate`    | `{}`                    | local keygen |
+| `secret_key_from_pem`              | `sdk_secret_key_from_pem`              | `{ secret_key }`        | secret in    |
+| `public_key_from_secret_key`       | `sdk_public_key_from_secret_key`       | `{ secret_key }`        | secret in    |
+| `hex_to_uint8_vec`                 | `sdk_hex_to_uint8_vec`                 | `{ hex_string }`        | no           |
+| `hex_to_string`                    | `sdk_hex_to_string`                    | `{ hex_string }`        | no           |
+| `motes_to_cspr`                    | `sdk_motes_to_cspr`                    | `{ motes }`             | no           |
+| `json_pretty_print`                | `sdk_json_pretty_print`                | `{ value, verbosity? }` | no           |
+
+---
+
+## rpc — feature `rpc` (reads + speculative)
+
+| Method                                          | Path                                  | MCP tool                      | write? |
+| ----------------------------------------------- | ------------------------------------- | ----------------------------- | ------ |
+| `get_account` (deprecated → `get_entity`)       | `sdk/rpcs/get_account.rs`             | `sdk_get_account`             | no     |
+| `get_auction_info`                              | `sdk/rpcs/get_auction_info.rs`        | `sdk_get_auction_info`        | no     |
+| `get_balance`                                   | `sdk/rpcs/get_balance.rs`             | `sdk_get_balance`             | no     |
+| `get_block`                                     | `sdk/rpcs/get_block.rs`               | `sdk_get_block`               | no     |
+| `get_block_transfers`                           | `sdk/rpcs/get_block_transfers.rs`     | `sdk_get_block_transfers`     | no     |
+| `get_chainspec`                                 | `sdk/rpcs/get_chainspec.rs`           | `sdk_get_chainspec`           | no     |
+| `get_deploy`                                    | `sdk/rpcs/get_deploy.rs`              | `sdk_get_deploy`              | no     |
+| `get_dictionary_item`                           | `sdk/rpcs/get_dictionary_item.rs`     | `sdk_get_dictionary_item`     | no     |
+| `get_entity`                                    | `sdk/rpcs/get_entity.rs`              | `sdk_get_entity`              | no     |
+| `get_era_info` (deprecated → `get_era_summary`) | `sdk/rpcs/get_era_info.rs`            | `sdk_get_era_info`            | no     |
+| `get_era_summary`                               | `sdk/rpcs/get_era_summary.rs`         | `sdk_get_era_summary`         | no     |
+| `get_node_status`                               | `sdk/rpcs/get_node_status.rs`         | `sdk_get_node_status`         | no     |
+| `get_peers`                                     | `sdk/rpcs/get_peers.rs`               | `sdk_get_peers`               | no     |
+| `get_state_root_hash`                           | `sdk/rpcs/get_state_root_hash.rs`     | `sdk_get_state_root_hash`     | no     |
+| `get_transaction`                               | `sdk/rpcs/get_transaction.rs`         | `sdk_get_transaction`         | no     |
+| `get_validator_changes`                         | `sdk/rpcs/get_validator_changes.rs`   | `sdk_get_validator_changes`   | no     |
+| `list_rpcs`                                     | `sdk/rpcs/list_rpcs.rs`               | `sdk_list_rpcs`               | no     |
+| `query_balance`                                 | `sdk/rpcs/query_balance.rs`           | `sdk_query_balance`           | no     |
+| `query_balance_details`                         | `sdk/rpcs/query_balance_details.rs`   | `sdk_query_balance_details`   | no     |
+| `query_global_state`                            | `sdk/rpcs/query_global_state.rs`      | `sdk_query_global_state`      | no     |
+| `speculative_exec`                              | `sdk/rpcs/speculative_exec.rs`        | `sdk_speculative_exec`        | no     |
+| `speculative_exec_deploy`                       | `sdk/rpcs/speculative_exec_deploy.rs` | `sdk_speculative_exec_deploy` | no     |
+
+Common optional args: `verbosity?`, `rpc_address?`.
+
+---
+
+## binary-port — feature `binary-port` (reads + speculative)
+
+Common optional: `node_address?`. Path: `sdk/binary_port/mod.rs`.
+
+| Method                                            | MCP tool                                              | Extra args                                       | write? |
+| ------------------------------------------------- | ----------------------------------------------------- | ------------------------------------------------ | ------ |
+| `get_binary_latest_switch_block_header`           | `sdk_get_binary_latest_switch_block_header`           | —                                                | no     |
+| `get_binary_latest_block_header`                  | `sdk_get_binary_latest_block_header`                  | —                                                | no     |
+| `get_binary_block_header_by_height`               | `sdk_get_binary_block_header_by_height`               | `{ height }`                                     | no     |
+| `get_binary_block_header_by_hash`                 | `sdk_get_binary_block_header_by_hash`                 | `{ block_hash }`                                 | no     |
+| `get_binary_latest_block_with_signatures`         | `sdk_get_binary_latest_block_with_signatures`         | —                                                | no     |
+| `get_binary_block_with_signatures_by_height`      | `sdk_get_binary_block_with_signatures_by_height`      | `{ height }`                                     | no     |
+| `get_binary_block_with_signatures_by_hash`        | `sdk_get_binary_block_with_signatures_by_hash`        | `{ block_hash }`                                 | no     |
+| `get_binary_transaction_by_hash`                  | `sdk_get_binary_transaction_by_hash`                  | `{ hash, with_finalized_approvals }`             | no     |
+| `get_binary_peers`                                | `sdk_get_binary_peers`                                | —                                                | no     |
+| `get_binary_uptime`                               | `sdk_get_binary_uptime`                               | —                                                | no     |
+| `get_binary_last_progress`                        | `sdk_get_binary_last_progress`                        | —                                                | no     |
+| `get_binary_reactor_state`                        | `sdk_get_binary_reactor_state`                        | —                                                | no     |
+| `get_binary_network_name`                         | `sdk_get_binary_network_name`                         | —                                                | no     |
+| `get_binary_consensus_validator_changes`          | `sdk_get_binary_consensus_validator_changes`          | —                                                | no     |
+| `get_binary_block_synchronizer_status`            | `sdk_get_binary_block_synchronizer_status`            | —                                                | no     |
+| `get_binary_available_block_range`                | `sdk_get_binary_available_block_range`                | —                                                | no     |
+| `get_binary_next_upgrade`                         | `sdk_get_binary_next_upgrade`                         | —                                                | no     |
+| `get_binary_consensus_status`                     | `sdk_get_binary_consensus_status`                     | —                                                | no     |
+| `get_binary_chainspec_raw_bytes`                  | `sdk_get_binary_chainspec_raw_bytes`                  | —                                                | no     |
+| `get_binary_node_status`                          | `sdk_get_binary_node_status`                          | —                                                | no     |
+| `get_binary_validator_reward_by_era`              | `sdk_get_binary_validator_reward_by_era`              | `{ validator_key, era }`                         | no     |
+| `get_binary_validator_reward_by_block_height`     | `sdk_get_binary_validator_reward_by_block_height`     | `{ validator_key, block_height }`                | no     |
+| `get_binary_validator_reward_by_block_hash`       | `sdk_get_binary_validator_reward_by_block_hash`       | `{ validator_key, block_hash }`                  | no     |
+| `get_binary_delegator_reward_by_era`              | `sdk_get_binary_delegator_reward_by_era`              | `{ validator_key, delegator_key, era }`          | no     |
+| `get_binary_delegator_reward_by_block_height`     | `sdk_get_binary_delegator_reward_by_block_height`     | `{ validator_key, delegator_key, block_height }` | no     |
+| `get_binary_delegator_reward_by_block_hash`       | `sdk_get_binary_delegator_reward_by_block_hash`       | `{ validator_key, delegator_key, block_hash }`   | no     |
+| `get_binary_read_record`                          | `sdk_get_binary_read_record`                          | `{ record_id, key }`                             | no     |
+| `get_binary_global_state_item`                    | `sdk_get_binary_global_state_item`                    | `{ key, path }`                                  | no     |
+| `get_binary_global_state_item_by_state_root_hash` | `sdk_get_binary_global_state_item_by_state_root_hash` | `{ state_root_hash, key, path }`                 | no     |
+| `get_binary_global_state_item_by_block_hash`      | `sdk_get_binary_global_state_item_by_block_hash`      | `{ block_hash, key, path }`                      | no     |
+| `get_binary_global_state_item_by_block_height`    | `sdk_get_binary_global_state_item_by_block_height`    | `{ block_height, key, path }`                    | no     |
+| `get_binary_try_speculative_execution`            | `sdk_get_binary_try_speculative_execution`            | `{ transaction }`                                | no     |
+| `get_binary_protocol_version`                     | `sdk_get_binary_protocol_version`                     | —                                                | no     |
+
+---
+
+## transaction — feature `transaction` (builders + speculative)
+
+| Method                             | Path                                                  | MCP tool                               | write? |
+| ---------------------------------- | ----------------------------------------------------- | -------------------------------------- | ------ |
+| `make_transaction`                 | `sdk/transaction_utils/make_transaction.rs`           | `sdk_make_transaction`                 | no     |
+| `make_transfer_transaction`        | `sdk/transaction_utils/make_transfer_transaction.rs`  | `sdk_make_transfer_transaction`        | no     |
+| `speculative_transaction`          | `sdk/transaction/speculative_transaction.rs`          | `sdk_speculative_transaction`          | no     |
+| `speculative_transfer_transaction` | `sdk/transaction/speculative_transfer_transaction.rs` | `sdk_speculative_transfer_transaction` | no     |
+
+---
+
+## deploy — feature `deploy` (builders + speculative)
+
+| Method                 | Path                                 | MCP tool                   | write? |
+| ---------------------- | ------------------------------------ | -------------------------- | ------ |
+| `make_deploy`          | `sdk/deploy_utils/make_deploy.rs`    | `sdk_make_deploy`          | no     |
+| `make_transfer`        | `sdk/deploy_utils/make_transfer.rs`  | `sdk_make_transfer`        | no     |
+| `speculative_deploy`   | `sdk/deploy/speculative_deploy.rs`   | `sdk_speculative_deploy`   | no     |
+| `speculative_transfer` | `sdk/deploy/speculative_transfer.rs` | `sdk_speculative_transfer` | no     |
+
+---
+
+## contract — feature `contract` (queries)
+
+| Method                | Path                                  | MCP tool                  | write? |
+| --------------------- | ------------------------------------- | ------------------------- | ------ |
+| `query_contract_dict` | `sdk/contract/query_contract_dict.rs` | `sdk_query_contract_dict` | no     |
+| `query_contract_key`  | `sdk/contract/query_contract_key.rs`  | `sdk_query_contract_key`  | no     |
+
+---
+
+## write — feature `write` (submit / sign / accept)
+
+Prefer dual-gate with domain feature where applicable (e.g. `transaction` + `write`).
+
+| Method                                | Path                                        | Domain      | MCP tool                                |
+| ------------------------------------- | ------------------------------------------- | ----------- | --------------------------------------- |
+| `put_transaction`                     | `sdk/rpcs/put_transaction.rs`               | rpc         | `sdk_put_transaction`                   |
+| `put_deploy`                          | `sdk/rpcs/put_deploy.rs`                    | rpc         | `sdk_put_deploy`                        |
+| `transaction`                         | `sdk/transaction/transaction.rs`            | transaction | `sdk_transaction`                       |
+| `transfer_transaction`                | `sdk/transaction/transfer_transaction.rs`   | transaction | `sdk_transfer_transaction`              |
+| `sign_transaction`                    | `sdk/transaction_utils/sign_transaction.rs` | transaction | `sdk_sign_transaction`                  |
+| `deploy`                              | `sdk/deploy/deploy.rs`                      | deploy      | `sdk_deploy`                            |
+| `transfer`                            | `sdk/deploy/transfer.rs`                    | deploy      | `sdk_transfer`                          |
+| `sign_deploy`                         | `sdk/deploy_utils/sign_deploy.rs`           | deploy      | `sdk_sign_deploy`                       |
+| `install`                             | `sdk/contract/install.rs`                   | contract    | `sdk_install`                           |
+| `install_deploy` (deprecated)         | `sdk/contract/install_deploy.rs`            | contract    | `sdk_install_deploy`                    |
+| `call_entrypoint`                     | `sdk/contract/call_entrypoint.rs`           | contract    | `sdk_call_entrypoint`                   |
+| `call_entrypoint_deploy` (deprecated) | `sdk/contract/call_entrypoint_deploy.rs`    | contract    | `sdk_call_entrypoint_deploy`            |
+| `get_binary_try_accept_transaction`   | `sdk/binary_port/mod.rs`                    | binary-port | `sdk_get_binary_try_accept_transaction` |
+
+---
+
+## Counts
+
+| Group                    | Methods  |
+| ------------------------ | -------- |
+| meta (+ `sdk_help`)      | 8        |
+| helpers                  | 18       |
+| rpc                      | 22       |
+| binary-port              | 33       |
+| transaction              | 4        |
+| deploy                   | 4        |
+| contract                 | 2        |
+| write                    | 13       |
+| **Total tools (approx)** | **~104** |
+
+---
+
+## Implementation notes (Phase 1+)
+
+1. Prefer transaction-path tools over deprecated deploy/contract aliases.
+2. Gate `write` and secret-key tools behind explicit agent approval UX.
+3. Complex structs (`TransactionStrParams`, `DeployStrParams`, `QueryGlobalStateParams`, …) accept JSON strings.
+4. Responses: pretty JSON via `format.rs`; map `SdkError` → `ToolOutput::error`.
+5. Binary-port tools need `CASPER_NODE_URL`, not only RPC.

--- a/mcp/TOOLS.md
+++ b/mcp/TOOLS.md
@@ -1,6 +1,7 @@
-# Phase 0 — Native Rust API → MCP tool checklist
+# Native Rust API → MCP tool checklist
 
-**Branch:** `feat/mcp-sidecar`
+**Status:** Implemented on `feat/mcp-sidecar` (Phases 0–5). Meta + feature groups below map to `sdk_*` tools; see `mcp/README.md`.
+
 **Scope:** `casper-rust-wasm-sdk` native-callable methods under `src/sdk` and `src/helpers`.
 
 **Include:** `impl SDK` + public helpers that compile on non-`wasm32`.

--- a/mcp/mcp.json.example
+++ b/mcp/mcp.json.example
@@ -1,9 +1,9 @@
 {
   "mcpServers": {
-    "casper-rust-wasm-sdk-http": {
+    "casper-rust-wasm-sdk": {
       "url": "http://127.0.0.1:8790/mcp"
     },
-    "casper-rust-wasm-sdk-stdio": {
+    "casper-rust-wasm-sdk-stdio-docker": {
       "command": "docker",
       "args": [
         "run",
@@ -17,19 +17,10 @@
         "CASPER_NODE_URL=host.docker.internal:28101",
         "-e",
         "RUST_LOG=warn",
-        "casper-rust-wasm-sdk-mcp:2.2.2",
-        "casper-rust-wasm-sdk-mcp"
+        "--entrypoint",
+        "casper-rust-wasm-sdk-mcp",
+        "casper-rust-wasm-sdk-mcp:2.2.2"
       ]
-    },
-    "casper-rust-wasm-sdk-stdio-host": {
-      "command": "target/release/casper-rust-wasm-sdk-mcp",
-      "args": [],
-      "cwd": "${workspaceFolder}",
-      "env": {
-        "RUST_LOG": "warn",
-        "CASPER_RPC_URL": "http://127.0.0.1:11101",
-        "CASPER_NODE_URL": "127.0.0.1:28101"
-      }
     },
     "casper-rust-wasm-sdk-stdio-cargo": {
       "command": "cargo",

--- a/mcp/mcp.json.example
+++ b/mcp/mcp.json.example
@@ -3,6 +3,24 @@
     "casper-rust-wasm-sdk-http": {
       "url": "http://127.0.0.1:8790/mcp"
     },
+    "casper-rust-wasm-sdk-stdio": {
+      "command": "docker",
+      "args": [
+        "run",
+        "--rm",
+        "-i",
+        "--add-host",
+        "host.docker.internal:host-gateway",
+        "-e",
+        "CASPER_RPC_URL=http://host.docker.internal:11101",
+        "-e",
+        "CASPER_NODE_URL=host.docker.internal:28101",
+        "-e",
+        "RUST_LOG=warn",
+        "casper-rust-wasm-sdk-mcp:2.2.2",
+        "casper-rust-wasm-sdk-mcp"
+      ]
+    },
     "casper-rust-wasm-sdk-stdio-host": {
       "command": "target/release/casper-rust-wasm-sdk-mcp",
       "args": [],

--- a/mcp/mcp.json.example
+++ b/mcp/mcp.json.example
@@ -1,0 +1,27 @@
+{
+  "mcpServers": {
+    "casper-rust-wasm-sdk-http": {
+      "url": "http://127.0.0.1:8790/mcp"
+    },
+    "casper-rust-wasm-sdk-stdio-host": {
+      "command": "target/release/casper-rust-wasm-sdk-mcp",
+      "args": [],
+      "cwd": "${workspaceFolder}",
+      "env": {
+        "RUST_LOG": "warn",
+        "CASPER_RPC_URL": "http://127.0.0.1:11101",
+        "CASPER_NODE_URL": "127.0.0.1:28101"
+      }
+    },
+    "casper-rust-wasm-sdk-stdio-cargo": {
+      "command": "cargo",
+      "args": ["run", "-p", "casper-rust-wasm-sdk-mcp", "--quiet", "--"],
+      "cwd": "${workspaceFolder}",
+      "env": {
+        "RUST_LOG": "warn",
+        "CASPER_RPC_URL": "http://127.0.0.1:11101",
+        "CASPER_NODE_URL": "127.0.0.1:28101"
+      }
+    }
+  }
+}

--- a/mcp/mcp.json.example
+++ b/mcp/mcp.json.example
@@ -19,7 +19,7 @@
         "RUST_LOG=warn",
         "--entrypoint",
         "casper-rust-wasm-sdk-mcp",
-        "casper-rust-wasm-sdk-mcp:2.2.2"
+        "interchouette/casper-rust-wasm-sdk-mcp:2.2.2-mcp"
       ]
     },
     "casper-rust-wasm-sdk-stdio-cargo": {

--- a/mcp/scripts/smoke_transports.sh
+++ b/mcp/scripts/smoke_transports.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 
 RPC_URL="${CASPER_RPC_URL:-http://127.0.0.1:11101}"
 HTTP_URL="${CASPER_SDK_MCP_HTTP_URL:-http://127.0.0.1:8790/mcp}"
-IMAGE="${CASPER_SDK_MCP_IMAGE:-casper-rust-wasm-sdk-mcp:2.2.2}"
+IMAGE="${CASPER_SDK_MCP_IMAGE:-interchouette/casper-rust-wasm-sdk-mcp:2.2.2-mcp}"
 PASS=0
 FAIL=0
 TMP=$(mktemp -d)

--- a/mcp/scripts/smoke_transports.sh
+++ b/mcp/scripts/smoke_transports.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+# Smoke both Cursor transports against a live NCTL (or CASPER_RPC_URL).
+# Usage: make mcp-smoke   # or: ./mcp/scripts/smoke_transports.sh
+set -euo pipefail
+
+RPC_URL="${CASPER_RPC_URL:-http://127.0.0.1:11101}"
+HTTP_URL="${CASPER_SDK_MCP_HTTP_URL:-http://127.0.0.1:8790/mcp}"
+IMAGE="${CASPER_SDK_MCP_IMAGE:-casper-rust-wasm-sdk-mcp:2.2.2}"
+PASS=0
+FAIL=0
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+ok() { echo "  OK  $*"; PASS=$((PASS + 1)); }
+bad() { echo "  FAIL $*"; FAIL=$((FAIL + 1)); }
+
+need() {
+  if ! command -v "$1" >/dev/null; then
+    echo "missing dependency: $1" >&2
+    exit 1
+  fi
+}
+need curl
+need docker
+need python3
+
+echo "== probe NCTL RPC ($RPC_URL) =="
+probe_rpc() {
+  local base="$1"
+  curl -s -m 3 -o "$TMP/nctl.json" -w '%{http_code}' \
+    -H 'Content-Type: application/json' \
+    -d '{"jsonrpc":"2.0","id":1,"method":"info_get_status","params":{}}' \
+    "$base"
+}
+CODE=$(probe_rpc "${RPC_URL%/}/rpc" || true)
+if [[ "$CODE" != "200" ]]; then
+  CODE=$(probe_rpc "$RPC_URL" || true)
+fi
+if [[ "$CODE" == "200" ]]; then
+  ok "NCTL reachable"
+else
+  bad "NCTL not reachable at $RPC_URL (start NCTL first)"
+  echo "PASS=$PASS FAIL=$FAIL"
+  exit 1
+fi
+
+json_rpc() {
+  python3 - "$@" <<'PY'
+import json, sys
+id_, method = sys.argv[1], sys.argv[2]
+params = json.loads(sys.argv[3]) if len(sys.argv) > 3 else {}
+msg = {"jsonrpc": "2.0", "method": method, "params": params}
+if id_ != "null":
+    msg["id"] = int(id_) if id_.isdigit() else id_
+sys.stdout.write(json.dumps(msg, separators=(",", ":")))
+PY
+}
+
+# --- HTTP (Docker compose sidecar) ---
+echo "== HTTP transport ($HTTP_URL) =="
+json_rpc 1 initialize '{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"smoke-transports","version":"0"}}' \
+  >"$TMP/init.json"
+
+CODE=$(curl -s -D "$TMP/hdrs" -o "$TMP/init.out" -m 8 -w '%{http_code}' \
+  -H 'Accept: application/json, text/event-stream' \
+  -H 'Content-Type: application/json' \
+  --data-binary @"$TMP/init.json" \
+  "$HTTP_URL" || echo 000)
+if [[ "$CODE" == "200" ]] && grep -q 'casper-rust-wasm-sdk' "$TMP/init.out"; then
+  ok "initialize"
+else
+  bad "initialize (HTTP $CODE) — run: make mcp-http"
+  echo "PASS=$PASS FAIL=$FAIL"
+  exit 1
+fi
+
+SESSION=$(grep -i '^mcp-session-id:' "$TMP/hdrs" | awk '{print $2}' | tr -d '\r')
+if [[ -n "$SESSION" ]]; then
+  ok "session $SESSION"
+else
+  bad "missing mcp-session-id"
+fi
+
+json_rpc null notifications/initialized '{}' >"$TMP/initialized.json"
+curl -s -m 5 \
+  -H "Mcp-Session-Id: $SESSION" \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json, text/event-stream' \
+  --data-binary @"$TMP/initialized.json" \
+  "$HTTP_URL" >/dev/null || true
+
+http_call() {
+  local id="$1" name="$2"
+  json_rpc "$id" tools/call "{\"name\":\"$name\",\"arguments\":{}}" >"$TMP/call.json"
+  curl -s -m 25 \
+    -H "Mcp-Session-Id: $SESSION" \
+    -H 'Content-Type: application/json' \
+    -H 'Accept: application/json, text/event-stream' \
+    --data-binary @"$TMP/call.json" \
+    "$HTTP_URL"
+}
+
+RESP=$(http_call 2 sdk_help)
+if echo "$RESP" | grep -q 'sdk_get_node_status\|helpers\|rpc\|Transports'; then
+  ok "tools/call sdk_help"
+else
+  bad "tools/call sdk_help: ${RESP:0:200}"
+fi
+
+RESP=$(http_call 3 sdk_get_node_status)
+if echo "$RESP" | grep -q 'api_version\|peers\|chainspec_name\|casper-net'; then
+  ok "tools/call sdk_get_node_status"
+else
+  bad "tools/call sdk_get_node_status: ${RESP:0:240}"
+fi
+
+RESP=$(http_call 4 sdk_get_block)
+if echo "$RESP" | grep -q 'block\|hash\|header'; then
+  ok "tools/call sdk_get_block"
+else
+  bad "tools/call sdk_get_block: ${RESP:0:240}"
+fi
+
+# --- Docker stdio ---
+echo "== Docker stdio ($IMAGE) =="
+if ! docker image inspect "$IMAGE" >/dev/null 2>&1; then
+  bad "image $IMAGE missing — run: make mcp-docker-build"
+else
+  {
+    json_rpc 1 initialize '{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"smoke-stdio","version":"0"}}'
+    printf '\n'
+    json_rpc null notifications/initialized '{}'
+    printf '\n'
+    json_rpc 2 tools/call '{"name":"sdk_help","arguments":{}}'
+    printf '\n'
+    json_rpc 3 tools/call '{"name":"sdk_get_node_status","arguments":{}}'
+    printf '\n'
+    sleep 2
+  } | timeout 30 docker run --rm -i \
+    --add-host host.docker.internal:host-gateway \
+    -e "CASPER_RPC_URL=http://host.docker.internal:11101" \
+    -e "CASPER_NODE_URL=host.docker.internal:28101" \
+    -e RUST_LOG=warn \
+    --entrypoint casper-rust-wasm-sdk-mcp \
+    "$IMAGE" >"$TMP/stdio.out" 2>"$TMP/stdio.err" || true
+
+  if grep -q 'casper-rust-wasm-sdk' "$TMP/stdio.out"; then
+    ok "initialize"
+  else
+    bad "initialize — $(head -c 160 "$TMP/stdio.err")"
+  fi
+  if grep -q 'sdk_get_node_status\|helpers\|rpc\|Transports' "$TMP/stdio.out"; then
+    ok "tools/call sdk_help"
+  else
+    bad "tools/call sdk_help — $(head -c 200 "$TMP/stdio.out")"
+  fi
+  if grep -q 'api_version\|peers\|chainspec_name\|casper-net' "$TMP/stdio.out"; then
+    ok "tools/call sdk_get_node_status"
+  else
+    bad "tools/call sdk_get_node_status — $(head -c 240 "$TMP/stdio.out")"
+  fi
+fi
+
+echo
+echo "PASS=$PASS FAIL=$FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/mcp/src/format.rs
+++ b/mcp/src/format.rs
@@ -1,0 +1,40 @@
+//! Map SDK / serde results to MCP `ToolOutput`.
+
+use mcpkit::prelude::ToolOutput;
+
+/// Pretty-print JSON for tool responses.
+pub fn json_ok(value: &serde_json::Value) -> ToolOutput {
+    match serde_json::to_string_pretty(value) {
+        Ok(text) => ToolOutput::text(text),
+        Err(err) => ToolOutput::error(format!("json encode failed: {err}")),
+    }
+}
+
+/// Wrap an arbitrary displayable error.
+pub fn err(err: impl std::fmt::Display) -> ToolOutput {
+    ToolOutput::error(err.to_string())
+}
+
+/// Success path for plain text.
+pub fn text_ok(text: impl Into<String>) -> ToolOutput {
+    ToolOutput::text(text.into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn json_ok_pretty_prints() {
+        let value = serde_json::json!({ "ok": true });
+        let out = json_ok(&value);
+        // ToolOutput debug / text content is opaque; just ensure it does not panic.
+        let _ = format!("{out:?}");
+    }
+
+    #[test]
+    fn err_builds_error_output() {
+        let out = err("boom");
+        let _ = format!("{out:?}");
+    }
+}

--- a/mcp/src/format.rs
+++ b/mcp/src/format.rs
@@ -1,12 +1,21 @@
 //! Map SDK / serde results to MCP `ToolOutput`.
 
 use mcpkit::prelude::ToolOutput;
+use serde::Serialize;
 
 /// Pretty-print JSON for tool responses.
 pub fn json_ok(value: &serde_json::Value) -> ToolOutput {
     match serde_json::to_string_pretty(value) {
         Ok(text) => ToolOutput::text(text),
         Err(err) => ToolOutput::error(format!("json encode failed: {err}")),
+    }
+}
+
+/// Serialize any `Serialize` value as pretty JSON text.
+pub fn serialize_ok<T: Serialize>(value: &T) -> ToolOutput {
+    match serde_json::to_value(value) {
+        Ok(v) => json_ok(&v),
+        Err(e) => err(e),
     }
 }
 
@@ -20,6 +29,14 @@ pub fn text_ok(text: impl Into<String>) -> ToolOutput {
     ToolOutput::text(text.into())
 }
 
+/// Map `Result` → `ToolOutput` using `serialize_ok` / `err`.
+pub fn from_result<T: Serialize, E: std::fmt::Display>(result: Result<T, E>) -> ToolOutput {
+    match result {
+        Ok(value) => serialize_ok(&value),
+        Err(error) => err(error),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -28,7 +45,6 @@ mod tests {
     fn json_ok_pretty_prints() {
         let value = serde_json::json!({ "ok": true });
         let out = json_ok(&value);
-        // ToolOutput debug / text content is opaque; just ensure it does not panic.
         let _ = format!("{out:?}");
     }
 
@@ -36,5 +52,13 @@ mod tests {
     fn err_builds_error_output() {
         let out = err("boom");
         let _ = format!("{out:?}");
+    }
+
+    #[test]
+    fn from_result_ok_and_err() {
+        let ok: Result<i32, &str> = Ok(7);
+        let _ = from_result(ok);
+        let bad: Result<i32, &str> = Err("nope");
+        let _ = from_result(bad);
     }
 }

--- a/mcp/src/lib.rs
+++ b/mcp/src/lib.rs
@@ -1,6 +1,11 @@
 //! MCP sidecar library for `casper-rust-wasm-sdk`.
-//!
-//! Phase 1 stub: path-depends on the SDK and compiles. Tool surface lands in later phases.
+
+pub mod format;
+pub mod sdk_handle;
+pub mod server;
+pub mod tools;
+
+pub use server::{run, run_http, DEFAULT_HTTP_LISTEN};
 
 /// Crate version (kept in sync with `Cargo.toml`).
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -28,13 +33,6 @@ pub fn enabled_features() -> Vec<&'static str> {
     features
 }
 
-/// Ensure the SDK path dependency stays linked in Phase 1 (no tools yet).
-pub fn sdk_crate_name() -> &'static str {
-    // Touch a public SDK root item so the dep is not dead-code eliminated in checks.
-    let _ = std::any::type_name::<casper_rust_wasm_sdk::SDK>();
-    "casper-rust-wasm-sdk"
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -51,10 +49,5 @@ mod tests {
         assert!(features.contains(&"rpc"));
         assert!(features.contains(&"helpers"));
         assert!(features.contains(&"write"));
-    }
-
-    #[test]
-    fn sdk_path_dep_resolves() {
-        assert_eq!(sdk_crate_name(), "casper-rust-wasm-sdk");
     }
 }

--- a/mcp/src/lib.rs
+++ b/mcp/src/lib.rs
@@ -1,0 +1,60 @@
+//! MCP sidecar library for `casper-rust-wasm-sdk`.
+//!
+//! Phase 1 stub: path-depends on the SDK and compiles. Tool surface lands in later phases.
+
+/// Crate version (kept in sync with `Cargo.toml`).
+pub const VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// Package name for the MCP binary / server identity.
+pub const NAME: &str = env!("CARGO_PKG_NAME");
+
+/// Enabled Cargo features as a stable list for help / diagnostics.
+pub fn enabled_features() -> Vec<&'static str> {
+    let mut features = Vec::new();
+    #[cfg(feature = "rpc")]
+    features.push("rpc");
+    #[cfg(feature = "binary-port")]
+    features.push("binary-port");
+    #[cfg(feature = "transaction")]
+    features.push("transaction");
+    #[cfg(feature = "deploy")]
+    features.push("deploy");
+    #[cfg(feature = "contract")]
+    features.push("contract");
+    #[cfg(feature = "helpers")]
+    features.push("helpers");
+    #[cfg(feature = "write")]
+    features.push("write");
+    features
+}
+
+/// Ensure the SDK path dependency stays linked in Phase 1 (no tools yet).
+pub fn sdk_crate_name() -> &'static str {
+    // Touch a public SDK root item so the dep is not dead-code eliminated in checks.
+    let _ = std::any::type_name::<casper_rust_wasm_sdk::SDK>();
+    "casper-rust-wasm-sdk"
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn version_is_semverish() {
+        assert!(!VERSION.is_empty());
+        assert!(VERSION.contains('.'));
+    }
+
+    #[test]
+    fn default_features_include_full_set() {
+        let features = enabled_features();
+        assert!(features.contains(&"rpc"));
+        assert!(features.contains(&"helpers"));
+        assert!(features.contains(&"write"));
+    }
+
+    #[test]
+    fn sdk_path_dep_resolves() {
+        assert_eq!(sdk_crate_name(), "casper-rust-wasm-sdk");
+    }
+}

--- a/mcp/src/main.rs
+++ b/mcp/src/main.rs
@@ -1,0 +1,17 @@
+//! `casper-rust-wasm-sdk-mcp` — Phase 1 stub binary.
+//!
+//! Phase 2 wires mcpkit stdio / Streamable HTTP. This binary only proves the
+//! workspace path-dep build.
+
+use anyhow::Result;
+
+fn main() -> Result<()> {
+    println!(
+        "{} {} (features: {})",
+        casper_rust_wasm_sdk_mcp::NAME,
+        casper_rust_wasm_sdk_mcp::VERSION,
+        casper_rust_wasm_sdk_mcp::enabled_features().join(", ")
+    );
+    let _ = casper_rust_wasm_sdk_mcp::sdk_crate_name();
+    Ok(())
+}

--- a/mcp/src/main.rs
+++ b/mcp/src/main.rs
@@ -1,17 +1,50 @@
-//! `casper-rust-wasm-sdk-mcp` — Phase 1 stub binary.
-//!
-//! Phase 2 wires mcpkit stdio / Streamable HTTP. This binary only proves the
-//! workspace path-dep build.
+//! `casper-rust-wasm-sdk-mcp` — MCP server (stdio by default, optional Streamable HTTP).
 
 use anyhow::Result;
+use clap::Parser;
+use casper_rust_wasm_sdk_mcp::server::{run, run_http, DEFAULT_HTTP_LISTEN};
 
-fn main() -> Result<()> {
-    println!(
-        "{} {} (features: {})",
-        casper_rust_wasm_sdk_mcp::NAME,
-        casper_rust_wasm_sdk_mcp::VERSION,
-        casper_rust_wasm_sdk_mcp::enabled_features().join(", ")
-    );
-    let _ = casper_rust_wasm_sdk_mcp::sdk_crate_name();
+#[derive(Debug, Parser)]
+#[command(
+    name = "casper-rust-wasm-sdk-mcp",
+    about = "casper-rust-wasm-sdk MCP server (stdio or Streamable HTTP)",
+    version
+)]
+struct Cli {
+    /// Serve Streamable HTTP instead of stdio (also: `CASPER_SDK_MCP_HTTP=1`).
+    #[arg(long, env = "CASPER_SDK_MCP_HTTP")]
+    http: bool,
+
+    /// HTTP bind address when `--http` is set (also: `CASPER_SDK_MCP_ADDR`).
+    #[arg(long, env = "CASPER_SDK_MCP_ADDR", default_value = DEFAULT_HTTP_LISTEN)]
+    listen: String,
+}
+
+fn init_logging() {
+    // Keep stdio MCP quiet: Cursor surfaces any stderr line as [error].
+    // Default warn; override with RUST_LOG when debugging.
+    let filter = tracing_subscriber::EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("warn"));
+    tracing_subscriber::fmt()
+        .with_env_filter(filter)
+        .with_ansi(false)
+        .with_writer(std::io::stderr)
+        .init();
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    init_logging();
+    let cli = Cli::parse();
+
+    if cli.http {
+        tracing::info!(addr = %cli.listen, "casper-rust-wasm-sdk-mcp starting (HTTP)");
+        run_http(&cli.listen)
+            .await
+            .map_err(|err| anyhow::anyhow!("{err}"))?;
+    } else {
+        tracing::info!("casper-rust-wasm-sdk-mcp starting (stdio)");
+        run().await.map_err(|err| anyhow::anyhow!("{err}"))?;
+    }
     Ok(())
 }

--- a/mcp/src/main.rs
+++ b/mcp/src/main.rs
@@ -1,8 +1,8 @@
 //! `casper-rust-wasm-sdk-mcp` — MCP server (stdio by default, optional Streamable HTTP).
 
 use anyhow::Result;
-use clap::Parser;
 use casper_rust_wasm_sdk_mcp::server::{run, run_http, DEFAULT_HTTP_LISTEN};
+use clap::Parser;
 
 #[derive(Debug, Parser)]
 #[command(

--- a/mcp/src/sdk_handle.rs
+++ b/mcp/src/sdk_handle.rs
@@ -1,0 +1,83 @@
+//! Shared `SDK` handle initialized from environment (NCTL-friendly defaults).
+
+use std::sync::{Arc, Mutex, OnceLock};
+
+use casper_rust_wasm_sdk::types::verbosity::Verbosity;
+use casper_rust_wasm_sdk::SDK;
+
+/// Default JSON-RPC URL (local NCTL node-1).
+pub const DEFAULT_RPC_URL: &str = "http://127.0.0.1:11101";
+
+/// Default binary-port address (local NCTL node-1).
+pub const DEFAULT_NODE_URL: &str = "127.0.0.1:28101";
+
+/// Env: JSON-RPC endpoint.
+pub const ENV_RPC_URL: &str = "CASPER_RPC_URL";
+
+/// Env: binary-port endpoint.
+pub const ENV_NODE_URL: &str = "CASPER_NODE_URL";
+
+/// Env: verbosity (`low` | `medium` | `high` | `0` | `1` | `2`).
+pub const ENV_VERBOSITY: &str = "CASPER_VERBOSITY";
+
+static SHARED: OnceLock<Arc<Mutex<SDK>>> = OnceLock::new();
+
+/// Process-wide SDK (lazy, env-initialized).
+pub fn shared() -> Arc<Mutex<SDK>> {
+    SHARED
+        .get_or_init(|| Arc::new(Mutex::new(from_env())))
+        .clone()
+}
+
+/// Build an `SDK` from env vars (does not touch the shared handle).
+pub fn from_env() -> SDK {
+    let rpc = std::env::var(ENV_RPC_URL).unwrap_or_else(|_| DEFAULT_RPC_URL.to_string());
+    let node = std::env::var(ENV_NODE_URL).unwrap_or_else(|_| DEFAULT_NODE_URL.to_string());
+    let verbosity = parse_verbosity(
+        std::env::var(ENV_VERBOSITY)
+            .unwrap_or_else(|_| "low".to_string())
+            .as_str(),
+    );
+    SDK::new(Some(rpc), Some(node), Some(verbosity))
+}
+
+/// Parse verbosity without panicking on bad input (falls back to Low).
+pub fn parse_verbosity(raw: &str) -> Verbosity {
+    match raw.trim().to_lowercase().as_str() {
+        "low" | "0" => Verbosity::Low,
+        "medium" | "1" => Verbosity::Medium,
+        "high" | "2" => Verbosity::High,
+        _ => Verbosity::Low,
+    }
+}
+
+/// Snapshot of current shared endpoints for help / diagnostics.
+pub fn endpoint_snapshot() -> EndpointSnapshot {
+    let sdk = shared();
+    let guard = sdk.lock().expect("sdk mutex poisoned");
+    EndpointSnapshot {
+        rpc_address: guard.get_rpc_address(None),
+        node_address: guard.get_node_address(None),
+        verbosity: format!("{:?}", guard.get_verbosity(None)),
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct EndpointSnapshot {
+    pub rpc_address: String,
+    pub node_address: String,
+    pub verbosity: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_verbosity_accepts_aliases() {
+        assert_eq!(parse_verbosity("LOW"), Verbosity::Low);
+        assert_eq!(parse_verbosity("1"), Verbosity::Medium);
+        assert_eq!(parse_verbosity("high"), Verbosity::High);
+        assert_eq!(parse_verbosity("nope"), Verbosity::Low);
+    }
+}

--- a/mcp/src/sdk_handle.rs
+++ b/mcp/src/sdk_handle.rs
@@ -62,6 +62,25 @@ pub fn endpoint_snapshot() -> EndpointSnapshot {
     }
 }
 
+/// Clone endpoint config into a fresh `SDK` (safe to hold across `.await`).
+pub fn sdk_snapshot() -> SDK {
+    let sdk = shared();
+    let guard = sdk.lock().expect("sdk mutex poisoned");
+    let rpc = guard.get_rpc_address(None);
+    let node = guard.get_node_address(None);
+    let verbosity = guard.get_verbosity(None);
+    SDK::new(
+        if rpc.is_empty() { None } else { Some(rpc) },
+        if node.is_empty() { None } else { Some(node) },
+        Some(verbosity),
+    )
+}
+
+/// Optional tool verbosity override (`None` → use SDK default).
+pub fn verbosity_override(raw: Option<&str>) -> Option<Verbosity> {
+    raw.map(parse_verbosity)
+}
+
 #[derive(Debug, Clone)]
 pub struct EndpointSnapshot {
     pub rpc_address: String,

--- a/mcp/src/server.rs
+++ b/mcp/src/server.rs
@@ -18,7 +18,7 @@ pub const DEFAULT_HTTP_LISTEN: &str = "0.0.0.0:8790";
 #[mcp_server(name = "casper-rust-wasm-sdk", version = "2.2.2")]
 impl CasperSdkMcp {
     #[tool(
-        description = "Help: feature matrix, env vars, endpoints, and planned/available sdk_* tools"
+        description = "Help: feature matrix, env vars, endpoints, and available sdk_* tools"
     )]
     async fn sdk_help(&self) -> ToolOutput {
         format::text_ok(help_text())
@@ -80,12 +80,413 @@ impl CasperSdkMcp {
             "verbosity": snap.verbosity,
         }))
     }
+
+    // --- helpers (feature = "helpers") ---
+
+    #[tool(description = "Current RFC3339 timestamp (optional unix-ms timestamp override)")]
+    async fn sdk_get_current_timestamp(&self, timestamp: Option<String>) -> ToolOutput {
+        tools::helpers::get_current_timestamp(timestamp)
+    }
+
+    #[tool(description = "Blake2b-256 hex digest of a UTF-8 string")]
+    async fn sdk_get_blake2b_hash(&self, meta_data: String) -> ToolOutput {
+        tools::helpers::get_blake2b_hash(meta_data)
+    }
+
+    #[tool(
+        description = "Dictionary item key from formatted key + exactly one of value_key (formatted Key) or value_u256"
+    )]
+    async fn sdk_make_dictionary_item_key(
+        &self,
+        key: String,
+        value_key: Option<String>,
+        value_u256: Option<String>,
+    ) -> ToolOutput {
+        tools::helpers::make_dictionary_item_key(key, value_key, value_u256)
+    }
+
+    #[tool(description = "CEP-18 base64 key from account-hash-… string")]
+    async fn sdk_get_base64_key_from_account_hash(&self, account_hash: String) -> ToolOutput {
+        tools::helpers::get_base64_key_from_account_hash(account_hash)
+    }
+
+    #[tool(description = "CEP-18 base64 key from hash-… formatted key")]
+    async fn sdk_get_base64_key_from_key_hash(&self, formatted_hash: String) -> ToolOutput {
+        tools::helpers::get_base64_key_from_key_hash(formatted_hash)
+    }
+
+    #[tool(description = "TTL string or SDK default")]
+    async fn sdk_get_ttl_or_default(&self, ttl: Option<String>) -> ToolOutput {
+        tools::helpers::get_ttl_or_default(ttl)
+    }
+
+    #[tool(description = "Parse a timestamp string")]
+    async fn sdk_parse_timestamp(&self, value: String) -> ToolOutput {
+        tools::helpers::parse_timestamp(value)
+    }
+
+    #[tool(description = "Parse a TTL / TimeDiff string")]
+    async fn sdk_parse_ttl(&self, value: String) -> ToolOutput {
+        tools::helpers::parse_ttl(value)
+    }
+
+    #[tool(description = "Gas price or SDK default")]
+    async fn sdk_get_gas_price_or_default(&self, gas_price: Option<u64>) -> ToolOutput {
+        tools::helpers::get_gas_price_or_default(gas_price)
+    }
+
+    #[tool(description = "Generate Ed25519 secret key PEM (local; treat as secret)")]
+    async fn sdk_secret_key_generate(&self) -> ToolOutput {
+        tools::helpers::secret_key_generate()
+    }
+
+    #[tool(description = "Generate secp256k1 secret key PEM (local; treat as secret)")]
+    async fn sdk_secret_key_secp256k1_generate(&self) -> ToolOutput {
+        tools::helpers::secret_key_secp256k1_generate()
+    }
+
+    #[tool(description = "Validate a secret key PEM (does not echo the secret)")]
+    async fn sdk_secret_key_from_pem(&self, secret_key: String) -> ToolOutput {
+        tools::helpers::secret_key_from_pem(secret_key)
+    }
+
+    #[tool(description = "Derive public key hex from secret key PEM")]
+    async fn sdk_public_key_from_secret_key(&self, secret_key: String) -> ToolOutput {
+        tools::helpers::public_key_from_secret_key(secret_key)
+    }
+
+    #[tool(description = "Decode hex string to byte array JSON")]
+    async fn sdk_hex_to_uint8_vec(&self, hex_string: String) -> ToolOutput {
+        tools::helpers::hex_to_uint8_vec(hex_string)
+    }
+
+    #[tool(description = "Decode hex string to UTF-8 (lossy) text")]
+    async fn sdk_hex_to_string(&self, hex_string: String) -> ToolOutput {
+        tools::helpers::hex_to_string(hex_string)
+    }
+
+    #[tool(description = "Convert motes string to CSPR")]
+    async fn sdk_motes_to_cspr(&self, motes: String) -> ToolOutput {
+        tools::helpers::motes_to_cspr(motes)
+    }
+
+    #[tool(description = "Pretty-print a JSON string at optional verbosity (low|medium|high)")]
+    async fn sdk_json_pretty_print(
+        &self,
+        value: String,
+        verbosity: Option<String>,
+    ) -> ToolOutput {
+        tools::helpers::json_pretty_print(value, verbosity)
+    }
+
+    #[tool(description = "Convert a CLValue JSON document to JSON Value")]
+    async fn sdk_cl_value_to_json(&self, cl_value_json: String) -> ToolOutput {
+        tools::helpers::cl_value_to_json(cl_value_json)
+    }
+
+    // --- rpc (feature = "rpc") ---
+
+    #[tool(description = "JSON-RPC info_get_status / get_node_status")]
+    async fn sdk_get_node_status(
+        &self,
+        verbosity: Option<String>,
+        rpc_address: Option<String>,
+    ) -> ToolOutput {
+        tools::rpc::get_node_status(verbosity, rpc_address).await
+    }
+
+    #[tool(description = "JSON-RPC info_get_peers")]
+    async fn sdk_get_peers(
+        &self,
+        verbosity: Option<String>,
+        rpc_address: Option<String>,
+    ) -> ToolOutput {
+        tools::rpc::get_peers(verbosity, rpc_address).await
+    }
+
+    #[tool(description = "JSON-RPC info_get_chainspec")]
+    async fn sdk_get_chainspec(
+        &self,
+        verbosity: Option<String>,
+        rpc_address: Option<String>,
+    ) -> ToolOutput {
+        tools::rpc::get_chainspec(verbosity, rpc_address).await
+    }
+
+    #[tool(description = "JSON-RPC info_get_validator_changes")]
+    async fn sdk_get_validator_changes(
+        &self,
+        verbosity: Option<String>,
+        rpc_address: Option<String>,
+    ) -> ToolOutput {
+        tools::rpc::get_validator_changes(verbosity, rpc_address).await
+    }
+
+    #[tool(description = "JSON-RPC list_rpcs")]
+    async fn sdk_list_rpcs(
+        &self,
+        verbosity: Option<String>,
+        rpc_address: Option<String>,
+    ) -> ToolOutput {
+        tools::rpc::list_rpcs(verbosity, rpc_address).await
+    }
+
+    #[tool(description = "JSON-RPC chain_get_block (optional block height or hash string)")]
+    async fn sdk_get_block(
+        &self,
+        maybe_block_identifier: Option<String>,
+        verbosity: Option<String>,
+        rpc_address: Option<String>,
+    ) -> ToolOutput {
+        tools::rpc::get_block(maybe_block_identifier, verbosity, rpc_address).await
+    }
+
+    #[tool(description = "JSON-RPC chain_get_block_transfers")]
+    async fn sdk_get_block_transfers(
+        &self,
+        maybe_block_identifier: Option<String>,
+        verbosity: Option<String>,
+        rpc_address: Option<String>,
+    ) -> ToolOutput {
+        tools::rpc::get_block_transfers(maybe_block_identifier, verbosity, rpc_address).await
+    }
+
+    #[tool(description = "JSON-RPC state_get_auction_info")]
+    async fn sdk_get_auction_info(
+        &self,
+        maybe_block_identifier: Option<String>,
+        verbosity: Option<String>,
+        rpc_address: Option<String>,
+    ) -> ToolOutput {
+        tools::rpc::get_auction_info(maybe_block_identifier, verbosity, rpc_address).await
+    }
+
+    #[tool(description = "JSON-RPC chain_get_era_summary")]
+    async fn sdk_get_era_summary(
+        &self,
+        maybe_block_identifier: Option<String>,
+        verbosity: Option<String>,
+        rpc_address: Option<String>,
+    ) -> ToolOutput {
+        tools::rpc::get_era_summary(maybe_block_identifier, verbosity, rpc_address).await
+    }
+
+    #[tool(description = "JSON-RPC chain_get_era_info_by_switch_block (deprecated; prefer era_summary)")]
+    async fn sdk_get_era_info(
+        &self,
+        maybe_block_identifier: Option<String>,
+        verbosity: Option<String>,
+        rpc_address: Option<String>,
+    ) -> ToolOutput {
+        tools::rpc::get_era_info(maybe_block_identifier, verbosity, rpc_address).await
+    }
+
+    #[tool(description = "JSON-RPC chain_get_state_root_hash")]
+    async fn sdk_get_state_root_hash(
+        &self,
+        maybe_block_identifier: Option<String>,
+        verbosity: Option<String>,
+        rpc_address: Option<String>,
+    ) -> ToolOutput {
+        tools::rpc::get_state_root_hash(maybe_block_identifier, verbosity, rpc_address).await
+    }
+
+    #[tool(description = "JSON-RPC state_get_account_info (deprecated; prefer get_entity)")]
+    async fn sdk_get_account(
+        &self,
+        account_identifier: Option<String>,
+        maybe_block_identifier: Option<String>,
+        verbosity: Option<String>,
+        rpc_address: Option<String>,
+    ) -> ToolOutput {
+        tools::rpc::get_account(
+            account_identifier,
+            maybe_block_identifier,
+            verbosity,
+            rpc_address,
+        )
+        .await
+    }
+
+    #[tool(description = "JSON-RPC state_get_entity / get_entity")]
+    async fn sdk_get_entity(
+        &self,
+        entity_identifier: Option<String>,
+        maybe_block_identifier: Option<String>,
+        verbosity: Option<String>,
+        rpc_address: Option<String>,
+    ) -> ToolOutput {
+        tools::rpc::get_entity(
+            entity_identifier,
+            maybe_block_identifier,
+            verbosity,
+            rpc_address,
+        )
+        .await
+    }
+
+    #[tool(description = "JSON-RPC info_get_deploy")]
+    async fn sdk_get_deploy(
+        &self,
+        deploy_hash: String,
+        finalized_approvals: Option<bool>,
+        verbosity: Option<String>,
+        rpc_address: Option<String>,
+    ) -> ToolOutput {
+        tools::rpc::get_deploy(deploy_hash, finalized_approvals, verbosity, rpc_address).await
+    }
+
+    #[tool(description = "JSON-RPC info_get_transaction")]
+    async fn sdk_get_transaction(
+        &self,
+        transaction_hash: String,
+        finalized_approvals: Option<bool>,
+        verbosity: Option<String>,
+        rpc_address: Option<String>,
+    ) -> ToolOutput {
+        tools::rpc::get_transaction(
+            transaction_hash,
+            finalized_approvals,
+            verbosity,
+            rpc_address,
+        )
+        .await
+    }
+
+    #[tool(description = "JSON-RPC state_get_balance (purse uref string)")]
+    async fn sdk_get_balance(
+        &self,
+        purse_uref: String,
+        state_root_hash: Option<String>,
+        verbosity: Option<String>,
+        rpc_address: Option<String>,
+    ) -> ToolOutput {
+        tools::rpc::get_balance(purse_uref, state_root_hash, verbosity, rpc_address).await
+    }
+
+    #[tool(description = "JSON-RPC query_balance (purse identifier string: pubkey / account-hash / uref)")]
+    async fn sdk_query_balance(
+        &self,
+        purse_identifier: String,
+        state_root_hash: Option<String>,
+        maybe_block_id: Option<String>,
+        verbosity: Option<String>,
+        rpc_address: Option<String>,
+    ) -> ToolOutput {
+        tools::rpc::query_balance(
+            purse_identifier,
+            state_root_hash,
+            maybe_block_id,
+            verbosity,
+            rpc_address,
+        )
+        .await
+    }
+
+    #[tool(description = "JSON-RPC query_balance_details")]
+    async fn sdk_query_balance_details(
+        &self,
+        purse_identifier: String,
+        state_root_hash: Option<String>,
+        maybe_block_id: Option<String>,
+        verbosity: Option<String>,
+        rpc_address: Option<String>,
+    ) -> ToolOutput {
+        tools::rpc::query_balance_details(
+            purse_identifier,
+            state_root_hash,
+            maybe_block_id,
+            verbosity,
+            rpc_address,
+        )
+        .await
+    }
+
+    #[tool(
+        description = "JSON-RPC state_get_dictionary_item; kind=uref|dictionary|account_named_key|contract_named_key|entity_named_key"
+    )]
+    async fn sdk_get_dictionary_item(
+        &self,
+        kind: String,
+        key: Option<String>,
+        dictionary_name: Option<String>,
+        dictionary_item_key: Option<String>,
+        seed_uref: Option<String>,
+        dictionary_value: Option<String>,
+        state_root_hash: Option<String>,
+        verbosity: Option<String>,
+        rpc_address: Option<String>,
+    ) -> ToolOutput {
+        tools::rpc::get_dictionary_item(
+            kind,
+            key,
+            dictionary_name,
+            dictionary_item_key,
+            seed_uref,
+            dictionary_value,
+            state_root_hash,
+            verbosity,
+            rpc_address,
+        )
+        .await
+    }
+
+    #[tool(description = "JSON-RPC query_global_state (formatted key; optional path / state root / block)")]
+    async fn sdk_query_global_state(
+        &self,
+        key: String,
+        path: Option<String>,
+        state_root_hash: Option<String>,
+        maybe_block_id: Option<String>,
+        verbosity: Option<String>,
+        rpc_address: Option<String>,
+    ) -> ToolOutput {
+        tools::rpc::query_global_state(
+            key,
+            path,
+            state_root_hash,
+            maybe_block_id,
+            verbosity,
+            rpc_address,
+        )
+        .await
+    }
+
+    #[tool(description = "JSON-RPC speculative_exec with full transaction JSON")]
+    async fn sdk_speculative_exec(
+        &self,
+        transaction_json: String,
+        verbosity: Option<String>,
+        rpc_address: Option<String>,
+    ) -> ToolOutput {
+        tools::rpc::speculative_exec(transaction_json, verbosity, rpc_address).await
+    }
+
+    #[tool(description = "JSON-RPC speculative_exec_deploy with full deploy JSON")]
+    async fn sdk_speculative_exec_deploy(
+        &self,
+        deploy_json: String,
+        verbosity: Option<String>,
+        rpc_address: Option<String>,
+    ) -> ToolOutput {
+        tools::rpc::speculative_exec_deploy(deploy_json, verbosity, rpc_address).await
+    }
 }
 
 fn help_text() -> String {
     let snap = sdk_handle::endpoint_snapshot();
     let groups = tools::enabled_tool_groups().join(", ");
-    let pending = tools::pending_tool_placeholders().join("\n  - ");
+    let pending = tools::pending_tool_placeholders();
+    let pending_block = if pending.is_empty() {
+        "  (none)".to_string()
+    } else {
+        format!("  - {}", pending.join("\n  - "))
+    };
+    let registered = tools::registered_tool_names()
+        .into_iter()
+        .map(|n| format!("  - {n}"))
+        .collect::<Vec<_>>()
+        .join("\n");
     format!(
         r#"casper-rust-wasm-sdk-mcp {version}
 
@@ -105,13 +506,11 @@ Current endpoints
 Enabled feature groups
   {groups}
 
-Always-on tools
-  - sdk_help
-  - sdk_get_endpoints
-  - sdk_set_endpoints
+Registered tools
+{registered}
 
-Pending tool groups (see mcp/TOOLS.md)
-  - {pending}
+Pending tool groups
+{pending_block}
 
 Compose with sibling MCPs: casper-nctl-2-docker (:8788), kms-secp256k1-api (:8789).
 "#,
@@ -126,7 +525,8 @@ Compose with sibling MCPs: casper-nctl-2-docker (:8788), kms-secp256k1-api (:878
         node = snap.node_address,
         verbosity = snap.verbosity,
         groups = groups,
-        pending = pending,
+        registered = registered,
+        pending_block = pending_block,
     )
 }
 

--- a/mcp/src/server.rs
+++ b/mcp/src/server.rs
@@ -17,14 +17,14 @@ pub const DEFAULT_HTTP_LISTEN: &str = "0.0.0.0:8790";
 // Keep in sync with Cargo.toml `version` (enforced by unit test below).
 #[mcp_server(name = "casper-rust-wasm-sdk", version = "2.2.2")]
 impl CasperSdkMcp {
-    #[tool(
-        description = "Help: feature matrix, env vars, endpoints, and available sdk_* tools"
-    )]
+    #[tool(description = "Help: feature matrix, env vars, endpoints, and available sdk_* tools")]
     async fn sdk_help(&self) -> ToolOutput {
         format::text_ok(help_text())
     }
 
-    #[tool(description = "Show current CASPER_RPC_URL / CASPER_NODE_URL / verbosity on the shared SDK")]
+    #[tool(
+        description = "Show current CASPER_RPC_URL / CASPER_NODE_URL / verbosity on the shared SDK"
+    )]
     async fn sdk_get_endpoints(&self) -> ToolOutput {
         let snap = sdk_handle::endpoint_snapshot();
         format::json_ok(&serde_json::json!({
@@ -171,11 +171,7 @@ impl CasperSdkMcp {
     }
 
     #[tool(description = "Pretty-print a JSON string at optional verbosity (low|medium|high)")]
-    async fn sdk_json_pretty_print(
-        &self,
-        value: String,
-        verbosity: Option<String>,
-    ) -> ToolOutput {
+    async fn sdk_json_pretty_print(&self, value: String, verbosity: Option<String>) -> ToolOutput {
         tools::helpers::json_pretty_print(value, verbosity)
     }
 
@@ -271,7 +267,9 @@ impl CasperSdkMcp {
         tools::rpc::get_era_summary(maybe_block_identifier, verbosity, rpc_address).await
     }
 
-    #[tool(description = "JSON-RPC chain_get_era_info_by_switch_block (deprecated; prefer era_summary)")]
+    #[tool(
+        description = "JSON-RPC chain_get_era_info_by_switch_block (deprecated; prefer era_summary)"
+    )]
     async fn sdk_get_era_info(
         &self,
         maybe_block_identifier: Option<String>,
@@ -364,7 +362,9 @@ impl CasperSdkMcp {
         tools::rpc::get_balance(purse_uref, state_root_hash, verbosity, rpc_address).await
     }
 
-    #[tool(description = "JSON-RPC query_balance (purse identifier string: pubkey / account-hash / uref)")]
+    #[tool(
+        description = "JSON-RPC query_balance (purse identifier string: pubkey / account-hash / uref)"
+    )]
     async fn sdk_query_balance(
         &self,
         purse_identifier: String,
@@ -431,7 +431,9 @@ impl CasperSdkMcp {
         .await
     }
 
-    #[tool(description = "JSON-RPC query_global_state (formatted key; optional path / state root / block)")]
+    #[tool(
+        description = "JSON-RPC query_global_state (formatted key; optional path / state root / block)"
+    )]
     async fn sdk_query_global_state(
         &self,
         key: String,
@@ -470,6 +472,333 @@ impl CasperSdkMcp {
         rpc_address: Option<String>,
     ) -> ToolOutput {
         tools::rpc::speculative_exec_deploy(deploy_json, verbosity, rpc_address).await
+    }
+
+    // --- binary-port (feature = "binary-port") ---
+
+    #[tool(description = "Binary port: latest switch block header (needs CASPER_NODE_URL)")]
+    async fn sdk_get_binary_latest_switch_block_header(
+        &self,
+        node_address: Option<String>,
+    ) -> ToolOutput {
+        tools::binary_port::get_binary_latest_switch_block_header(node_address).await
+    }
+
+    #[tool(description = "Binary port: latest block header")]
+    async fn sdk_get_binary_latest_block_header(
+        &self,
+        node_address: Option<String>,
+    ) -> ToolOutput {
+        tools::binary_port::get_binary_latest_block_header(node_address).await
+    }
+
+    #[tool(description = "Binary port: block header by height")]
+    async fn sdk_get_binary_block_header_by_height(
+        &self,
+        height: u64,
+        node_address: Option<String>,
+    ) -> ToolOutput {
+        tools::binary_port::get_binary_block_header_by_height(height, node_address).await
+    }
+
+    #[tool(description = "Binary port: block header by hash hex")]
+    async fn sdk_get_binary_block_header_by_hash(
+        &self,
+        block_hash: String,
+        node_address: Option<String>,
+    ) -> ToolOutput {
+        tools::binary_port::get_binary_block_header_by_hash(block_hash, node_address).await
+    }
+
+    #[tool(description = "Binary port: latest block with signatures")]
+    async fn sdk_get_binary_latest_block_with_signatures(
+        &self,
+        node_address: Option<String>,
+    ) -> ToolOutput {
+        tools::binary_port::get_binary_latest_block_with_signatures(node_address).await
+    }
+
+    #[tool(description = "Binary port: block with signatures by height")]
+    async fn sdk_get_binary_block_with_signatures_by_height(
+        &self,
+        height: u64,
+        node_address: Option<String>,
+    ) -> ToolOutput {
+        tools::binary_port::get_binary_block_with_signatures_by_height(height, node_address).await
+    }
+
+    #[tool(description = "Binary port: block with signatures by hash hex")]
+    async fn sdk_get_binary_block_with_signatures_by_hash(
+        &self,
+        block_hash: String,
+        node_address: Option<String>,
+    ) -> ToolOutput {
+        tools::binary_port::get_binary_block_with_signatures_by_hash(block_hash, node_address).await
+    }
+
+    #[tool(description = "Binary port: transaction by hash hex")]
+    async fn sdk_get_binary_transaction_by_hash(
+        &self,
+        hash: String,
+        with_finalized_approvals: Option<bool>,
+        node_address: Option<String>,
+    ) -> ToolOutput {
+        tools::binary_port::get_binary_transaction_by_hash(
+            hash,
+            with_finalized_approvals,
+            node_address,
+        )
+        .await
+    }
+
+    #[tool(description = "Binary port: peers")]
+    async fn sdk_get_binary_peers(&self, node_address: Option<String>) -> ToolOutput {
+        tools::binary_port::get_binary_peers(node_address).await
+    }
+
+    #[tool(description = "Binary port: node uptime")]
+    async fn sdk_get_binary_uptime(&self, node_address: Option<String>) -> ToolOutput {
+        tools::binary_port::get_binary_uptime(node_address).await
+    }
+
+    #[tool(description = "Binary port: last progress")]
+    async fn sdk_get_binary_last_progress(&self, node_address: Option<String>) -> ToolOutput {
+        tools::binary_port::get_binary_last_progress(node_address).await
+    }
+
+    #[tool(description = "Binary port: reactor state")]
+    async fn sdk_get_binary_reactor_state(&self, node_address: Option<String>) -> ToolOutput {
+        tools::binary_port::get_binary_reactor_state(node_address).await
+    }
+
+    #[tool(description = "Binary port: network name")]
+    async fn sdk_get_binary_network_name(&self, node_address: Option<String>) -> ToolOutput {
+        tools::binary_port::get_binary_network_name(node_address).await
+    }
+
+    #[tool(description = "Binary port: consensus validator changes")]
+    async fn sdk_get_binary_consensus_validator_changes(
+        &self,
+        node_address: Option<String>,
+    ) -> ToolOutput {
+        tools::binary_port::get_binary_consensus_validator_changes(node_address).await
+    }
+
+    #[tool(description = "Binary port: block synchronizer status")]
+    async fn sdk_get_binary_block_synchronizer_status(
+        &self,
+        node_address: Option<String>,
+    ) -> ToolOutput {
+        tools::binary_port::get_binary_block_synchronizer_status(node_address).await
+    }
+
+    #[tool(description = "Binary port: available block range")]
+    async fn sdk_get_binary_available_block_range(
+        &self,
+        node_address: Option<String>,
+    ) -> ToolOutput {
+        tools::binary_port::get_binary_available_block_range(node_address).await
+    }
+
+    #[tool(description = "Binary port: next upgrade")]
+    async fn sdk_get_binary_next_upgrade(&self, node_address: Option<String>) -> ToolOutput {
+        tools::binary_port::get_binary_next_upgrade(node_address).await
+    }
+
+    #[tool(description = "Binary port: consensus status")]
+    async fn sdk_get_binary_consensus_status(&self, node_address: Option<String>) -> ToolOutput {
+        tools::binary_port::get_binary_consensus_status(node_address).await
+    }
+
+    #[tool(description = "Binary port: chainspec raw bytes")]
+    async fn sdk_get_binary_chainspec_raw_bytes(
+        &self,
+        node_address: Option<String>,
+    ) -> ToolOutput {
+        tools::binary_port::get_binary_chainspec_raw_bytes(node_address).await
+    }
+
+    #[tool(description = "Binary port: node status")]
+    async fn sdk_get_binary_node_status(&self, node_address: Option<String>) -> ToolOutput {
+        tools::binary_port::get_binary_node_status(node_address).await
+    }
+
+    #[tool(description = "Binary port: validator reward by era")]
+    async fn sdk_get_binary_validator_reward_by_era(
+        &self,
+        validator_key: String,
+        era: u64,
+        node_address: Option<String>,
+    ) -> ToolOutput {
+        tools::binary_port::get_binary_validator_reward_by_era(validator_key, era, node_address)
+            .await
+    }
+
+    #[tool(description = "Binary port: validator reward by block height")]
+    async fn sdk_get_binary_validator_reward_by_block_height(
+        &self,
+        validator_key: String,
+        block_height: u64,
+        node_address: Option<String>,
+    ) -> ToolOutput {
+        tools::binary_port::get_binary_validator_reward_by_block_height(
+            validator_key,
+            block_height,
+            node_address,
+        )
+        .await
+    }
+
+    #[tool(description = "Binary port: validator reward by block hash hex")]
+    async fn sdk_get_binary_validator_reward_by_block_hash(
+        &self,
+        validator_key: String,
+        block_hash: String,
+        node_address: Option<String>,
+    ) -> ToolOutput {
+        tools::binary_port::get_binary_validator_reward_by_block_hash(
+            validator_key,
+            block_hash,
+            node_address,
+        )
+        .await
+    }
+
+    #[tool(description = "Binary port: delegator reward by era")]
+    async fn sdk_get_binary_delegator_reward_by_era(
+        &self,
+        validator_key: String,
+        delegator_key: String,
+        era: u64,
+        node_address: Option<String>,
+    ) -> ToolOutput {
+        tools::binary_port::get_binary_delegator_reward_by_era(
+            validator_key,
+            delegator_key,
+            era,
+            node_address,
+        )
+        .await
+    }
+
+    #[tool(description = "Binary port: delegator reward by block height")]
+    async fn sdk_get_binary_delegator_reward_by_block_height(
+        &self,
+        validator_key: String,
+        delegator_key: String,
+        block_height: u64,
+        node_address: Option<String>,
+    ) -> ToolOutput {
+        tools::binary_port::get_binary_delegator_reward_by_block_height(
+            validator_key,
+            delegator_key,
+            block_height,
+            node_address,
+        )
+        .await
+    }
+
+    #[tool(description = "Binary port: delegator reward by block hash hex")]
+    async fn sdk_get_binary_delegator_reward_by_block_hash(
+        &self,
+        validator_key: String,
+        delegator_key: String,
+        block_hash: String,
+        node_address: Option<String>,
+    ) -> ToolOutput {
+        tools::binary_port::get_binary_delegator_reward_by_block_hash(
+            validator_key,
+            delegator_key,
+            block_hash,
+            node_address,
+        )
+        .await
+    }
+
+    #[tool(description = "Binary port: read record (record_id 0-7, key_hex)")]
+    async fn sdk_get_binary_read_record(
+        &self,
+        record_id: u16,
+        key_hex: String,
+        node_address: Option<String>,
+    ) -> ToolOutput {
+        tools::binary_port::get_binary_read_record(record_id, key_hex, node_address).await
+    }
+
+    #[tool(description = "Binary port: global state item (formatted key; path as a/b or JSON array)")]
+    async fn sdk_get_binary_global_state_item(
+        &self,
+        key: String,
+        path: Option<String>,
+        node_address: Option<String>,
+    ) -> ToolOutput {
+        tools::binary_port::get_binary_global_state_item(key, path, node_address).await
+    }
+
+    #[tool(description = "Binary port: global state item by state root hash")]
+    async fn sdk_get_binary_global_state_item_by_state_root_hash(
+        &self,
+        state_root_hash: String,
+        key: String,
+        path: Option<String>,
+        node_address: Option<String>,
+    ) -> ToolOutput {
+        tools::binary_port::get_binary_global_state_item_by_state_root_hash(
+            state_root_hash,
+            key,
+            path,
+            node_address,
+        )
+        .await
+    }
+
+    #[tool(description = "Binary port: global state item by block hash")]
+    async fn sdk_get_binary_global_state_item_by_block_hash(
+        &self,
+        block_hash: String,
+        key: String,
+        path: Option<String>,
+        node_address: Option<String>,
+    ) -> ToolOutput {
+        tools::binary_port::get_binary_global_state_item_by_block_hash(
+            block_hash,
+            key,
+            path,
+            node_address,
+        )
+        .await
+    }
+
+    #[tool(description = "Binary port: global state item by block height")]
+    async fn sdk_get_binary_global_state_item_by_block_height(
+        &self,
+        block_height: u64,
+        key: String,
+        path: Option<String>,
+        node_address: Option<String>,
+    ) -> ToolOutput {
+        tools::binary_port::get_binary_global_state_item_by_block_height(
+            block_height,
+            key,
+            path,
+            node_address,
+        )
+        .await
+    }
+
+    #[tool(description = "Binary port: speculative execution of transaction JSON")]
+    async fn sdk_get_binary_try_speculative_execution(
+        &self,
+        transaction_json: String,
+        node_address: Option<String>,
+    ) -> ToolOutput {
+        tools::binary_port::get_binary_try_speculative_execution(transaction_json, node_address)
+            .await
+    }
+
+    #[tool(description = "Binary port: protocol version")]
+    async fn sdk_get_binary_protocol_version(&self, node_address: Option<String>) -> ToolOutput {
+        tools::binary_port::get_binary_protocol_version(node_address).await
     }
 }
 

--- a/mcp/src/server.rs
+++ b/mcp/src/server.rs
@@ -800,6 +800,369 @@ impl CasperSdkMcp {
     async fn sdk_get_binary_protocol_version(&self, node_address: Option<String>) -> ToolOutput {
         tools::binary_port::get_binary_protocol_version(node_address).await
     }
+
+    // --- transaction (feature = "transaction") ---
+
+    #[tool(description = "Build unsigned transaction from builder_params_json + transaction_params_json")]
+    async fn sdk_make_transaction(
+        &self,
+        builder_params_json: String,
+        transaction_params_json: String,
+    ) -> ToolOutput {
+        tools::transaction::make_transaction(builder_params_json, transaction_params_json)
+    }
+
+    #[tool(description = "Build unsigned transfer transaction")]
+    async fn sdk_make_transfer_transaction(
+        &self,
+        target: String,
+        amount: String,
+        transaction_params_json: String,
+        maybe_source: Option<String>,
+        maybe_id: Option<String>,
+    ) -> ToolOutput {
+        tools::transaction::make_transfer_transaction(
+            target,
+            amount,
+            transaction_params_json,
+            maybe_source,
+            maybe_id,
+        )
+    }
+
+    #[tool(description = "Speculative exec of a built transaction (no submit)")]
+    async fn sdk_speculative_transaction(
+        &self,
+        builder_params_json: String,
+        transaction_params_json: String,
+        verbosity: Option<String>,
+        rpc_address: Option<String>,
+    ) -> ToolOutput {
+        tools::transaction::speculative_transaction(
+            builder_params_json,
+            transaction_params_json,
+            verbosity,
+            rpc_address,
+        )
+        .await
+    }
+
+    #[tool(description = "Speculative transfer transaction (no submit)")]
+    async fn sdk_speculative_transfer_transaction(
+        &self,
+        target_account: String,
+        amount: String,
+        transaction_params_json: String,
+        maybe_source: Option<String>,
+        maybe_id: Option<String>,
+        verbosity: Option<String>,
+        rpc_address: Option<String>,
+    ) -> ToolOutput {
+        tools::transaction::speculative_transfer_transaction(
+            target_account,
+            amount,
+            transaction_params_json,
+            maybe_source,
+            maybe_id,
+            verbosity,
+            rpc_address,
+        )
+        .await
+    }
+
+    // --- deploy (feature = "deploy", legacy) ---
+
+    #[tool(description = "Build unsigned legacy deploy")]
+    async fn sdk_make_deploy(
+        &self,
+        deploy_params_json: String,
+        session_params_json: String,
+        payment_params_json: String,
+    ) -> ToolOutput {
+        tools::deploy::make_deploy(deploy_params_json, session_params_json, payment_params_json)
+    }
+
+    #[tool(description = "Build unsigned legacy transfer deploy")]
+    async fn sdk_make_transfer(
+        &self,
+        amount: String,
+        target_account: String,
+        deploy_params_json: String,
+        payment_params_json: String,
+        transfer_id: Option<String>,
+    ) -> ToolOutput {
+        tools::deploy::make_transfer(
+            amount,
+            target_account,
+            deploy_params_json,
+            payment_params_json,
+            transfer_id,
+        )
+    }
+
+    #[tool(description = "Speculative legacy deploy (no submit)")]
+    async fn sdk_speculative_deploy(
+        &self,
+        deploy_params_json: String,
+        session_params_json: String,
+        payment_params_json: String,
+        verbosity: Option<String>,
+        rpc_address: Option<String>,
+    ) -> ToolOutput {
+        tools::deploy::speculative_deploy(
+            deploy_params_json,
+            session_params_json,
+            payment_params_json,
+            verbosity,
+            rpc_address,
+        )
+        .await
+    }
+
+    #[tool(description = "Speculative legacy transfer (no submit)")]
+    async fn sdk_speculative_transfer(
+        &self,
+        amount: String,
+        target_account: String,
+        deploy_params_json: String,
+        payment_params_json: String,
+        transfer_id: Option<String>,
+        verbosity: Option<String>,
+        rpc_address: Option<String>,
+    ) -> ToolOutput {
+        tools::deploy::speculative_transfer(
+            amount,
+            target_account,
+            deploy_params_json,
+            payment_params_json,
+            transfer_id,
+            verbosity,
+            rpc_address,
+        )
+        .await
+    }
+
+    // --- contract queries (feature = "contract") ---
+
+    #[tool(description = "Query contract dictionary; kind + dictionary_item_json fields")]
+    async fn sdk_query_contract_dict(
+        &self,
+        kind: String,
+        dictionary_item_json: String,
+        state_root_hash: Option<String>,
+        verbosity: Option<String>,
+        rpc_address: Option<String>,
+    ) -> ToolOutput {
+        tools::contract::query_contract_dict(
+            kind,
+            dictionary_item_json,
+            state_root_hash,
+            verbosity,
+            rpc_address,
+        )
+        .await
+    }
+
+    #[tool(description = "Query contract named key path under an entity")]
+    async fn sdk_query_contract_key(
+        &self,
+        entity_identifier: String,
+        path: String,
+        maybe_block_identifier: Option<String>,
+        verbosity: Option<String>,
+        rpc_address: Option<String>,
+    ) -> ToolOutput {
+        tools::contract::query_contract_key(
+            entity_identifier,
+            path,
+            maybe_block_identifier,
+            verbosity,
+            rpc_address,
+        )
+        .await
+    }
+
+    // --- write (feature = "write") ---
+
+    #[tool(description = "Sign transaction JSON with secret key PEM (mutates approvals)")]
+    async fn sdk_sign_transaction(
+        &self,
+        transaction_json: String,
+        secret_key: String,
+    ) -> ToolOutput {
+        tools::write::sign_transaction(transaction_json, secret_key)
+    }
+
+    #[tool(description = "Submit signed transaction JSON via put_transaction")]
+    async fn sdk_put_transaction(
+        &self,
+        transaction_json: String,
+        verbosity: Option<String>,
+        rpc_address: Option<String>,
+    ) -> ToolOutput {
+        tools::write::put_transaction(transaction_json, verbosity, rpc_address).await
+    }
+
+    #[tool(description = "Build + submit transaction (make + put)")]
+    async fn sdk_transaction(
+        &self,
+        builder_params_json: String,
+        transaction_params_json: String,
+        verbosity: Option<String>,
+        rpc_address: Option<String>,
+    ) -> ToolOutput {
+        tools::write::transaction(
+            builder_params_json,
+            transaction_params_json,
+            verbosity,
+            rpc_address,
+        )
+        .await
+    }
+
+    #[tool(description = "Build + submit transfer transaction")]
+    async fn sdk_transfer_transaction(
+        &self,
+        target_account: String,
+        amount: String,
+        transaction_params_json: String,
+        maybe_source: Option<String>,
+        maybe_id: Option<String>,
+        verbosity: Option<String>,
+        rpc_address: Option<String>,
+    ) -> ToolOutput {
+        tools::write::transfer_transaction(
+            target_account,
+            amount,
+            transaction_params_json,
+            maybe_source,
+            maybe_id,
+            verbosity,
+            rpc_address,
+        )
+        .await
+    }
+
+    #[tool(description = "Sign deploy JSON with secret key PEM")]
+    async fn sdk_sign_deploy(&self, deploy_json: String, secret_key: String) -> ToolOutput {
+        tools::write::sign_deploy(deploy_json, secret_key)
+    }
+
+    #[tool(description = "Submit signed deploy JSON")]
+    async fn sdk_put_deploy(
+        &self,
+        deploy_json: String,
+        verbosity: Option<String>,
+        rpc_address: Option<String>,
+    ) -> ToolOutput {
+        tools::write::put_deploy(deploy_json, verbosity, rpc_address).await
+    }
+
+    #[tool(description = "Build + submit legacy deploy")]
+    async fn sdk_deploy(
+        &self,
+        deploy_params_json: String,
+        session_params_json: String,
+        payment_params_json: String,
+        verbosity: Option<String>,
+        rpc_address: Option<String>,
+    ) -> ToolOutput {
+        tools::write::deploy(
+            deploy_params_json,
+            session_params_json,
+            payment_params_json,
+            verbosity,
+            rpc_address,
+        )
+        .await
+    }
+
+    #[tool(description = "Build + submit legacy transfer")]
+    async fn sdk_transfer(
+        &self,
+        amount: String,
+        target_account: String,
+        deploy_params_json: String,
+        payment_params_json: String,
+        transfer_id: Option<String>,
+        verbosity: Option<String>,
+        rpc_address: Option<String>,
+    ) -> ToolOutput {
+        tools::write::transfer(
+            amount,
+            target_account,
+            deploy_params_json,
+            payment_params_json,
+            transfer_id,
+            verbosity,
+            rpc_address,
+        )
+        .await
+    }
+
+    #[tool(description = "Install wasm (hex) as transaction session with is_install_upgrade")]
+    async fn sdk_install(
+        &self,
+        transaction_params_json: String,
+        wasm_hex: String,
+        rpc_address: Option<String>,
+    ) -> ToolOutput {
+        tools::write::install(transaction_params_json, wasm_hex, rpc_address).await
+    }
+
+    #[tool(description = "Install via legacy deploy (deprecated; prefer sdk_install)")]
+    async fn sdk_install_deploy(
+        &self,
+        deploy_params_json: String,
+        session_params_json: String,
+        payment_amount: String,
+        rpc_address: Option<String>,
+    ) -> ToolOutput {
+        tools::write::install_deploy(
+            deploy_params_json,
+            session_params_json,
+            payment_amount,
+            rpc_address,
+        )
+        .await
+    }
+
+    #[tool(description = "Call contract entrypoint via transaction submit")]
+    async fn sdk_call_entrypoint(
+        &self,
+        builder_params_json: String,
+        transaction_params_json: String,
+        rpc_address: Option<String>,
+    ) -> ToolOutput {
+        tools::write::call_entrypoint(builder_params_json, transaction_params_json, rpc_address)
+            .await
+    }
+
+    #[tool(description = "Call entrypoint via legacy deploy (deprecated)")]
+    async fn sdk_call_entrypoint_deploy(
+        &self,
+        deploy_params_json: String,
+        session_params_json: String,
+        payment_params_json: String,
+        rpc_address: Option<String>,
+    ) -> ToolOutput {
+        tools::write::call_entrypoint_deploy(
+            deploy_params_json,
+            session_params_json,
+            payment_params_json,
+            rpc_address,
+        )
+        .await
+    }
+
+    #[tool(description = "Binary port: try_accept_transaction (submit via binary port)")]
+    async fn sdk_get_binary_try_accept_transaction(
+        &self,
+        transaction_json: String,
+        node_address: Option<String>,
+    ) -> ToolOutput {
+        tools::write::get_binary_try_accept_transaction(transaction_json, node_address).await
+    }
 }
 
 fn help_text() -> String {

--- a/mcp/src/server.rs
+++ b/mcp/src/server.rs
@@ -1,0 +1,197 @@
+//! MCP server (`mcpkit`) for `casper-rust-wasm-sdk-mcp` (stdio or Streamable HTTP).
+
+#![allow(clippy::unused_async)]
+
+use mcpkit::prelude::*;
+use mcpkit::transport::stdio::StdioTransport;
+use mcpkit_axum::McpRouter;
+
+use crate::{format, sdk_handle, tools};
+
+/// MCP server handle exposing Casper SDK tools.
+pub struct CasperSdkMcp;
+
+/// Default HTTP bind address for Streamable MCP.
+pub const DEFAULT_HTTP_LISTEN: &str = "0.0.0.0:8790";
+
+// Keep in sync with Cargo.toml `version` (enforced by unit test below).
+#[mcp_server(name = "casper-rust-wasm-sdk", version = "2.2.2")]
+impl CasperSdkMcp {
+    #[tool(
+        description = "Help: feature matrix, env vars, endpoints, and planned/available sdk_* tools"
+    )]
+    async fn sdk_help(&self) -> ToolOutput {
+        format::text_ok(help_text())
+    }
+
+    #[tool(description = "Show current CASPER_RPC_URL / CASPER_NODE_URL / verbosity on the shared SDK")]
+    async fn sdk_get_endpoints(&self) -> ToolOutput {
+        let snap = sdk_handle::endpoint_snapshot();
+        format::json_ok(&serde_json::json!({
+            "rpc_address": snap.rpc_address,
+            "node_address": snap.node_address,
+            "verbosity": snap.verbosity,
+            "env": {
+                "CASPER_RPC_URL": sdk_handle::ENV_RPC_URL,
+                "CASPER_NODE_URL": sdk_handle::ENV_NODE_URL,
+                "CASPER_VERBOSITY": sdk_handle::ENV_VERBOSITY,
+            }
+        }))
+    }
+
+    #[tool(
+        description = "Update shared SDK endpoints for this process (optional rpc_address, node_address, verbosity)"
+    )]
+    async fn sdk_set_endpoints(
+        &self,
+        rpc_address: Option<String>,
+        node_address: Option<String>,
+        verbosity: Option<String>,
+    ) -> ToolOutput {
+        let sdk = sdk_handle::shared();
+        let mut guard = match sdk.lock() {
+            Ok(g) => g,
+            Err(err) => return format::err(format!("sdk mutex poisoned: {err}")),
+        };
+        if let Some(rpc) = rpc_address {
+            if let Err(err) = guard.set_rpc_address(Some(rpc)) {
+                return format::err(err);
+            }
+        }
+        if let Some(node) = node_address {
+            if let Err(err) = guard.set_node_address(Some(node)) {
+                return format::err(err);
+            }
+        }
+        if let Some(raw) = verbosity {
+            let v = sdk_handle::parse_verbosity(&raw);
+            if let Err(err) = guard.set_verbosity(Some(v)) {
+                return format::err(err);
+            }
+        }
+        let snap = sdk_handle::EndpointSnapshot {
+            rpc_address: guard.get_rpc_address(None),
+            node_address: guard.get_node_address(None),
+            verbosity: format!("{:?}", guard.get_verbosity(None)),
+        };
+        format::json_ok(&serde_json::json!({
+            "rpc_address": snap.rpc_address,
+            "node_address": snap.node_address,
+            "verbosity": snap.verbosity,
+        }))
+    }
+}
+
+fn help_text() -> String {
+    let snap = sdk_handle::endpoint_snapshot();
+    let groups = tools::enabled_tool_groups().join(", ");
+    let pending = tools::pending_tool_placeholders().join("\n  - ");
+    format!(
+        r#"casper-rust-wasm-sdk-mcp {version}
+
+Transports
+  stdio (default)  |  --http / CASPER_SDK_MCP_HTTP  listen CASPER_SDK_MCP_ADDR (default {listen})
+
+Env (SDK)
+  {rpc_env}   JSON-RPC URL   (default {rpc_default})
+  {node_env}  binary port    (default {node_default})
+  {verb_env}  low|medium|high|0|1|2 (default low)
+
+Current endpoints
+  rpc_address  = {rpc}
+  node_address = {node}
+  verbosity    = {verbosity}
+
+Enabled feature groups
+  {groups}
+
+Always-on tools
+  - sdk_help
+  - sdk_get_endpoints
+  - sdk_set_endpoints
+
+Pending tool groups (see mcp/TOOLS.md)
+  - {pending}
+
+Compose with sibling MCPs: casper-nctl-2-docker (:8788), kms-secp256k1-api (:8789).
+"#,
+        version = env!("CARGO_PKG_VERSION"),
+        listen = DEFAULT_HTTP_LISTEN,
+        rpc_env = sdk_handle::ENV_RPC_URL,
+        node_env = sdk_handle::ENV_NODE_URL,
+        verb_env = sdk_handle::ENV_VERBOSITY,
+        rpc_default = sdk_handle::DEFAULT_RPC_URL,
+        node_default = sdk_handle::DEFAULT_NODE_URL,
+        rpc = snap.rpc_address,
+        node = snap.node_address,
+        verbosity = snap.verbosity,
+        groups = groups,
+        pending = pending,
+    )
+}
+
+/// Serves MCP over stdio until the client disconnects.
+pub async fn run() -> Result<(), McpError> {
+    let transport = StdioTransport::new();
+    let server = ServerBuilder::new(CasperSdkMcp)
+        .with_tools(CasperSdkMcp)
+        .build();
+    server.serve(transport).await
+}
+
+/// Serves MCP over Streamable HTTP until the process is stopped.
+pub async fn run_http(addr: &str) -> std::io::Result<()> {
+    McpRouter::new(CasperSdkMcp).serve(addr).await
+}
+
+impl ResourceHandler for CasperSdkMcp {
+    async fn list_resources(&self, _ctx: &Context<'_>) -> Result<Vec<Resource>, McpError> {
+        Ok(Vec::new())
+    }
+
+    async fn read_resource(
+        &self,
+        uri: &str,
+        _ctx: &Context<'_>,
+    ) -> Result<Vec<ResourceContents>, McpError> {
+        Err(McpError::invalid_params(
+            "resources/read",
+            format!("unknown resource: {uri}"),
+        ))
+    }
+}
+
+impl PromptHandler for CasperSdkMcp {
+    async fn list_prompts(&self, _ctx: &Context<'_>) -> Result<Vec<Prompt>, McpError> {
+        Ok(Vec::new())
+    }
+
+    async fn get_prompt(
+        &self,
+        name: &str,
+        _args: Option<serde_json::Map<String, serde_json::Value>>,
+        _ctx: &Context<'_>,
+    ) -> Result<GetPromptResult, McpError> {
+        Err(McpError::invalid_params(
+            "prompts/get",
+            format!("unknown prompt: {name}"),
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn mcp_server_version_matches_crate() {
+        let src = include_str!("server.rs");
+        let needle = format!(
+            r#"#[mcp_server(name = "casper-rust-wasm-sdk", version = "{}")]"#,
+            env!("CARGO_PKG_VERSION")
+        );
+        assert!(
+            src.contains(&needle),
+            "bump #[mcp_server(version = …)] to {} when changing Cargo.toml version",
+            env!("CARGO_PKG_VERSION")
+        );
+    }
+}

--- a/mcp/src/server.rs
+++ b/mcp/src/server.rs
@@ -485,10 +485,7 @@ impl CasperSdkMcp {
     }
 
     #[tool(description = "Binary port: latest block header")]
-    async fn sdk_get_binary_latest_block_header(
-        &self,
-        node_address: Option<String>,
-    ) -> ToolOutput {
+    async fn sdk_get_binary_latest_block_header(&self, node_address: Option<String>) -> ToolOutput {
         tools::binary_port::get_binary_latest_block_header(node_address).await
     }
 
@@ -611,10 +608,7 @@ impl CasperSdkMcp {
     }
 
     #[tool(description = "Binary port: chainspec raw bytes")]
-    async fn sdk_get_binary_chainspec_raw_bytes(
-        &self,
-        node_address: Option<String>,
-    ) -> ToolOutput {
+    async fn sdk_get_binary_chainspec_raw_bytes(&self, node_address: Option<String>) -> ToolOutput {
         tools::binary_port::get_binary_chainspec_raw_bytes(node_address).await
     }
 
@@ -725,7 +719,9 @@ impl CasperSdkMcp {
         tools::binary_port::get_binary_read_record(record_id, key_hex, node_address).await
     }
 
-    #[tool(description = "Binary port: global state item (formatted key; path as a/b or JSON array)")]
+    #[tool(
+        description = "Binary port: global state item (formatted key; path as a/b or JSON array)"
+    )]
     async fn sdk_get_binary_global_state_item(
         &self,
         key: String,
@@ -803,7 +799,9 @@ impl CasperSdkMcp {
 
     // --- transaction (feature = "transaction") ---
 
-    #[tool(description = "Build unsigned transaction from builder_params_json + transaction_params_json")]
+    #[tool(
+        description = "Build unsigned transaction from builder_params_json + transaction_params_json"
+    )]
     async fn sdk_make_transaction(
         &self,
         builder_params_json: String,

--- a/mcp/src/tools/binary_port.rs
+++ b/mcp/src/tools/binary_port.rs
@@ -1,6 +1,491 @@
-//! Placeholder: binary-port tools (Phase 4).
+//! Binary-port tools domain logic (feature `binary-port`).
 
-#![allow(dead_code)]
+use casper_rust_wasm_sdk::helpers;
+use casper_rust_wasm_sdk::types::digest::Digest;
+use casper_rust_wasm_sdk::types::hash::block_hash::BlockHash;
+use casper_rust_wasm_sdk::types::hash::transaction_hash::TransactionHash;
+use casper_rust_wasm_sdk::types::key::Key;
+use casper_rust_wasm_sdk::types::public_key::PublicKey;
+use casper_rust_wasm_sdk::types::record_id::RecordId;
+use casper_rust_wasm_sdk::types::transaction::Transaction;
+use casper_types::EraId;
+use mcpkit::prelude::ToolOutput;
+use serde::Serialize;
 
-/// Marker so the `binary-port` feature module compiles.
-pub const FEATURE: &str = "binary-port";
+use crate::format;
+use crate::sdk_handle;
+
+/// Registered binary-port tool names for help text.
+pub fn tool_names() -> &'static [&'static str] {
+    &[
+        "sdk_get_binary_latest_switch_block_header",
+        "sdk_get_binary_latest_block_header",
+        "sdk_get_binary_block_header_by_height",
+        "sdk_get_binary_block_header_by_hash",
+        "sdk_get_binary_latest_block_with_signatures",
+        "sdk_get_binary_block_with_signatures_by_height",
+        "sdk_get_binary_block_with_signatures_by_hash",
+        "sdk_get_binary_transaction_by_hash",
+        "sdk_get_binary_peers",
+        "sdk_get_binary_uptime",
+        "sdk_get_binary_last_progress",
+        "sdk_get_binary_reactor_state",
+        "sdk_get_binary_network_name",
+        "sdk_get_binary_consensus_validator_changes",
+        "sdk_get_binary_block_synchronizer_status",
+        "sdk_get_binary_available_block_range",
+        "sdk_get_binary_next_upgrade",
+        "sdk_get_binary_consensus_status",
+        "sdk_get_binary_chainspec_raw_bytes",
+        "sdk_get_binary_node_status",
+        "sdk_get_binary_validator_reward_by_era",
+        "sdk_get_binary_validator_reward_by_block_height",
+        "sdk_get_binary_validator_reward_by_block_hash",
+        "sdk_get_binary_delegator_reward_by_era",
+        "sdk_get_binary_delegator_reward_by_block_height",
+        "sdk_get_binary_delegator_reward_by_block_hash",
+        "sdk_get_binary_read_record",
+        "sdk_get_binary_global_state_item",
+        "sdk_get_binary_global_state_item_by_state_root_hash",
+        "sdk_get_binary_global_state_item_by_block_hash",
+        "sdk_get_binary_global_state_item_by_block_height",
+        "sdk_get_binary_try_speculative_execution",
+        "sdk_get_binary_protocol_version",
+    ]
+}
+
+fn bin_ok<T: Serialize, E: std::fmt::Display>(result: Result<T, E>) -> ToolOutput {
+    match result {
+        Ok(value) => format::serialize_ok(&value),
+        Err(err) => format::err(err),
+    }
+}
+
+fn parse_block_hash(hex: &str) -> Result<casper_types::BlockHash, String> {
+    BlockHash::new(hex)
+        .map(Into::into)
+        .map_err(|e| e.to_string())
+}
+
+fn parse_tx_hash(hex: &str) -> Result<casper_types::TransactionHash, String> {
+    TransactionHash::new(hex)
+        .map(Into::into)
+        .map_err(|e| e.to_string())
+}
+
+fn parse_pubkey(hex: &str) -> Result<casper_types::PublicKey, String> {
+    PublicKey::new(hex)
+        .map(Into::into)
+        .map_err(|e| e.to_string())
+}
+
+fn parse_key(formatted: &str) -> Result<casper_types::Key, String> {
+    Key::from_formatted_str(formatted)
+        .map(Into::into)
+        .map_err(|e| e.to_string())
+}
+
+fn parse_digest(hex: &str) -> Result<casper_types::Digest, String> {
+    Digest::new(hex)
+        .map(Into::into)
+        .map_err(|e| e.to_string())
+}
+
+fn parse_path(path: Option<String>) -> Result<Vec<String>, String> {
+    let Some(raw) = path.filter(|s| !s.trim().is_empty()) else {
+        return Ok(Vec::new());
+    };
+    let trimmed = raw.trim();
+    if trimmed.starts_with('[') {
+        serde_json::from_str(trimmed).map_err(|e| format!("path JSON array: {e}"))
+    } else {
+        Ok(trimmed
+            .split('/')
+            .filter(|p| !p.is_empty())
+            .map(str::to_string)
+            .collect())
+    }
+}
+
+macro_rules! bin_call {
+    ($expr:expr) => {
+        bin_ok($expr.await)
+    };
+}
+
+pub async fn get_binary_latest_switch_block_header(node_address: Option<String>) -> ToolOutput {
+    let sdk = sdk_handle::sdk_snapshot();
+    bin_call!(sdk.get_binary_latest_switch_block_header(node_address))
+}
+
+pub async fn get_binary_latest_block_header(node_address: Option<String>) -> ToolOutput {
+    let sdk = sdk_handle::sdk_snapshot();
+    bin_call!(sdk.get_binary_latest_block_header(node_address))
+}
+
+pub async fn get_binary_block_header_by_height(
+    height: u64,
+    node_address: Option<String>,
+) -> ToolOutput {
+    let sdk = sdk_handle::sdk_snapshot();
+    bin_call!(sdk.get_binary_block_header_by_height(node_address, height))
+}
+
+pub async fn get_binary_block_header_by_hash(
+    block_hash: String,
+    node_address: Option<String>,
+) -> ToolOutput {
+    let hash = match parse_block_hash(&block_hash) {
+        Ok(h) => h,
+        Err(err) => return format::err(err),
+    };
+    let sdk = sdk_handle::sdk_snapshot();
+    bin_call!(sdk.get_binary_block_header_by_hash(node_address, hash))
+}
+
+pub async fn get_binary_latest_block_with_signatures(node_address: Option<String>) -> ToolOutput {
+    let sdk = sdk_handle::sdk_snapshot();
+    bin_call!(sdk.get_binary_latest_block_with_signatures(node_address))
+}
+
+pub async fn get_binary_block_with_signatures_by_height(
+    height: u64,
+    node_address: Option<String>,
+) -> ToolOutput {
+    let sdk = sdk_handle::sdk_snapshot();
+    bin_call!(sdk.get_binary_block_with_signatures_by_height(node_address, height))
+}
+
+pub async fn get_binary_block_with_signatures_by_hash(
+    block_hash: String,
+    node_address: Option<String>,
+) -> ToolOutput {
+    let hash = match parse_block_hash(&block_hash) {
+        Ok(h) => h,
+        Err(err) => return format::err(err),
+    };
+    let sdk = sdk_handle::sdk_snapshot();
+    bin_call!(sdk.get_binary_block_with_signatures_by_hash(node_address, hash))
+}
+
+pub async fn get_binary_transaction_by_hash(
+    hash: String,
+    with_finalized_approvals: Option<bool>,
+    node_address: Option<String>,
+) -> ToolOutput {
+    let tx_hash = match parse_tx_hash(&hash) {
+        Ok(h) => h,
+        Err(err) => return format::err(err),
+    };
+    let sdk = sdk_handle::sdk_snapshot();
+    bin_call!(sdk.get_binary_transaction_by_hash(
+        node_address,
+        tx_hash,
+        with_finalized_approvals.unwrap_or(false)
+    ))
+}
+
+pub async fn get_binary_peers(node_address: Option<String>) -> ToolOutput {
+    let sdk = sdk_handle::sdk_snapshot();
+    bin_call!(sdk.get_binary_peers(node_address))
+}
+
+pub async fn get_binary_uptime(node_address: Option<String>) -> ToolOutput {
+    let sdk = sdk_handle::sdk_snapshot();
+    bin_call!(sdk.get_binary_uptime(node_address))
+}
+
+pub async fn get_binary_last_progress(node_address: Option<String>) -> ToolOutput {
+    let sdk = sdk_handle::sdk_snapshot();
+    bin_call!(sdk.get_binary_last_progress(node_address))
+}
+
+pub async fn get_binary_reactor_state(node_address: Option<String>) -> ToolOutput {
+    let sdk = sdk_handle::sdk_snapshot();
+    bin_call!(sdk.get_binary_reactor_state(node_address))
+}
+
+pub async fn get_binary_network_name(node_address: Option<String>) -> ToolOutput {
+    let sdk = sdk_handle::sdk_snapshot();
+    bin_call!(sdk.get_binary_network_name(node_address))
+}
+
+pub async fn get_binary_consensus_validator_changes(node_address: Option<String>) -> ToolOutput {
+    let sdk = sdk_handle::sdk_snapshot();
+    bin_call!(sdk.get_binary_consensus_validator_changes(node_address))
+}
+
+pub async fn get_binary_block_synchronizer_status(node_address: Option<String>) -> ToolOutput {
+    let sdk = sdk_handle::sdk_snapshot();
+    bin_call!(sdk.get_binary_block_synchronizer_status(node_address))
+}
+
+pub async fn get_binary_available_block_range(node_address: Option<String>) -> ToolOutput {
+    let sdk = sdk_handle::sdk_snapshot();
+    bin_call!(sdk.get_binary_available_block_range(node_address))
+}
+
+pub async fn get_binary_next_upgrade(node_address: Option<String>) -> ToolOutput {
+    let sdk = sdk_handle::sdk_snapshot();
+    bin_call!(sdk.get_binary_next_upgrade(node_address))
+}
+
+pub async fn get_binary_consensus_status(node_address: Option<String>) -> ToolOutput {
+    let sdk = sdk_handle::sdk_snapshot();
+    bin_call!(sdk.get_binary_consensus_status(node_address))
+}
+
+pub async fn get_binary_chainspec_raw_bytes(node_address: Option<String>) -> ToolOutput {
+    let sdk = sdk_handle::sdk_snapshot();
+    bin_call!(sdk.get_binary_chainspec_raw_bytes(node_address))
+}
+
+pub async fn get_binary_node_status(node_address: Option<String>) -> ToolOutput {
+    let sdk = sdk_handle::sdk_snapshot();
+    bin_call!(sdk.get_binary_node_status(node_address))
+}
+
+pub async fn get_binary_validator_reward_by_era(
+    validator_key: String,
+    era: u64,
+    node_address: Option<String>,
+) -> ToolOutput {
+    let pk = match parse_pubkey(&validator_key) {
+        Ok(k) => k,
+        Err(err) => return format::err(err),
+    };
+    let sdk = sdk_handle::sdk_snapshot();
+    bin_call!(sdk.get_binary_validator_reward_by_era(node_address, pk, EraId::new(era)))
+}
+
+pub async fn get_binary_validator_reward_by_block_height(
+    validator_key: String,
+    block_height: u64,
+    node_address: Option<String>,
+) -> ToolOutput {
+    let pk = match parse_pubkey(&validator_key) {
+        Ok(k) => k,
+        Err(err) => return format::err(err),
+    };
+    let sdk = sdk_handle::sdk_snapshot();
+    bin_call!(sdk.get_binary_validator_reward_by_block_height(node_address, pk, block_height))
+}
+
+pub async fn get_binary_validator_reward_by_block_hash(
+    validator_key: String,
+    block_hash: String,
+    node_address: Option<String>,
+) -> ToolOutput {
+    let pk = match parse_pubkey(&validator_key) {
+        Ok(k) => k,
+        Err(err) => return format::err(err),
+    };
+    let hash = match parse_block_hash(&block_hash) {
+        Ok(h) => h,
+        Err(err) => return format::err(err),
+    };
+    let sdk = sdk_handle::sdk_snapshot();
+    bin_call!(sdk.get_binary_validator_reward_by_block_hash(node_address, pk, hash))
+}
+
+pub async fn get_binary_delegator_reward_by_era(
+    validator_key: String,
+    delegator_key: String,
+    era: u64,
+    node_address: Option<String>,
+) -> ToolOutput {
+    let v = match parse_pubkey(&validator_key) {
+        Ok(k) => k,
+        Err(err) => return format::err(err),
+    };
+    let d = match parse_pubkey(&delegator_key) {
+        Ok(k) => k,
+        Err(err) => return format::err(err),
+    };
+    let sdk = sdk_handle::sdk_snapshot();
+    bin_call!(sdk.get_binary_delegator_reward_by_era(node_address, v, d, EraId::new(era)))
+}
+
+pub async fn get_binary_delegator_reward_by_block_height(
+    validator_key: String,
+    delegator_key: String,
+    block_height: u64,
+    node_address: Option<String>,
+) -> ToolOutput {
+    let v = match parse_pubkey(&validator_key) {
+        Ok(k) => k,
+        Err(err) => return format::err(err),
+    };
+    let d = match parse_pubkey(&delegator_key) {
+        Ok(k) => k,
+        Err(err) => return format::err(err),
+    };
+    let sdk = sdk_handle::sdk_snapshot();
+    bin_call!(sdk.get_binary_delegator_reward_by_block_height(node_address, v, d, block_height))
+}
+
+pub async fn get_binary_delegator_reward_by_block_hash(
+    validator_key: String,
+    delegator_key: String,
+    block_hash: String,
+    node_address: Option<String>,
+) -> ToolOutput {
+    let v = match parse_pubkey(&validator_key) {
+        Ok(k) => k,
+        Err(err) => return format::err(err),
+    };
+    let d = match parse_pubkey(&delegator_key) {
+        Ok(k) => k,
+        Err(err) => return format::err(err),
+    };
+    let hash = match parse_block_hash(&block_hash) {
+        Ok(h) => h,
+        Err(err) => return format::err(err),
+    };
+    let sdk = sdk_handle::sdk_snapshot();
+    bin_call!(sdk.get_binary_delegator_reward_by_block_hash(node_address, v, d, hash))
+}
+
+pub async fn get_binary_read_record(
+    record_id: u16,
+    key_hex: String,
+    node_address: Option<String>,
+) -> ToolOutput {
+    let id = match RecordId::new(record_id) {
+        Ok(id) => id,
+        Err(err) => return format::err(err),
+    };
+    let key = helpers::hex_to_uint8_vec(&key_hex);
+    if key.is_empty() {
+        return format::err("key_hex decoded empty (need even-length hex)");
+    }
+    let sdk = sdk_handle::sdk_snapshot();
+    match sdk
+        .get_binary_read_record(node_address, id.into(), &key)
+        .await
+    {
+        Ok(bytes) => format::json_ok(&serde_json::json!({
+            "bytes_hex": hex::encode(bytes),
+        })),
+        Err(err) => format::err(err),
+    }
+}
+
+pub async fn get_binary_global_state_item(
+    key: String,
+    path: Option<String>,
+    node_address: Option<String>,
+) -> ToolOutput {
+    let key = match parse_key(&key) {
+        Ok(k) => k,
+        Err(err) => return format::err(err),
+    };
+    let path = match parse_path(path) {
+        Ok(p) => p,
+        Err(err) => return format::err(err),
+    };
+    let sdk = sdk_handle::sdk_snapshot();
+    bin_call!(sdk.get_binary_global_state_item(node_address, key, path))
+}
+
+pub async fn get_binary_global_state_item_by_state_root_hash(
+    state_root_hash: String,
+    key: String,
+    path: Option<String>,
+    node_address: Option<String>,
+) -> ToolOutput {
+    let digest = match parse_digest(&state_root_hash) {
+        Ok(d) => d,
+        Err(err) => return format::err(err),
+    };
+    let key = match parse_key(&key) {
+        Ok(k) => k,
+        Err(err) => return format::err(err),
+    };
+    let path = match parse_path(path) {
+        Ok(p) => p,
+        Err(err) => return format::err(err),
+    };
+    let sdk = sdk_handle::sdk_snapshot();
+    bin_call!(sdk.get_binary_global_state_item_by_state_root_hash(node_address, digest, key, path))
+}
+
+pub async fn get_binary_global_state_item_by_block_hash(
+    block_hash: String,
+    key: String,
+    path: Option<String>,
+    node_address: Option<String>,
+) -> ToolOutput {
+    let hash = match parse_block_hash(&block_hash) {
+        Ok(h) => h,
+        Err(err) => return format::err(err),
+    };
+    let key = match parse_key(&key) {
+        Ok(k) => k,
+        Err(err) => return format::err(err),
+    };
+    let path = match parse_path(path) {
+        Ok(p) => p,
+        Err(err) => return format::err(err),
+    };
+    let sdk = sdk_handle::sdk_snapshot();
+    bin_call!(sdk.get_binary_global_state_item_by_block_hash(node_address, hash, key, path))
+}
+
+pub async fn get_binary_global_state_item_by_block_height(
+    block_height: u64,
+    key: String,
+    path: Option<String>,
+    node_address: Option<String>,
+) -> ToolOutput {
+    let key = match parse_key(&key) {
+        Ok(k) => k,
+        Err(err) => return format::err(err),
+    };
+    let path = match parse_path(path) {
+        Ok(p) => p,
+        Err(err) => return format::err(err),
+    };
+    let sdk = sdk_handle::sdk_snapshot();
+    bin_call!(sdk.get_binary_global_state_item_by_block_height(node_address, block_height, key, path))
+}
+
+pub async fn get_binary_try_speculative_execution(
+    transaction_json: String,
+    node_address: Option<String>,
+) -> ToolOutput {
+    let transaction = match Transaction::from_json_string(&transaction_json) {
+        Ok(t) => t,
+        Err(err) => return format::err(err),
+    };
+    let sdk = sdk_handle::sdk_snapshot();
+    bin_call!(sdk.get_binary_try_speculative_execution(node_address, transaction.into()))
+}
+
+pub async fn get_binary_protocol_version(node_address: Option<String>) -> ToolOutput {
+    let sdk = sdk_handle::sdk_snapshot();
+    bin_call!(sdk.get_binary_protocol_version(node_address))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_path_slash_and_json() {
+        assert_eq!(
+            parse_path(Some("a/b/c".into())).unwrap(),
+            vec!["a", "b", "c"]
+        );
+        assert_eq!(
+            parse_path(Some(r#"["x","y"]"#.into())).unwrap(),
+            vec!["x", "y"]
+        );
+        assert!(parse_path(None).unwrap().is_empty());
+    }
+
+    #[test]
+    fn tool_names_nonempty() {
+        assert!(tool_names().len() >= 30);
+    }
+}

--- a/mcp/src/tools/binary_port.rs
+++ b/mcp/src/tools/binary_port.rs
@@ -1,0 +1,6 @@
+//! Placeholder: binary-port tools (Phase 4).
+
+#![allow(dead_code)]
+
+/// Marker so the `binary-port` feature module compiles.
+pub const FEATURE: &str = "binary-port";

--- a/mcp/src/tools/binary_port.rs
+++ b/mcp/src/tools/binary_port.rs
@@ -86,9 +86,7 @@ fn parse_key(formatted: &str) -> Result<casper_types::Key, String> {
 }
 
 fn parse_digest(hex: &str) -> Result<casper_types::Digest, String> {
-    Digest::new(hex)
-        .map(Into::into)
-        .map_err(|e| e.to_string())
+    Digest::new(hex).map(Into::into).map_err(|e| e.to_string())
 }
 
 fn parse_path(path: Option<String>) -> Result<Vec<String>, String> {
@@ -447,7 +445,12 @@ pub async fn get_binary_global_state_item_by_block_height(
         Err(err) => return format::err(err),
     };
     let sdk = sdk_handle::sdk_snapshot();
-    bin_call!(sdk.get_binary_global_state_item_by_block_height(node_address, block_height, key, path))
+    bin_call!(sdk.get_binary_global_state_item_by_block_height(
+        node_address,
+        block_height,
+        key,
+        path
+    ))
 }
 
 pub async fn get_binary_try_speculative_execution(

--- a/mcp/src/tools/contract.rs
+++ b/mcp/src/tools/contract.rs
@@ -1,0 +1,6 @@
+//! Placeholder: contract tools (Phase 5).
+
+#![allow(dead_code)]
+
+/// Marker so the `contract` feature module compiles.
+pub const FEATURE: &str = "contract";

--- a/mcp/src/tools/contract.rs
+++ b/mcp/src/tools/contract.rs
@@ -17,7 +17,10 @@ fn verb(verbosity: Option<&str>) -> Option<casper_rust_wasm_sdk::types::verbosit
     sdk_handle::verbosity_override(verbosity)
 }
 
-fn parse_dictionary_item(kind: &str, fields: &serde_json::Value) -> Result<DictionaryItemInput, String> {
+fn parse_dictionary_item(
+    kind: &str,
+    fields: &serde_json::Value,
+) -> Result<DictionaryItemInput, String> {
     let mut params = DictionaryItemStrParams::new();
     match kind {
         "uref" => {

--- a/mcp/src/tools/contract.rs
+++ b/mcp/src/tools/contract.rs
@@ -1,6 +1,150 @@
-//! Placeholder: contract tools (Phase 5).
+//! Contract query tools (feature `contract`).
 
-#![allow(dead_code)]
+use casper_rust_wasm_sdk::rpcs::get_dictionary_item::DictionaryItemInput;
+use casper_rust_wasm_sdk::rpcs::query_global_state::PathIdentifierInput;
+use casper_rust_wasm_sdk::types::deploy_params::dictionary_item_str_params::DictionaryItemStrParams;
+use casper_rust_wasm_sdk::types::identifier::block_identifier::BlockIdentifierInput;
+use mcpkit::prelude::ToolOutput;
 
-/// Marker so the `contract` feature module compiles.
-pub const FEATURE: &str = "contract";
+use crate::format;
+use crate::sdk_handle;
+
+pub fn tool_names() -> &'static [&'static str] {
+    &["sdk_query_contract_dict", "sdk_query_contract_key"]
+}
+
+fn verb(verbosity: Option<&str>) -> Option<casper_rust_wasm_sdk::types::verbosity::Verbosity> {
+    sdk_handle::verbosity_override(verbosity)
+}
+
+fn parse_dictionary_item(kind: &str, fields: &serde_json::Value) -> Result<DictionaryItemInput, String> {
+    let mut params = DictionaryItemStrParams::new();
+    match kind {
+        "uref" => {
+            let seed = fields
+                .get("seed_uref")
+                .and_then(|v| v.as_str())
+                .ok_or("uref requires seed_uref")?;
+            let item = fields
+                .get("dictionary_item_key")
+                .and_then(|v| v.as_str())
+                .ok_or("uref requires dictionary_item_key")?;
+            params.set_uref(seed, item);
+        }
+        "dictionary" => {
+            let value = fields
+                .get("dictionary_value")
+                .or_else(|| fields.get("value"))
+                .and_then(|v| v.as_str())
+                .ok_or("dictionary requires dictionary_value")?;
+            params.set_dictionary(value);
+        }
+        "account_named_key" => {
+            let key = fields
+                .get("key")
+                .and_then(|v| v.as_str())
+                .ok_or("account_named_key requires key")?;
+            let dn = fields
+                .get("dictionary_name")
+                .and_then(|v| v.as_str())
+                .ok_or("account_named_key requires dictionary_name")?;
+            let dik = fields
+                .get("dictionary_item_key")
+                .and_then(|v| v.as_str())
+                .ok_or("account_named_key requires dictionary_item_key")?;
+            params.set_account_named_key(key, dn, dik);
+        }
+        "contract_named_key" => {
+            let key = fields
+                .get("key")
+                .and_then(|v| v.as_str())
+                .ok_or("contract_named_key requires key")?;
+            let dn = fields
+                .get("dictionary_name")
+                .and_then(|v| v.as_str())
+                .ok_or("contract_named_key requires dictionary_name")?;
+            let dik = fields
+                .get("dictionary_item_key")
+                .and_then(|v| v.as_str())
+                .ok_or("contract_named_key requires dictionary_item_key")?;
+            params.set_contract_named_key(key, dn, dik);
+        }
+        "entity_named_key" => {
+            let key = fields
+                .get("key")
+                .and_then(|v| v.as_str())
+                .ok_or("entity_named_key requires key")?;
+            let dn = fields
+                .get("dictionary_name")
+                .and_then(|v| v.as_str())
+                .ok_or("entity_named_key requires dictionary_name")?;
+            let dik = fields
+                .get("dictionary_item_key")
+                .and_then(|v| v.as_str())
+                .ok_or("entity_named_key requires dictionary_item_key")?;
+            params.set_entity_named_key(key, dn, dik);
+        }
+        other => {
+            return Err(format!(
+                "unknown dictionary kind `{other}` (uref|dictionary|account_named_key|…)"
+            ))
+        }
+    }
+    Ok(DictionaryItemInput::Params(Box::new(params)))
+}
+
+pub async fn query_contract_dict(
+    kind: String,
+    dictionary_item_json: String,
+    state_root_hash: Option<String>,
+    verbosity: Option<String>,
+    rpc_address: Option<String>,
+) -> ToolOutput {
+    let fields: serde_json::Value = match serde_json::from_str(&dictionary_item_json) {
+        Ok(v) => v,
+        Err(err) => return format::err(format!("dictionary_item_json: {err}")),
+    };
+    let input = match parse_dictionary_item(&kind, &fields) {
+        Ok(i) => i,
+        Err(err) => return format::err(err),
+    };
+    let sdk = sdk_handle::sdk_snapshot();
+    match sdk
+        .query_contract_dict(
+            input,
+            state_root_hash.as_deref(),
+            verb(verbosity.as_deref()),
+            rpc_address,
+        )
+        .await
+    {
+        Ok(resp) => format::serialize_ok(&resp.result),
+        Err(err) => format::err(err),
+    }
+}
+
+pub async fn query_contract_key(
+    entity_identifier: String,
+    path: String,
+    maybe_block_identifier: Option<String>,
+    verbosity: Option<String>,
+    rpc_address: Option<String>,
+) -> ToolOutput {
+    let sdk = sdk_handle::sdk_snapshot();
+    let path = PathIdentifierInput::String(path);
+    let block = maybe_block_identifier.map(BlockIdentifierInput::String);
+    match sdk
+        .query_contract_key(
+            None,
+            Some(entity_identifier),
+            path,
+            block,
+            verb(verbosity.as_deref()),
+            rpc_address,
+        )
+        .await
+    {
+        Ok(resp) => format::serialize_ok(&resp.result),
+        Err(err) => format::err(err),
+    }
+}

--- a/mcp/src/tools/deploy.rs
+++ b/mcp/src/tools/deploy.rs
@@ -1,6 +1,157 @@
-//! Placeholder: deploy tools (Phase 5).
+//! Legacy deploy builder / speculative tools (feature `deploy`).
 
-#![allow(dead_code)]
+#![allow(deprecated)]
 
-/// Marker so the `deploy` feature module compiles.
-pub const FEATURE: &str = "deploy";
+use casper_rust_wasm_sdk::types::deploy::Deploy;
+use mcpkit::prelude::ToolOutput;
+
+use crate::format;
+use crate::sdk_handle;
+use crate::tools::params::{
+    parse_deploy_str_params, parse_payment_str_params, parse_session_str_params,
+};
+
+pub fn tool_names() -> &'static [&'static str] {
+    &[
+        "sdk_make_deploy",
+        "sdk_make_transfer",
+        "sdk_speculative_deploy",
+        "sdk_speculative_transfer",
+    ]
+}
+
+pub fn serialize_deploy(deploy: Deploy) -> ToolOutput {
+    match deploy.to_json_string() {
+        Ok(s) => match serde_json::from_str::<serde_json::Value>(&s) {
+            Ok(v) => format::json_ok(&v),
+            Err(_) => format::text_ok(s),
+        },
+        Err(err) => format::err(err),
+    }
+}
+
+fn verb(verbosity: Option<&str>) -> Option<casper_rust_wasm_sdk::types::verbosity::Verbosity> {
+    sdk_handle::verbosity_override(verbosity)
+}
+
+pub fn make_deploy(
+    deploy_params_json: String,
+    session_params_json: String,
+    payment_params_json: String,
+) -> ToolOutput {
+    let deploy_params = match parse_deploy_str_params(&deploy_params_json) {
+        Ok(p) => p,
+        Err(err) => return format::err(err),
+    };
+    let session_params = match parse_session_str_params(&session_params_json) {
+        Ok(p) => p,
+        Err(err) => return format::err(err),
+    };
+    let payment_params = match parse_payment_str_params(&payment_params_json) {
+        Ok(p) => p,
+        Err(err) => return format::err(err),
+    };
+    let sdk = sdk_handle::sdk_snapshot();
+    match sdk.make_deploy(deploy_params, session_params, payment_params) {
+        Ok(d) => serialize_deploy(d),
+        Err(err) => format::err(err),
+    }
+}
+
+pub fn make_transfer(
+    amount: String,
+    target_account: String,
+    deploy_params_json: String,
+    payment_params_json: String,
+    transfer_id: Option<String>,
+) -> ToolOutput {
+    let deploy_params = match parse_deploy_str_params(&deploy_params_json) {
+        Ok(p) => p,
+        Err(err) => return format::err(err),
+    };
+    let payment_params = match parse_payment_str_params(&payment_params_json) {
+        Ok(p) => p,
+        Err(err) => return format::err(err),
+    };
+    let sdk = sdk_handle::sdk_snapshot();
+    match sdk.make_transfer(
+        &amount,
+        &target_account,
+        transfer_id,
+        deploy_params,
+        payment_params,
+    ) {
+        Ok(d) => serialize_deploy(d),
+        Err(err) => format::err(err),
+    }
+}
+
+pub async fn speculative_deploy(
+    deploy_params_json: String,
+    session_params_json: String,
+    payment_params_json: String,
+    verbosity: Option<String>,
+    rpc_address: Option<String>,
+) -> ToolOutput {
+    let deploy_params = match parse_deploy_str_params(&deploy_params_json) {
+        Ok(p) => p,
+        Err(err) => return format::err(err),
+    };
+    let session_params = match parse_session_str_params(&session_params_json) {
+        Ok(p) => p,
+        Err(err) => return format::err(err),
+    };
+    let payment_params = match parse_payment_str_params(&payment_params_json) {
+        Ok(p) => p,
+        Err(err) => return format::err(err),
+    };
+    let sdk = sdk_handle::sdk_snapshot();
+    match sdk
+        .speculative_deploy(
+            deploy_params,
+            session_params,
+            payment_params,
+            verb(verbosity.as_deref()),
+            rpc_address,
+        )
+        .await
+    {
+        Ok(resp) => format::serialize_ok(&resp.result),
+        Err(err) => format::err(err),
+    }
+}
+
+pub async fn speculative_transfer(
+    amount: String,
+    target_account: String,
+    deploy_params_json: String,
+    payment_params_json: String,
+    transfer_id: Option<String>,
+    verbosity: Option<String>,
+    rpc_address: Option<String>,
+) -> ToolOutput {
+    let deploy_params = match parse_deploy_str_params(&deploy_params_json) {
+        Ok(p) => p,
+        Err(err) => return format::err(err),
+    };
+    let payment_params = match parse_payment_str_params(&payment_params_json) {
+        Ok(p) => p,
+        Err(err) => return format::err(err),
+    };
+    let sdk = sdk_handle::sdk_snapshot();
+    match sdk
+        .speculative_transfer(
+            &amount,
+            &target_account,
+            transfer_id,
+            deploy_params,
+            payment_params,
+            verb(verbosity.as_deref()),
+            rpc_address,
+        )
+        .await
+    {
+        Ok(resp) => format::serialize_ok(&resp.result),
+        Err(err) => format::err(err),
+    }
+}

--- a/mcp/src/tools/deploy.rs
+++ b/mcp/src/tools/deploy.rs
@@ -1,0 +1,6 @@
+//! Placeholder: deploy tools (Phase 5).
+
+#![allow(dead_code)]
+
+/// Marker so the `deploy` feature module compiles.
+pub const FEATURE: &str = "deploy";

--- a/mcp/src/tools/helpers.rs
+++ b/mcp/src/tools/helpers.rs
@@ -176,9 +176,7 @@ pub fn cl_value_to_json(cl_value_json: String) -> ToolOutput {
     let cl_value: casper_types::CLValue = match serde_json::from_str(&cl_value_json) {
         Ok(v) => v,
         Err(err) => {
-            return format::err(format!(
-                "cl_value_json must deserialize as CLValue: {err}"
-            ))
+            return format::err(format!("cl_value_json must deserialize as CLValue: {err}"))
         }
     };
     match helpers::cl_value_to_json(&cl_value) {

--- a/mcp/src/tools/helpers.rs
+++ b/mcp/src/tools/helpers.rs
@@ -1,6 +1,206 @@
-//! Placeholder: helper tools (Phase 3).
+//! Helper tools domain logic (feature `helpers`).
 
-#![allow(dead_code)]
+use casper_rust_wasm_sdk::helpers;
+use casper_rust_wasm_sdk::types::key::Key;
+use casper_types::U256;
+use mcpkit::prelude::ToolOutput;
+use std::str::FromStr;
 
-/// Marker so the `helpers` feature module compiles.
-pub const FEATURE: &str = "helpers";
+use crate::format;
+use crate::sdk_handle;
+
+/// Registered helper tool names for help text.
+pub fn tool_names() -> &'static [&'static str] {
+    &[
+        "sdk_get_current_timestamp",
+        "sdk_get_blake2b_hash",
+        "sdk_make_dictionary_item_key",
+        "sdk_get_base64_key_from_account_hash",
+        "sdk_get_base64_key_from_key_hash",
+        "sdk_get_ttl_or_default",
+        "sdk_parse_timestamp",
+        "sdk_parse_ttl",
+        "sdk_get_gas_price_or_default",
+        "sdk_secret_key_generate",
+        "sdk_secret_key_secp256k1_generate",
+        "sdk_secret_key_from_pem",
+        "sdk_public_key_from_secret_key",
+        "sdk_hex_to_uint8_vec",
+        "sdk_hex_to_string",
+        "sdk_motes_to_cspr",
+        "sdk_json_pretty_print",
+        "sdk_cl_value_to_json",
+    ]
+}
+
+pub fn get_current_timestamp(timestamp: Option<String>) -> ToolOutput {
+    format::text_ok(helpers::get_current_timestamp(timestamp))
+}
+
+pub fn get_blake2b_hash(meta_data: String) -> ToolOutput {
+    format::text_ok(helpers::get_blake2b_hash(&meta_data))
+}
+
+pub fn make_dictionary_item_key(
+    key: String,
+    value_key: Option<String>,
+    value_u256: Option<String>,
+) -> ToolOutput {
+    let key = match Key::from_formatted_str(&key) {
+        Ok(k) => k,
+        Err(err) => return format::err(format!("invalid key: {err}")),
+    };
+    match (value_key, value_u256) {
+        (Some(vk), None) => match Key::from_formatted_str(&vk) {
+            Ok(value) => format::text_ok(helpers::make_dictionary_item_key(&key, &value)),
+            Err(err) => format::err(format!("invalid value_key: {err}")),
+        },
+        (None, Some(vu)) => match U256::from_str(&vu) {
+            Ok(value) => format::text_ok(helpers::make_dictionary_item_key(&key, &value)),
+            Err(err) => format::err(format!("invalid value_u256: {err}")),
+        },
+        _ => format::err("provide exactly one of value_key or value_u256"),
+    }
+}
+
+pub fn get_base64_key_from_account_hash(account_hash: String) -> ToolOutput {
+    match helpers::get_base64_key_from_account_hash(&account_hash) {
+        Ok(v) => format::text_ok(v),
+        Err(err) => format::err(err),
+    }
+}
+
+pub fn get_base64_key_from_key_hash(formatted_hash: String) -> ToolOutput {
+    match helpers::get_base64_key_from_key_hash(&formatted_hash) {
+        Ok(v) => format::text_ok(v),
+        Err(err) => format::err(err),
+    }
+}
+
+pub fn get_ttl_or_default(ttl: Option<String>) -> ToolOutput {
+    format::text_ok(helpers::get_ttl_or_default(ttl.as_deref()))
+}
+
+pub fn parse_timestamp(value: String) -> ToolOutput {
+    match helpers::parse_timestamp(&value) {
+        Ok(ts) => format::text_ok(ts.to_string()),
+        Err(err) => format::err(err),
+    }
+}
+
+pub fn parse_ttl(value: String) -> ToolOutput {
+    match helpers::parse_ttl(&value) {
+        Ok(ttl) => format::text_ok(ttl.to_string()),
+        Err(err) => format::err(err),
+    }
+}
+
+pub fn get_gas_price_or_default(gas_price: Option<u64>) -> ToolOutput {
+    format::json_ok(&serde_json::json!({
+        "gas_price": helpers::get_gas_price_or_default(gas_price)
+    }))
+}
+
+pub fn secret_key_generate() -> ToolOutput {
+    match helpers::secret_key_generate() {
+        Ok(sk) => match sk.to_pem() {
+            Ok(pem) => format::json_ok(&serde_json::json!({
+                "algorithm": "ed25519",
+                "secret_key_pem": pem,
+            })),
+            Err(err) => format::err(err),
+        },
+        Err(err) => format::err(err),
+    }
+}
+
+pub fn secret_key_secp256k1_generate() -> ToolOutput {
+    match helpers::secret_key_secp256k1_generate() {
+        Ok(sk) => match sk.to_pem() {
+            Ok(pem) => format::json_ok(&serde_json::json!({
+                "algorithm": "secp256k1",
+                "secret_key_pem": pem,
+            })),
+            Err(err) => format::err(err),
+        },
+        Err(err) => format::err(err),
+    }
+}
+
+pub fn secret_key_from_pem(secret_key: String) -> ToolOutput {
+    match helpers::secret_key_from_pem(&secret_key) {
+        Ok(sk) => format::json_ok(&serde_json::json!({
+            "ok": true,
+            "algorithm": format!("{sk:?}").split('(').next().unwrap_or("unknown"),
+        })),
+        Err(err) => format::err(err),
+    }
+}
+
+pub fn public_key_from_secret_key(secret_key: String) -> ToolOutput {
+    match helpers::public_key_from_secret_key(&secret_key) {
+        Ok(pk) => format::text_ok(pk),
+        Err(err) => format::err(err),
+    }
+}
+
+pub fn hex_to_uint8_vec(hex_string: String) -> ToolOutput {
+    let bytes = helpers::hex_to_uint8_vec(&hex_string);
+    format::json_ok(&serde_json::json!({ "bytes": bytes }))
+}
+
+pub fn hex_to_string(hex_string: String) -> ToolOutput {
+    format::text_ok(helpers::hex_to_string(&hex_string))
+}
+
+pub fn motes_to_cspr(motes: String) -> ToolOutput {
+    match helpers::motes_to_cspr(&motes) {
+        Ok(cspr) => format::json_ok(&serde_json::json!({ "motes": motes, "cspr": cspr })),
+        Err(err) => format::err(err),
+    }
+}
+
+pub fn json_pretty_print(value: String, verbosity: Option<String>) -> ToolOutput {
+    let parsed: serde_json::Value = match serde_json::from_str(&value) {
+        Ok(v) => v,
+        Err(err) => return format::err(format!("value must be JSON: {err}")),
+    };
+    let verbosity = sdk_handle::verbosity_override(verbosity.as_deref());
+    match helpers::json_pretty_print(parsed, verbosity) {
+        Ok(text) => format::text_ok(text),
+        Err(err) => format::err(err),
+    }
+}
+
+pub fn cl_value_to_json(cl_value_json: String) -> ToolOutput {
+    let cl_value: casper_types::CLValue = match serde_json::from_str(&cl_value_json) {
+        Ok(v) => v,
+        Err(err) => {
+            return format::err(format!(
+                "cl_value_json must deserialize as CLValue: {err}"
+            ))
+        }
+    };
+    match helpers::cl_value_to_json(&cl_value) {
+        Some(v) => format::json_ok(&v),
+        None => format::err("cl_value_to_json returned None"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn motes_to_cspr_basic() {
+        let out = motes_to_cspr("1000000000".into());
+        let _ = format!("{out:?}");
+    }
+
+    #[test]
+    fn blake2b_deterministic() {
+        let a = get_blake2b_hash("hello".into());
+        let b = get_blake2b_hash("hello".into());
+        let _ = (a, b);
+    }
+}

--- a/mcp/src/tools/helpers.rs
+++ b/mcp/src/tools/helpers.rs
@@ -1,0 +1,6 @@
+//! Placeholder: helper tools (Phase 3).
+
+#![allow(dead_code)]
+
+/// Marker so the `helpers` feature module compiles.
+pub const FEATURE: &str = "helpers";

--- a/mcp/src/tools/mod.rs
+++ b/mcp/src/tools/mod.rs
@@ -6,7 +6,7 @@ pub mod helpers;
 /// JSON-RPC domain (always compiled; enable via Cargo feature `rpc`).
 pub mod rpc;
 
-#[cfg(feature = "binary-port")]
+/// Binary-port domain (always compiled; enable via Cargo feature `binary-port`).
 pub mod binary_port;
 
 #[cfg(feature = "transaction")]
@@ -42,8 +42,6 @@ pub fn enabled_tool_groups() -> Vec<&'static str> {
 pub fn pending_tool_placeholders() -> Vec<&'static str> {
     #[allow(unused_mut)]
     let mut pending = Vec::new();
-    #[cfg(feature = "binary-port")]
-    pending.push("binary-port (Phase 4)");
     #[cfg(feature = "transaction")]
     pending.push("transaction (Phase 5)");
     #[cfg(feature = "deploy")]
@@ -62,6 +60,8 @@ pub fn registered_tool_names() -> Vec<&'static str> {
     names.extend_from_slice(helpers::tool_names());
     #[cfg(feature = "rpc")]
     names.extend_from_slice(rpc::tool_names());
+    #[cfg(feature = "binary-port")]
+    names.extend_from_slice(binary_port::tool_names());
     names
 }
 

--- a/mcp/src/tools/mod.rs
+++ b/mcp/src/tools/mod.rs
@@ -1,22 +1,13 @@
 //! Feature-gated tool modules.
 
-/// Helpers domain (always compiled; enable via Cargo feature `helpers`).
 pub mod helpers;
-
-/// JSON-RPC domain (always compiled; enable via Cargo feature `rpc`).
 pub mod rpc;
-
-/// Binary-port domain (always compiled; enable via Cargo feature `binary-port`).
 pub mod binary_port;
-
-#[cfg(feature = "transaction")]
+pub mod params;
 pub mod transaction;
-
-#[cfg(feature = "deploy")]
 pub mod deploy;
-
-#[cfg(feature = "contract")]
 pub mod contract;
+pub mod write;
 
 /// Human-readable list of tool groups enabled in this build.
 pub fn enabled_tool_groups() -> Vec<&'static str> {
@@ -38,19 +29,9 @@ pub fn enabled_tool_groups() -> Vec<&'static str> {
     groups
 }
 
-/// Placeholder summary for groups that are compiled but not yet wired as MCP tools.
+/// Placeholder summary for groups not yet wired (none after Phase 5).
 pub fn pending_tool_placeholders() -> Vec<&'static str> {
-    #[allow(unused_mut)]
-    let mut pending = Vec::new();
-    #[cfg(feature = "transaction")]
-    pending.push("transaction (Phase 5)");
-    #[cfg(feature = "deploy")]
-    pending.push("deploy (Phase 5)");
-    #[cfg(feature = "contract")]
-    pending.push("contract (Phase 5)");
-    #[cfg(feature = "write")]
-    pending.push("write (Phase 5)");
-    pending
+    Vec::new()
 }
 
 /// Flat list of registered tool names for the current feature set.
@@ -62,6 +43,14 @@ pub fn registered_tool_names() -> Vec<&'static str> {
     names.extend_from_slice(rpc::tool_names());
     #[cfg(feature = "binary-port")]
     names.extend_from_slice(binary_port::tool_names());
+    #[cfg(feature = "transaction")]
+    names.extend_from_slice(transaction::tool_names());
+    #[cfg(feature = "deploy")]
+    names.extend_from_slice(deploy::tool_names());
+    #[cfg(feature = "contract")]
+    names.extend_from_slice(contract::tool_names());
+    #[cfg(feature = "write")]
+    names.extend_from_slice(write::tool_names());
     names
 }
 

--- a/mcp/src/tools/mod.rs
+++ b/mcp/src/tools/mod.rs
@@ -1,9 +1,9 @@
-//! Feature-gated tool modules (bodies land in Phases 3–5).
+//! Feature-gated tool modules.
 
-#[cfg(feature = "helpers")]
+/// Helpers domain (always compiled; enable via Cargo feature `helpers`).
 pub mod helpers;
 
-#[cfg(feature = "rpc")]
+/// JSON-RPC domain (always compiled; enable via Cargo feature `rpc`).
 pub mod rpc;
 
 #[cfg(feature = "binary-port")]
@@ -40,11 +40,8 @@ pub fn enabled_tool_groups() -> Vec<&'static str> {
 
 /// Placeholder summary for groups that are compiled but not yet wired as MCP tools.
 pub fn pending_tool_placeholders() -> Vec<&'static str> {
+    #[allow(unused_mut)]
     let mut pending = Vec::new();
-    #[cfg(feature = "helpers")]
-    pending.push("helpers (Phase 3)");
-    #[cfg(feature = "rpc")]
-    pending.push("rpc (Phase 3)");
     #[cfg(feature = "binary-port")]
     pending.push("binary-port (Phase 4)");
     #[cfg(feature = "transaction")]
@@ -56,4 +53,21 @@ pub fn pending_tool_placeholders() -> Vec<&'static str> {
     #[cfg(feature = "write")]
     pending.push("write (Phase 5)");
     pending
+}
+
+/// Flat list of registered tool names for the current feature set.
+pub fn registered_tool_names() -> Vec<&'static str> {
+    let mut names = vec!["sdk_help", "sdk_get_endpoints", "sdk_set_endpoints"];
+    #[cfg(feature = "helpers")]
+    names.extend_from_slice(helpers::tool_names());
+    #[cfg(feature = "rpc")]
+    names.extend_from_slice(rpc::tool_names());
+    names
+}
+
+/// Error when a Cargo feature is disabled (mcpkit still lists the tool).
+pub fn feature_disabled(feature: &str) -> mcpkit::prelude::ToolOutput {
+    crate::format::err(format!(
+        "Cargo feature `{feature}` is disabled; rebuild with --features {feature} (or full)"
+    ))
 }

--- a/mcp/src/tools/mod.rs
+++ b/mcp/src/tools/mod.rs
@@ -1,0 +1,59 @@
+//! Feature-gated tool modules (bodies land in Phases 3–5).
+
+#[cfg(feature = "helpers")]
+pub mod helpers;
+
+#[cfg(feature = "rpc")]
+pub mod rpc;
+
+#[cfg(feature = "binary-port")]
+pub mod binary_port;
+
+#[cfg(feature = "transaction")]
+pub mod transaction;
+
+#[cfg(feature = "deploy")]
+pub mod deploy;
+
+#[cfg(feature = "contract")]
+pub mod contract;
+
+/// Human-readable list of tool groups enabled in this build.
+pub fn enabled_tool_groups() -> Vec<&'static str> {
+    let mut groups = vec!["meta"];
+    #[cfg(feature = "helpers")]
+    groups.push("helpers");
+    #[cfg(feature = "rpc")]
+    groups.push("rpc");
+    #[cfg(feature = "binary-port")]
+    groups.push("binary-port");
+    #[cfg(feature = "transaction")]
+    groups.push("transaction");
+    #[cfg(feature = "deploy")]
+    groups.push("deploy");
+    #[cfg(feature = "contract")]
+    groups.push("contract");
+    #[cfg(feature = "write")]
+    groups.push("write");
+    groups
+}
+
+/// Placeholder summary for groups that are compiled but not yet wired as MCP tools.
+pub fn pending_tool_placeholders() -> Vec<&'static str> {
+    let mut pending = Vec::new();
+    #[cfg(feature = "helpers")]
+    pending.push("helpers (Phase 3)");
+    #[cfg(feature = "rpc")]
+    pending.push("rpc (Phase 3)");
+    #[cfg(feature = "binary-port")]
+    pending.push("binary-port (Phase 4)");
+    #[cfg(feature = "transaction")]
+    pending.push("transaction (Phase 5)");
+    #[cfg(feature = "deploy")]
+    pending.push("deploy (Phase 5)");
+    #[cfg(feature = "contract")]
+    pending.push("contract (Phase 5)");
+    #[cfg(feature = "write")]
+    pending.push("write (Phase 5)");
+    pending
+}

--- a/mcp/src/tools/mod.rs
+++ b/mcp/src/tools/mod.rs
@@ -1,12 +1,12 @@
 //! Feature-gated tool modules.
 
-pub mod helpers;
-pub mod rpc;
 pub mod binary_port;
-pub mod params;
-pub mod transaction;
-pub mod deploy;
 pub mod contract;
+pub mod deploy;
+pub mod helpers;
+pub mod params;
+pub mod rpc;
+pub mod transaction;
 pub mod write;
 
 /// Human-readable list of tool groups enabled in this build.

--- a/mcp/src/tools/params.rs
+++ b/mcp/src/tools/params.rs
@@ -1,0 +1,439 @@
+//! JSON → SDK *StrParams / TransactionBuilderParams parsers for MCP tools.
+
+use casper_rust_wasm_sdk::helpers;
+use casper_rust_wasm_sdk::types::cl::bytes::Bytes;
+use casper_rust_wasm_sdk::types::deploy_params::deploy_str_params::DeployStrParams;
+use casper_rust_wasm_sdk::types::deploy_params::payment_str_params::PaymentStrParams;
+use casper_rust_wasm_sdk::types::deploy_params::session_str_params::SessionStrParams;
+use casper_rust_wasm_sdk::types::hash::account_hash::AccountHash;
+use casper_rust_wasm_sdk::types::hash::addressable_entity_hash::AddressableEntityHash;
+use casper_rust_wasm_sdk::types::hash::package_hash::PackageHash;
+use casper_rust_wasm_sdk::types::pricing_mode::PricingMode;
+use casper_rust_wasm_sdk::types::public_key::PublicKey;
+use casper_rust_wasm_sdk::types::transaction_params::transaction_builder_params::{
+    TransactionBuilderParams, TransferTarget, TransferTargetKind,
+};
+use casper_rust_wasm_sdk::types::transaction_params::transaction_str_params::TransactionStrParams;
+use casper_rust_wasm_sdk::types::uref::URef;
+use serde_json::Value;
+
+fn req_str(obj: &Value, key: &str) -> Result<String, String> {
+    obj.get(key)
+        .and_then(|v| v.as_str())
+        .map(str::to_string)
+        .ok_or_else(|| format!("missing or non-string field `{key}`"))
+}
+
+fn opt_str(obj: &Value, key: &str) -> Option<String> {
+    obj.get(key).and_then(|v| v.as_str()).map(str::to_string)
+}
+
+fn opt_bool(obj: &Value, key: &str) -> Option<bool> {
+    obj.get(key).and_then(|v| v.as_bool())
+}
+
+fn opt_u64(obj: &Value, key: &str) -> Option<u64> {
+    obj.get(key).and_then(|v| {
+        v.as_u64()
+            .or_else(|| v.as_str().and_then(|s| s.parse().ok()))
+    })
+}
+
+fn opt_string_vec(obj: &Value, key: &str) -> Option<Vec<String>> {
+    obj.get(key).and_then(|v| {
+        if let Some(arr) = v.as_array() {
+            Some(
+                arr.iter()
+                    .filter_map(|x| x.as_str().map(str::to_string))
+                    .collect(),
+            )
+        } else {
+            None
+        }
+    })
+}
+
+fn parse_pricing_mode(raw: &str) -> Result<PricingMode, String> {
+    match raw.trim().to_lowercase().as_str() {
+        "fixed" => Ok(PricingMode::Fixed),
+        "classic" => Ok(PricingMode::Classic),
+        "reserved" => Ok(PricingMode::Reserved),
+        other => Err(format!(
+            "invalid pricing_mode `{other}` (fixed|classic|reserved)"
+        )),
+    }
+}
+
+fn bytes_from_hex(hex: &str) -> Result<Bytes, String> {
+    let bytes = helpers::hex_to_uint8_vec(hex);
+    if bytes.is_empty() && !hex.is_empty() {
+        return Err("invalid hex for bytes".into());
+    }
+    Ok(Bytes::from(bytes))
+}
+
+/// Parse `TransactionStrParams` from a JSON object string.
+pub fn parse_transaction_str_params(json: &str) -> Result<TransactionStrParams, String> {
+    let obj: Value = serde_json::from_str(json).map_err(|e| format!("transaction_params JSON: {e}"))?;
+    let obj = obj
+        .as_object()
+        .ok_or_else(|| "transaction_params must be a JSON object".to_string())?;
+    let obj = Value::Object(obj.clone());
+
+    let chain_name = req_str(&obj, "chain_name")?;
+    let mut params = TransactionStrParams::default();
+    params.set_chain_name(&chain_name);
+
+    if let Some(v) = opt_str(&obj, "initiator_addr") {
+        params.set_initiator_addr(&v);
+    }
+    if let Some(v) = opt_str(&obj, "secret_key") {
+        params.set_secret_key(&v);
+    }
+    if obj.get("timestamp").is_some() {
+        params.set_timestamp(opt_str(&obj, "timestamp"));
+    }
+    if obj.get("ttl").is_some() {
+        params.set_ttl(opt_str(&obj, "ttl"));
+    }
+    if let Some(args) = opt_string_vec(&obj, "session_args_simple") {
+        params.set_session_args_simple(args);
+    }
+    if let Some(v) = opt_str(&obj, "session_args_json") {
+        params.set_session_args_json(&v);
+    }
+    if let Some(v) = opt_str(&obj, "pricing_mode") {
+        params.set_pricing_mode(parse_pricing_mode(&v)?);
+    }
+    if let Some(v) = opt_str(&obj, "additional_computation_factor") {
+        params.set_additional_computation_factor(&v);
+    }
+    if let Some(v) = opt_str(&obj, "payment_amount") {
+        params.set_payment_amount(&v);
+    }
+    if let Some(v) = opt_str(&obj, "gas_price_tolerance") {
+        params.set_gas_price_tolerance(&v);
+    }
+    if let Some(v) = opt_str(&obj, "receipt") {
+        params.set_receipt(&v);
+    }
+    if let Some(v) = opt_bool(&obj, "standard_payment") {
+        params.set_standard_payment(v);
+    }
+    if let Some(v) = opt_str(&obj, "transferred_value") {
+        params.set_transferred_value(&v);
+    }
+    if let Some(v) = opt_str(&obj, "session_entry_point") {
+        params.set_session_entry_point(&v);
+    }
+    if let Some(v) = opt_str(&obj, "chunked_args_hex") {
+        params.set_chunked_args(bytes_from_hex(&v)?);
+    }
+    if let Some(v) = opt_bool(&obj, "min_bid_override") {
+        params.set_min_bid_override(v);
+    }
+    Ok(params)
+}
+
+fn parse_uref(s: &str) -> Result<URef, String> {
+    URef::from_formatted_str(s).map_err(|e| e.to_string())
+}
+
+fn parse_pubkey(s: &str) -> Result<PublicKey, String> {
+    PublicKey::new(s).map_err(|e| e.to_string())
+}
+
+fn parse_transfer_target(obj: &Value) -> Result<TransferTarget, String> {
+    let kind_raw = req_str(obj, "kind")?;
+    match kind_raw.to_lowercase().as_str() {
+        "publickey" | "public_key" => {
+            let pk = parse_pubkey(&req_str(obj, "public_key")?)?;
+            Ok(TransferTarget::new(
+                TransferTargetKind::PublicKey,
+                Some(pk),
+                None,
+                None,
+            ))
+        }
+        "accounthash" | "account_hash" => {
+            let ah = AccountHash::from_formatted_str(&req_str(obj, "account_hash")?)
+                .map_err(|e| e.to_string())?;
+            Ok(TransferTarget::new(
+                TransferTargetKind::AccountHash,
+                None,
+                Some(ah),
+                None,
+            ))
+        }
+        "uref" => {
+            let uref = parse_uref(&req_str(obj, "uref")?)?;
+            Ok(TransferTarget::new(
+                TransferTargetKind::URef,
+                None,
+                None,
+                Some(uref),
+            ))
+        }
+        other => Err(format!(
+            "unknown transfer target kind `{other}` (PublicKey|AccountHash|URef)"
+        )),
+    }
+}
+
+/// Parse `TransactionBuilderParams` from JSON (`kind` discriminant).
+pub fn parse_transaction_builder_params(json: &str) -> Result<TransactionBuilderParams, String> {
+    let obj: Value =
+        serde_json::from_str(json).map_err(|e| format!("builder_params JSON: {e}"))?;
+    let kind = req_str(&obj, "kind")?;
+    match kind.to_lowercase().as_str() {
+        "session" => {
+            let bytes = match opt_str(&obj, "transaction_bytes_hex") {
+                Some(h) => Some(bytes_from_hex(&h)?),
+                None => None,
+            };
+            Ok(TransactionBuilderParams::new_session(
+                bytes,
+                opt_bool(&obj, "is_install_upgrade"),
+            ))
+        }
+        "transfer" => {
+            let target = obj
+                .get("target")
+                .ok_or_else(|| "transfer requires `target` object".to_string())?;
+            let target = parse_transfer_target(target)?;
+            let amount = req_str(&obj, "amount")?;
+            let source = match opt_str(&obj, "source") {
+                Some(s) => Some(parse_uref(&s)?),
+                None => None,
+            };
+            Ok(TransactionBuilderParams::new_transfer(
+                source,
+                target,
+                &amount,
+                opt_u64(&obj, "maybe_id"),
+            ))
+        }
+        "invocableentity" | "invocable_entity" => {
+            let raw = req_str(&obj, "entity_hash")?;
+            let entity = AddressableEntityHash::from_formatted_str(&raw)
+                .or_else(|_| AddressableEntityHash::new(&raw))
+                .map_err(|e| e.to_string())?;
+            let entry = req_str(&obj, "entry_point")?;
+            Ok(TransactionBuilderParams::new_invocable_entity(
+                entity, &entry,
+            ))
+        }
+        "invocableentityalias" | "invocable_entity_alias" => {
+            let alias = req_str(&obj, "entity_alias")?;
+            let entry = req_str(&obj, "entry_point")?;
+            Ok(TransactionBuilderParams::new_invocable_entity_alias(
+                &alias, &entry,
+            ))
+        }
+        "package" => {
+            let raw = req_str(&obj, "package_hash")?;
+            let hash = PackageHash::from_formatted_str(&raw)
+                .or_else(|_| PackageHash::new(&raw))
+                .map_err(|e| e.to_string())?;
+            let entry = req_str(&obj, "entry_point")?;
+            let version = opt_str(&obj, "maybe_entity_version");
+            Ok(TransactionBuilderParams::new_package(
+                hash,
+                &entry,
+                version,
+            ))
+        }
+        "packagealias" | "package_alias" => {
+            let alias = req_str(&obj, "package_alias")?;
+            let entry = req_str(&obj, "entry_point")?;
+            let version = opt_str(&obj, "maybe_entity_version");
+            Ok(TransactionBuilderParams::new_package_alias(
+                &alias, &entry, version,
+            ))
+        }
+        "addbid" | "add_bid" => {
+            let pk = parse_pubkey(&req_str(&obj, "public_key")?)?;
+            let amount = req_str(&obj, "amount")?;
+            let rate = obj
+                .get("delegation_rate")
+                .and_then(|v| v.as_u64())
+                .ok_or_else(|| "add_bid requires delegation_rate".to_string())?
+                as u8;
+            Ok(TransactionBuilderParams::new_add_bid(
+                pk,
+                rate,
+                &amount,
+                opt_u64(&obj, "minimum_delegation_amount"),
+                opt_u64(&obj, "maximum_delegation_amount"),
+                obj.get("reserved_slots")
+                    .and_then(|v| v.as_u64())
+                    .map(|v| v as u32),
+            ))
+        }
+        "delegate" => {
+            let delegator = parse_pubkey(&req_str(&obj, "delegator")?)?;
+            let validator = parse_pubkey(&req_str(&obj, "validator")?)?;
+            let amount = req_str(&obj, "amount")?;
+            Ok(TransactionBuilderParams::new_delegate(
+                delegator, validator, &amount,
+            ))
+        }
+        "undelegate" => {
+            let delegator = parse_pubkey(&req_str(&obj, "delegator")?)?;
+            let validator = parse_pubkey(&req_str(&obj, "validator")?)?;
+            let amount = req_str(&obj, "amount")?;
+            Ok(TransactionBuilderParams::new_undelegate(
+                delegator, validator, &amount,
+            ))
+        }
+        "redelegate" => {
+            let delegator = parse_pubkey(&req_str(&obj, "delegator")?)?;
+            let validator = parse_pubkey(&req_str(&obj, "validator")?)?;
+            let new_validator = parse_pubkey(&req_str(&obj, "new_validator")?)?;
+            let amount = req_str(&obj, "amount")?;
+            Ok(TransactionBuilderParams::new_redelegate(
+                delegator,
+                validator,
+                new_validator,
+                &amount,
+            ))
+        }
+        "withdrawbid" | "withdraw_bid" => {
+            let pk = parse_pubkey(&req_str(&obj, "public_key")?)?;
+            let amount = req_str(&obj, "amount")?;
+            Ok(TransactionBuilderParams::new_withdraw_bid(pk, &amount))
+        }
+        other => Err(format!(
+            "unknown builder kind `{other}` (Session|Transfer|InvocableEntity|…)"
+        )),
+    }
+}
+
+/// Parse `DeployStrParams` from JSON.
+pub fn parse_deploy_str_params(json: &str) -> Result<DeployStrParams, String> {
+    let obj: Value = serde_json::from_str(json).map_err(|e| format!("deploy_params JSON: {e}"))?;
+    let chain_name = req_str(&obj, "chain_name")?;
+    let session_account = req_str(&obj, "session_account")?;
+    Ok(DeployStrParams::new(
+        &chain_name,
+        &session_account,
+        opt_str(&obj, "secret_key"),
+        opt_str(&obj, "timestamp"),
+        opt_str(&obj, "ttl"),
+        opt_str(&obj, "gas_price_tolerance"),
+    ))
+}
+
+/// Parse `SessionStrParams` from JSON.
+pub fn parse_session_str_params(json: &str) -> Result<SessionStrParams, String> {
+    let obj: Value = serde_json::from_str(json).map_err(|e| format!("session_params JSON: {e}"))?;
+    let mut params = SessionStrParams::default();
+    if let Some(v) = opt_str(&obj, "session_hash") {
+        params.set_session_hash(&v);
+    }
+    if let Some(v) = opt_str(&obj, "session_name") {
+        params.set_session_name(&v);
+    }
+    if let Some(v) = opt_str(&obj, "session_package_hash") {
+        params.set_session_package_hash(&v);
+    }
+    if let Some(v) = opt_str(&obj, "session_package_name") {
+        params.set_session_package_name(&v);
+    }
+    if let Some(v) = opt_str(&obj, "session_path") {
+        params.set_session_path(&v);
+    }
+    if let Some(v) = opt_str(&obj, "session_bytes_hex") {
+        params.set_session_bytes(bytes_from_hex(&v)?);
+    }
+    if let Some(args) = opt_string_vec(&obj, "session_args_simple") {
+        params.set_session_args(args);
+    }
+    if let Some(v) = opt_str(&obj, "session_args_json") {
+        params.set_session_args_json(&v);
+    }
+    if let Some(v) = opt_str(&obj, "session_version") {
+        params.set_session_version(&v);
+    }
+    if let Some(v) = opt_str(&obj, "session_entry_point") {
+        params.set_session_entry_point(&v);
+    }
+    if let Some(v) = opt_bool(&obj, "is_session_transfer") {
+        params.set_is_session_transfer(v);
+    }
+    Ok(params)
+}
+
+/// Parse `PaymentStrParams` from JSON (prefer `payment_amount` / `payment_args_json`).
+pub fn parse_payment_str_params(json: &str) -> Result<PaymentStrParams, String> {
+    let obj: Value = serde_json::from_str(json).map_err(|e| format!("payment_params JSON: {e}"))?;
+    let params = PaymentStrParams::default();
+    if let Some(v) = opt_str(&obj, "payment_amount") {
+        params.set_payment_amount(&v);
+    }
+    if let Some(v) = opt_str(&obj, "payment_hash") {
+        params.set_payment_hash(&v);
+    }
+    if let Some(v) = opt_str(&obj, "payment_name") {
+        params.set_payment_name(&v);
+    }
+    if let Some(v) = opt_str(&obj, "payment_package_hash") {
+        params.set_payment_package_hash(&v);
+    }
+    if let Some(v) = opt_str(&obj, "payment_package_name") {
+        params.set_payment_package_name(&v);
+    }
+    if let Some(v) = opt_str(&obj, "payment_path") {
+        params.set_payment_path(&v);
+    }
+    if let Some(v) = opt_str(&obj, "payment_args_json") {
+        params.set_payment_args_json(&v);
+    }
+    if let Some(v) = opt_str(&obj, "payment_version") {
+        params.set_payment_version(&v);
+    }
+    if let Some(v) = opt_str(&obj, "payment_entry_point") {
+        params.set_payment_entry_point(&v);
+    }
+    Ok(params)
+}
+
+pub fn parse_optional_uref(raw: Option<&str>) -> Result<Option<URef>, String> {
+    match raw {
+        None => Ok(None),
+        Some(s) if s.is_empty() => Ok(None),
+        Some(s) => Ok(Some(parse_uref(s)?)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_tx_str_params_minimal() {
+        let p = parse_transaction_str_params(
+            r#"{"chain_name":"casper-net-1","initiator_addr":"01aa"}"#,
+        )
+        .unwrap();
+        assert!(p.chain_name().is_some());
+    }
+
+    #[test]
+    fn parse_session_builder() {
+        let b = parse_transaction_builder_params(
+            r#"{"kind":"Session","is_install_upgrade":false}"#,
+        )
+        .unwrap();
+        let _ = b;
+    }
+
+    #[test]
+    fn parse_deploy_params() {
+        let d = parse_deploy_str_params(
+            r#"{"chain_name":"casper-net-1","session_account":"01aa"}"#,
+        )
+        .unwrap();
+        let _ = d;
+    }
+}

--- a/mcp/src/tools/params.rs
+++ b/mcp/src/tools/params.rs
@@ -74,7 +74,8 @@ fn bytes_from_hex(hex: &str) -> Result<Bytes, String> {
 
 /// Parse `TransactionStrParams` from a JSON object string.
 pub fn parse_transaction_str_params(json: &str) -> Result<TransactionStrParams, String> {
-    let obj: Value = serde_json::from_str(json).map_err(|e| format!("transaction_params JSON: {e}"))?;
+    let obj: Value =
+        serde_json::from_str(json).map_err(|e| format!("transaction_params JSON: {e}"))?;
     let obj = obj
         .as_object()
         .ok_or_else(|| "transaction_params must be a JSON object".to_string())?;
@@ -182,8 +183,7 @@ fn parse_transfer_target(obj: &Value) -> Result<TransferTarget, String> {
 
 /// Parse `TransactionBuilderParams` from JSON (`kind` discriminant).
 pub fn parse_transaction_builder_params(json: &str) -> Result<TransactionBuilderParams, String> {
-    let obj: Value =
-        serde_json::from_str(json).map_err(|e| format!("builder_params JSON: {e}"))?;
+    let obj: Value = serde_json::from_str(json).map_err(|e| format!("builder_params JSON: {e}"))?;
     let kind = req_str(&obj, "kind")?;
     match kind.to_lowercase().as_str() {
         "session" => {
@@ -237,11 +237,7 @@ pub fn parse_transaction_builder_params(json: &str) -> Result<TransactionBuilder
                 .map_err(|e| e.to_string())?;
             let entry = req_str(&obj, "entry_point")?;
             let version = opt_str(&obj, "maybe_entity_version");
-            Ok(TransactionBuilderParams::new_package(
-                hash,
-                &entry,
-                version,
-            ))
+            Ok(TransactionBuilderParams::new_package(hash, &entry, version))
         }
         "packagealias" | "package_alias" => {
             let alias = req_str(&obj, "package_alias")?;
@@ -421,19 +417,17 @@ mod tests {
 
     #[test]
     fn parse_session_builder() {
-        let b = parse_transaction_builder_params(
-            r#"{"kind":"Session","is_install_upgrade":false}"#,
-        )
-        .unwrap();
+        let b =
+            parse_transaction_builder_params(r#"{"kind":"Session","is_install_upgrade":false}"#)
+                .unwrap();
         let _ = b;
     }
 
     #[test]
     fn parse_deploy_params() {
-        let d = parse_deploy_str_params(
-            r#"{"chain_name":"casper-net-1","session_account":"01aa"}"#,
-        )
-        .unwrap();
+        let d =
+            parse_deploy_str_params(r#"{"chain_name":"casper-net-1","session_account":"01aa"}"#)
+                .unwrap();
         let _ = d;
     }
 }

--- a/mcp/src/tools/rpc.rs
+++ b/mcp/src/tools/rpc.rs
@@ -1,6 +1,480 @@
-//! Placeholder: JSON-RPC tools (Phase 3).
+//! JSON-RPC tools domain logic (feature `rpc`).
 
-#![allow(dead_code)]
+#![allow(deprecated)]
 
-/// Marker so the `rpc` feature module compiles.
-pub const FEATURE: &str = "rpc";
+use casper_rust_wasm_sdk::rpcs::get_balance::GetBalanceInput;
+use casper_rust_wasm_sdk::rpcs::get_dictionary_item::DictionaryItemInput;
+use casper_rust_wasm_sdk::rpcs::query_global_state::{
+    KeyIdentifierInput, PathIdentifierInput, QueryGlobalStateParams,
+};
+use casper_rust_wasm_sdk::types::deploy::Deploy;
+use casper_rust_wasm_sdk::types::deploy_params::dictionary_item_str_params::DictionaryItemStrParams;
+use casper_rust_wasm_sdk::types::hash::deploy_hash::DeployHash;
+use casper_rust_wasm_sdk::types::hash::transaction_hash::TransactionHash;
+use casper_rust_wasm_sdk::types::identifier::block_identifier::BlockIdentifierInput;
+use casper_rust_wasm_sdk::types::transaction::Transaction;
+use mcpkit::prelude::ToolOutput;
+
+use crate::format;
+use crate::sdk_handle;
+
+/// Registered RPC tool names for help text.
+pub fn tool_names() -> &'static [&'static str] {
+    &[
+        "sdk_get_account",
+        "sdk_get_auction_info",
+        "sdk_get_balance",
+        "sdk_get_block",
+        "sdk_get_block_transfers",
+        "sdk_get_chainspec",
+        "sdk_get_deploy",
+        "sdk_get_dictionary_item",
+        "sdk_get_entity",
+        "sdk_get_era_info",
+        "sdk_get_era_summary",
+        "sdk_get_node_status",
+        "sdk_get_peers",
+        "sdk_get_state_root_hash",
+        "sdk_get_transaction",
+        "sdk_get_validator_changes",
+        "sdk_list_rpcs",
+        "sdk_query_balance",
+        "sdk_query_balance_details",
+        "sdk_query_global_state",
+        "sdk_speculative_exec",
+        "sdk_speculative_exec_deploy",
+    ]
+}
+
+fn block_id(maybe: Option<String>) -> Option<BlockIdentifierInput> {
+    maybe.map(BlockIdentifierInput::String)
+}
+
+fn verb(verbosity: Option<&str>) -> Option<casper_rust_wasm_sdk::types::verbosity::Verbosity> {
+    sdk_handle::verbosity_override(verbosity)
+}
+
+macro_rules! rpc_ok {
+    ($expr:expr) => {
+        match $expr {
+            Ok(resp) => format::serialize_ok(&resp.result),
+            Err(err) => format::err(err),
+        }
+    };
+}
+
+pub async fn get_node_status(
+    verbosity: Option<String>,
+    rpc_address: Option<String>,
+) -> ToolOutput {
+    let sdk = sdk_handle::sdk_snapshot();
+    rpc_ok!(
+        sdk.get_node_status(verb(verbosity.as_deref()), rpc_address)
+            .await
+    )
+}
+
+pub async fn get_peers(verbosity: Option<String>, rpc_address: Option<String>) -> ToolOutput {
+    let sdk = sdk_handle::sdk_snapshot();
+    rpc_ok!(sdk.get_peers(verb(verbosity.as_deref()), rpc_address).await)
+}
+
+pub async fn get_chainspec(verbosity: Option<String>, rpc_address: Option<String>) -> ToolOutput {
+    let sdk = sdk_handle::sdk_snapshot();
+    rpc_ok!(
+        sdk.get_chainspec(verb(verbosity.as_deref()), rpc_address)
+            .await
+    )
+}
+
+pub async fn get_validator_changes(
+    verbosity: Option<String>,
+    rpc_address: Option<String>,
+) -> ToolOutput {
+    let sdk = sdk_handle::sdk_snapshot();
+    rpc_ok!(
+        sdk.get_validator_changes(verb(verbosity.as_deref()), rpc_address)
+            .await
+    )
+}
+
+pub async fn list_rpcs(verbosity: Option<String>, rpc_address: Option<String>) -> ToolOutput {
+    let sdk = sdk_handle::sdk_snapshot();
+    rpc_ok!(sdk.list_rpcs(verb(verbosity.as_deref()), rpc_address).await)
+}
+
+pub async fn get_block(
+    maybe_block_identifier: Option<String>,
+    verbosity: Option<String>,
+    rpc_address: Option<String>,
+) -> ToolOutput {
+    let sdk = sdk_handle::sdk_snapshot();
+    rpc_ok!(
+        sdk.get_block(
+            block_id(maybe_block_identifier),
+            verb(verbosity.as_deref()),
+            rpc_address
+        )
+        .await
+    )
+}
+
+pub async fn get_block_transfers(
+    maybe_block_identifier: Option<String>,
+    verbosity: Option<String>,
+    rpc_address: Option<String>,
+) -> ToolOutput {
+    let sdk = sdk_handle::sdk_snapshot();
+    rpc_ok!(
+        sdk.get_block_transfers(
+            block_id(maybe_block_identifier),
+            verb(verbosity.as_deref()),
+            rpc_address
+        )
+        .await
+    )
+}
+
+pub async fn get_auction_info(
+    maybe_block_identifier: Option<String>,
+    verbosity: Option<String>,
+    rpc_address: Option<String>,
+) -> ToolOutput {
+    let sdk = sdk_handle::sdk_snapshot();
+    rpc_ok!(
+        sdk.get_auction_info(
+            block_id(maybe_block_identifier),
+            verb(verbosity.as_deref()),
+            rpc_address
+        )
+        .await
+    )
+}
+
+pub async fn get_era_summary(
+    maybe_block_identifier: Option<String>,
+    verbosity: Option<String>,
+    rpc_address: Option<String>,
+) -> ToolOutput {
+    let sdk = sdk_handle::sdk_snapshot();
+    rpc_ok!(
+        sdk.get_era_summary(
+            block_id(maybe_block_identifier),
+            verb(verbosity.as_deref()),
+            rpc_address
+        )
+        .await
+    )
+}
+
+pub async fn get_era_info(
+    maybe_block_identifier: Option<String>,
+    verbosity: Option<String>,
+    rpc_address: Option<String>,
+) -> ToolOutput {
+    let sdk = sdk_handle::sdk_snapshot();
+    rpc_ok!(
+        sdk.get_era_info(
+            block_id(maybe_block_identifier),
+            verb(verbosity.as_deref()),
+            rpc_address
+        )
+        .await
+    )
+}
+
+pub async fn get_state_root_hash(
+    maybe_block_identifier: Option<String>,
+    verbosity: Option<String>,
+    rpc_address: Option<String>,
+) -> ToolOutput {
+    let sdk = sdk_handle::sdk_snapshot();
+    rpc_ok!(
+        sdk.get_state_root_hash(
+            block_id(maybe_block_identifier),
+            verb(verbosity.as_deref()),
+            rpc_address
+        )
+        .await
+    )
+}
+
+pub async fn get_account(
+    account_identifier: Option<String>,
+    maybe_block_identifier: Option<String>,
+    verbosity: Option<String>,
+    rpc_address: Option<String>,
+) -> ToolOutput {
+    let sdk = sdk_handle::sdk_snapshot();
+    rpc_ok!(
+        sdk.get_account(
+            None,
+            account_identifier,
+            block_id(maybe_block_identifier),
+            verb(verbosity.as_deref()),
+            rpc_address
+        )
+        .await
+    )
+}
+
+pub async fn get_entity(
+    entity_identifier: Option<String>,
+    maybe_block_identifier: Option<String>,
+    verbosity: Option<String>,
+    rpc_address: Option<String>,
+) -> ToolOutput {
+    let sdk = sdk_handle::sdk_snapshot();
+    rpc_ok!(
+        sdk.get_entity(
+            None,
+            entity_identifier,
+            block_id(maybe_block_identifier),
+            verb(verbosity.as_deref()),
+            rpc_address
+        )
+        .await
+    )
+}
+
+pub async fn get_deploy(
+    deploy_hash: String,
+    finalized_approvals: Option<bool>,
+    verbosity: Option<String>,
+    rpc_address: Option<String>,
+) -> ToolOutput {
+    let hash = match DeployHash::new(&deploy_hash) {
+        Ok(h) => h,
+        Err(err) => return format::err(err),
+    };
+    let sdk = sdk_handle::sdk_snapshot();
+    rpc_ok!(
+        sdk.get_deploy(
+            hash,
+            finalized_approvals,
+            verb(verbosity.as_deref()),
+            rpc_address
+        )
+        .await
+    )
+}
+
+pub async fn get_transaction(
+    transaction_hash: String,
+    finalized_approvals: Option<bool>,
+    verbosity: Option<String>,
+    rpc_address: Option<String>,
+) -> ToolOutput {
+    let hash = match TransactionHash::new(&transaction_hash) {
+        Ok(h) => h,
+        Err(err) => return format::err(err),
+    };
+    let sdk = sdk_handle::sdk_snapshot();
+    rpc_ok!(
+        sdk.get_transaction(
+            hash,
+            finalized_approvals,
+            verb(verbosity.as_deref()),
+            rpc_address
+        )
+        .await
+    )
+}
+
+pub async fn get_balance(
+    purse_uref: String,
+    state_root_hash: Option<String>,
+    verbosity: Option<String>,
+    rpc_address: Option<String>,
+) -> ToolOutput {
+    let sdk = sdk_handle::sdk_snapshot();
+    rpc_ok!(
+        sdk.get_balance(
+            GetBalanceInput::PurseUrefAsString(purse_uref),
+            state_root_hash.as_deref(),
+            verb(verbosity.as_deref()),
+            rpc_address
+        )
+        .await
+    )
+}
+
+pub async fn query_balance(
+    purse_identifier: String,
+    state_root_hash: Option<String>,
+    maybe_block_id: Option<String>,
+    verbosity: Option<String>,
+    rpc_address: Option<String>,
+) -> ToolOutput {
+    let sdk = sdk_handle::sdk_snapshot();
+    rpc_ok!(
+        sdk.query_balance(
+            None,
+            Some(purse_identifier),
+            None,
+            state_root_hash,
+            maybe_block_id,
+            verb(verbosity.as_deref()),
+            rpc_address
+        )
+        .await
+    )
+}
+
+pub async fn query_balance_details(
+    purse_identifier: String,
+    state_root_hash: Option<String>,
+    maybe_block_id: Option<String>,
+    verbosity: Option<String>,
+    rpc_address: Option<String>,
+) -> ToolOutput {
+    let sdk = sdk_handle::sdk_snapshot();
+    rpc_ok!(
+        sdk.query_balance_details(
+            None,
+            Some(purse_identifier),
+            None,
+            state_root_hash,
+            maybe_block_id,
+            verb(verbosity.as_deref()),
+            rpc_address
+        )
+        .await
+    )
+}
+
+pub async fn get_dictionary_item(
+    kind: String,
+    key: Option<String>,
+    dictionary_name: Option<String>,
+    dictionary_item_key: Option<String>,
+    seed_uref: Option<String>,
+    dictionary_value: Option<String>,
+    state_root_hash: Option<String>,
+    verbosity: Option<String>,
+    rpc_address: Option<String>,
+) -> ToolOutput {
+    let mut params = DictionaryItemStrParams::new();
+    match kind.as_str() {
+        "uref" => {
+            let seed = match seed_uref {
+                Some(s) => s,
+                None => return format::err("kind=uref requires seed_uref"),
+            };
+            let item_key = match dictionary_item_key {
+                Some(s) => s,
+                None => return format::err("kind=uref requires dictionary_item_key"),
+            };
+            params.set_uref(&seed, &item_key);
+        }
+        "dictionary" => {
+            let value = match dictionary_value {
+                Some(s) => s,
+                None => return format::err("kind=dictionary requires dictionary_value"),
+            };
+            params.set_dictionary(&value);
+        }
+        "account_named_key" => {
+            let (k, dn, dik) = match (key, dictionary_name, dictionary_item_key) {
+                (Some(k), Some(dn), Some(dik)) => (k, dn, dik),
+                _ => {
+                    return format::err(
+                        "kind=account_named_key requires key, dictionary_name, dictionary_item_key",
+                    )
+                }
+            };
+            params.set_account_named_key(&k, &dn, &dik);
+        }
+        "contract_named_key" => {
+            let (k, dn, dik) = match (key, dictionary_name, dictionary_item_key) {
+                (Some(k), Some(dn), Some(dik)) => (k, dn, dik),
+                _ => {
+                    return format::err(
+                        "kind=contract_named_key requires key, dictionary_name, dictionary_item_key",
+                    )
+                }
+            };
+            params.set_contract_named_key(&k, &dn, &dik);
+        }
+        "entity_named_key" => {
+            let (k, dn, dik) = match (key, dictionary_name, dictionary_item_key) {
+                (Some(k), Some(dn), Some(dik)) => (k, dn, dik),
+                _ => {
+                    return format::err(
+                        "kind=entity_named_key requires key, dictionary_name, dictionary_item_key",
+                    )
+                }
+            };
+            params.set_entity_named_key(&k, &dn, &dik);
+        }
+        other => {
+            return format::err(format!(
+                "unknown kind '{other}' (uref|dictionary|account_named_key|contract_named_key|entity_named_key)"
+            ))
+        }
+    }
+
+    let sdk = sdk_handle::sdk_snapshot();
+    rpc_ok!(
+        sdk.get_dictionary_item(
+            DictionaryItemInput::Params(Box::new(params)),
+            state_root_hash.as_deref(),
+            verb(verbosity.as_deref()),
+            rpc_address
+        )
+        .await
+    )
+}
+
+pub async fn query_global_state(
+    key: String,
+    path: Option<String>,
+    state_root_hash: Option<String>,
+    maybe_block_id: Option<String>,
+    verbosity: Option<String>,
+    rpc_address: Option<String>,
+) -> ToolOutput {
+    let sdk = sdk_handle::sdk_snapshot();
+    let params = QueryGlobalStateParams {
+        key: KeyIdentifierInput::String(key),
+        path: path.map(PathIdentifierInput::String),
+        maybe_global_state_identifier: None,
+        state_root_hash,
+        maybe_block_id,
+        rpc_address,
+        verbosity: verb(verbosity.as_deref()),
+    };
+    rpc_ok!(sdk.query_global_state(params).await)
+}
+
+pub async fn speculative_exec(
+    transaction_json: String,
+    verbosity: Option<String>,
+    rpc_address: Option<String>,
+) -> ToolOutput {
+    let transaction = match Transaction::from_json_string(&transaction_json) {
+        Ok(t) => t,
+        Err(err) => return format::err(err),
+    };
+    let sdk = sdk_handle::sdk_snapshot();
+    rpc_ok!(
+        sdk.speculative_exec(transaction, verb(verbosity.as_deref()), rpc_address)
+            .await
+    )
+}
+
+pub async fn speculative_exec_deploy(
+    deploy_json: String,
+    verbosity: Option<String>,
+    rpc_address: Option<String>,
+) -> ToolOutput {
+    let deploy = match Deploy::from_json_string(&deploy_json) {
+        Ok(d) => d,
+        Err(err) => return format::err(err),
+    };
+    let sdk = sdk_handle::sdk_snapshot();
+    rpc_ok!(
+        sdk.speculative_exec_deploy(deploy, verb(verbosity.as_deref()), rpc_address)
+            .await
+    )
+}

--- a/mcp/src/tools/rpc.rs
+++ b/mcp/src/tools/rpc.rs
@@ -475,3 +475,40 @@ pub async fn speculative_exec_deploy(
             .await
     )
 }
+
+#[cfg(test)]
+mod live_tests {
+    use super::*;
+
+    /// Requires a reachable JSON-RPC node (`CASPER_RPC_URL`, default NCTL `:11101`).
+    #[tokio::test]
+    #[ignore = "requires live NCTL / RPC"]
+    async fn live_sdk_get_node_status() {
+        let rpc = std::env::var("CASPER_RPC_URL")
+            .unwrap_or_else(|_| "http://127.0.0.1:11101".to_string());
+        let out = get_node_status(Some("low".into()), Some(rpc)).await;
+        let text = format!("{out:?}");
+        assert!(
+            text.contains("api_version") || text.contains("peers") || text.contains("protocol"),
+            "unexpected ToolOutput (is NCTL up?): {text}"
+        );
+        assert!(
+            !text.to_lowercase().contains("connection refused")
+                && !text.to_lowercase().contains("error(\"http"),
+            "RPC failed: {text}"
+        );
+    }
+
+    #[tokio::test]
+    #[ignore = "requires live NCTL / RPC"]
+    async fn live_sdk_get_peers() {
+        let rpc = std::env::var("CASPER_RPC_URL")
+            .unwrap_or_else(|_| "http://127.0.0.1:11101".to_string());
+        let out = get_peers(None, Some(rpc)).await;
+        let text = format!("{out:?}");
+        assert!(
+            text.contains("peer") || text.contains("address") || text.contains("[]"),
+            "unexpected peers ToolOutput: {text}"
+        );
+    }
+}

--- a/mcp/src/tools/rpc.rs
+++ b/mcp/src/tools/rpc.rs
@@ -63,10 +63,7 @@ macro_rules! rpc_ok {
     };
 }
 
-pub async fn get_node_status(
-    verbosity: Option<String>,
-    rpc_address: Option<String>,
-) -> ToolOutput {
+pub async fn get_node_status(verbosity: Option<String>, rpc_address: Option<String>) -> ToolOutput {
     let sdk = sdk_handle::sdk_snapshot();
     rpc_ok!(
         sdk.get_node_status(verb(verbosity.as_deref()), rpc_address)

--- a/mcp/src/tools/rpc.rs
+++ b/mcp/src/tools/rpc.rs
@@ -1,0 +1,6 @@
+//! Placeholder: JSON-RPC tools (Phase 3).
+
+#![allow(dead_code)]
+
+/// Marker so the `rpc` feature module compiles.
+pub const FEATURE: &str = "rpc";

--- a/mcp/src/tools/transaction.rs
+++ b/mcp/src/tools/transaction.rs
@@ -1,6 +1,133 @@
-//! Placeholder: transaction tools (Phase 5).
+//! Transaction builder / speculative tools (feature `transaction`).
 
-#![allow(dead_code)]
+use casper_rust_wasm_sdk::types::transaction::Transaction;
+use mcpkit::prelude::ToolOutput;
 
-/// Marker so the `transaction` feature module compiles.
-pub const FEATURE: &str = "transaction";
+use crate::format;
+use crate::sdk_handle;
+use crate::tools::params::{
+    parse_optional_uref, parse_transaction_builder_params, parse_transaction_str_params,
+};
+
+pub fn tool_names() -> &'static [&'static str] {
+    &[
+        "sdk_make_transaction",
+        "sdk_make_transfer_transaction",
+        "sdk_speculative_transaction",
+        "sdk_speculative_transfer_transaction",
+    ]
+}
+
+pub fn serialize_transaction(tx: Transaction) -> ToolOutput {
+    match tx.to_json_string() {
+        Ok(s) => match serde_json::from_str::<serde_json::Value>(&s) {
+            Ok(v) => format::json_ok(&v),
+            Err(_) => format::text_ok(s),
+        },
+        Err(err) => format::err(err),
+    }
+}
+
+fn verb(verbosity: Option<&str>) -> Option<casper_rust_wasm_sdk::types::verbosity::Verbosity> {
+    sdk_handle::verbosity_override(verbosity)
+}
+
+pub fn make_transaction(
+    builder_params_json: String,
+    transaction_params_json: String,
+) -> ToolOutput {
+    let builder = match parse_transaction_builder_params(&builder_params_json) {
+        Ok(b) => b,
+        Err(err) => return format::err(err),
+    };
+    let params = match parse_transaction_str_params(&transaction_params_json) {
+        Ok(p) => p,
+        Err(err) => return format::err(err),
+    };
+    let sdk = sdk_handle::sdk_snapshot();
+    match sdk.make_transaction(builder, params) {
+        Ok(tx) => serialize_transaction(tx),
+        Err(err) => format::err(err),
+    }
+}
+
+pub fn make_transfer_transaction(
+    target: String,
+    amount: String,
+    transaction_params_json: String,
+    maybe_source: Option<String>,
+    maybe_id: Option<String>,
+) -> ToolOutput {
+    let params = match parse_transaction_str_params(&transaction_params_json) {
+        Ok(p) => p,
+        Err(err) => return format::err(err),
+    };
+    let source = match parse_optional_uref(maybe_source.as_deref()) {
+        Ok(s) => s,
+        Err(err) => return format::err(err),
+    };
+    let sdk = sdk_handle::sdk_snapshot();
+    match sdk.make_transfer_transaction(source, &target, &amount, params, maybe_id) {
+        Ok(tx) => serialize_transaction(tx),
+        Err(err) => format::err(err),
+    }
+}
+
+pub async fn speculative_transaction(
+    builder_params_json: String,
+    transaction_params_json: String,
+    verbosity: Option<String>,
+    rpc_address: Option<String>,
+) -> ToolOutput {
+    let builder = match parse_transaction_builder_params(&builder_params_json) {
+        Ok(b) => b,
+        Err(err) => return format::err(err),
+    };
+    let params = match parse_transaction_str_params(&transaction_params_json) {
+        Ok(p) => p,
+        Err(err) => return format::err(err),
+    };
+    let sdk = sdk_handle::sdk_snapshot();
+    match sdk
+        .speculative_transaction(builder, params, verb(verbosity.as_deref()), rpc_address)
+        .await
+    {
+        Ok(resp) => format::serialize_ok(&resp.result),
+        Err(err) => format::err(err),
+    }
+}
+
+pub async fn speculative_transfer_transaction(
+    target_account: String,
+    amount: String,
+    transaction_params_json: String,
+    maybe_source: Option<String>,
+    maybe_id: Option<String>,
+    verbosity: Option<String>,
+    rpc_address: Option<String>,
+) -> ToolOutput {
+    let params = match parse_transaction_str_params(&transaction_params_json) {
+        Ok(p) => p,
+        Err(err) => return format::err(err),
+    };
+    let source = match parse_optional_uref(maybe_source.as_deref()) {
+        Ok(s) => s,
+        Err(err) => return format::err(err),
+    };
+    let sdk = sdk_handle::sdk_snapshot();
+    match sdk
+        .speculative_transfer_transaction(
+            source,
+            &target_account,
+            &amount,
+            params,
+            maybe_id,
+            verb(verbosity.as_deref()),
+            rpc_address,
+        )
+        .await
+    {
+        Ok(resp) => format::serialize_ok(&resp.result),
+        Err(err) => format::err(err),
+    }
+}

--- a/mcp/src/tools/transaction.rs
+++ b/mcp/src/tools/transaction.rs
@@ -1,0 +1,6 @@
+//! Placeholder: transaction tools (Phase 5).
+
+#![allow(dead_code)]
+
+/// Marker so the `transaction` feature module compiles.
+pub const FEATURE: &str = "transaction";

--- a/mcp/src/tools/write.rs
+++ b/mcp/src/tools/write.rs
@@ -238,10 +238,7 @@ pub async fn install(
         return format::err("wasm_hex decoded empty");
     }
     let sdk = sdk_handle::sdk_snapshot();
-    match sdk
-        .install(params, Bytes::from(bytes), rpc_address)
-        .await
-    {
+    match sdk.install(params, Bytes::from(bytes), rpc_address).await {
         Ok(resp) => format::serialize_ok(&resp.result),
         Err(err) => format::err(err),
     }
@@ -285,10 +282,7 @@ pub async fn call_entrypoint(
         Err(err) => return format::err(err),
     };
     let sdk = sdk_handle::sdk_snapshot();
-    match sdk
-        .call_entrypoint(builder, params, rpc_address)
-        .await
-    {
+    match sdk.call_entrypoint(builder, params, rpc_address).await {
         Ok(resp) => format::serialize_ok(&resp.result),
         Err(err) => format::err(err),
     }

--- a/mcp/src/tools/write.rs
+++ b/mcp/src/tools/write.rs
@@ -1,0 +1,341 @@
+//! Mutating / signing / submit tools (feature `write`).
+
+#![allow(deprecated)]
+
+use casper_rust_wasm_sdk::helpers;
+use casper_rust_wasm_sdk::types::cl::bytes::Bytes;
+use casper_rust_wasm_sdk::types::deploy::Deploy;
+use casper_rust_wasm_sdk::types::transaction::Transaction;
+use mcpkit::prelude::ToolOutput;
+
+use crate::format;
+use crate::sdk_handle;
+use crate::tools::deploy;
+use crate::tools::params::{
+    parse_deploy_str_params, parse_optional_uref, parse_payment_str_params,
+    parse_session_str_params, parse_transaction_builder_params, parse_transaction_str_params,
+};
+use crate::tools::transaction;
+
+pub fn tool_names() -> &'static [&'static str] {
+    &[
+        "sdk_sign_transaction",
+        "sdk_put_transaction",
+        "sdk_transaction",
+        "sdk_transfer_transaction",
+        "sdk_sign_deploy",
+        "sdk_put_deploy",
+        "sdk_deploy",
+        "sdk_transfer",
+        "sdk_install",
+        "sdk_install_deploy",
+        "sdk_call_entrypoint",
+        "sdk_call_entrypoint_deploy",
+        "sdk_get_binary_try_accept_transaction",
+    ]
+}
+
+fn verb(verbosity: Option<&str>) -> Option<casper_rust_wasm_sdk::types::verbosity::Verbosity> {
+    sdk_handle::verbosity_override(verbosity)
+}
+
+pub fn sign_transaction(transaction_json: String, secret_key: String) -> ToolOutput {
+    let tx = match Transaction::from_json_string(&transaction_json) {
+        Ok(t) => t,
+        Err(err) => return format::err(err),
+    };
+    let sdk = sdk_handle::sdk_snapshot();
+    transaction::serialize_transaction(sdk.sign_transaction(tx, &secret_key))
+}
+
+pub async fn put_transaction(
+    transaction_json: String,
+    verbosity: Option<String>,
+    rpc_address: Option<String>,
+) -> ToolOutput {
+    let tx = match Transaction::from_json_string(&transaction_json) {
+        Ok(t) => t,
+        Err(err) => return format::err(err),
+    };
+    let sdk = sdk_handle::sdk_snapshot();
+    match sdk
+        .put_transaction(tx, verb(verbosity.as_deref()), rpc_address)
+        .await
+    {
+        Ok(resp) => format::serialize_ok(&resp.result),
+        Err(err) => format::err(err),
+    }
+}
+
+pub async fn transaction(
+    builder_params_json: String,
+    transaction_params_json: String,
+    verbosity: Option<String>,
+    rpc_address: Option<String>,
+) -> ToolOutput {
+    let builder = match parse_transaction_builder_params(&builder_params_json) {
+        Ok(b) => b,
+        Err(err) => return format::err(err),
+    };
+    let params = match parse_transaction_str_params(&transaction_params_json) {
+        Ok(p) => p,
+        Err(err) => return format::err(err),
+    };
+    let sdk = sdk_handle::sdk_snapshot();
+    match sdk
+        .transaction(builder, params, verb(verbosity.as_deref()), rpc_address)
+        .await
+    {
+        Ok(resp) => format::serialize_ok(&resp.result),
+        Err(err) => format::err(err),
+    }
+}
+
+pub async fn transfer_transaction(
+    target_account: String,
+    amount: String,
+    transaction_params_json: String,
+    maybe_source: Option<String>,
+    maybe_id: Option<String>,
+    verbosity: Option<String>,
+    rpc_address: Option<String>,
+) -> ToolOutput {
+    let params = match parse_transaction_str_params(&transaction_params_json) {
+        Ok(p) => p,
+        Err(err) => return format::err(err),
+    };
+    let source = match parse_optional_uref(maybe_source.as_deref()) {
+        Ok(s) => s,
+        Err(err) => return format::err(err),
+    };
+    let sdk = sdk_handle::sdk_snapshot();
+    match sdk
+        .transfer_transaction(
+            source,
+            &target_account,
+            &amount,
+            params,
+            maybe_id,
+            verb(verbosity.as_deref()),
+            rpc_address,
+        )
+        .await
+    {
+        Ok(resp) => format::serialize_ok(&resp.result),
+        Err(err) => format::err(err),
+    }
+}
+
+pub fn sign_deploy(deploy_json: String, secret_key: String) -> ToolOutput {
+    let deploy = match Deploy::from_json_string(&deploy_json) {
+        Ok(d) => d,
+        Err(err) => return format::err(err),
+    };
+    let sdk = sdk_handle::sdk_snapshot();
+    deploy::serialize_deploy(sdk.sign_deploy(deploy, &secret_key))
+}
+
+pub async fn put_deploy(
+    deploy_json: String,
+    verbosity: Option<String>,
+    rpc_address: Option<String>,
+) -> ToolOutput {
+    let deploy = match Deploy::from_json_string(&deploy_json) {
+        Ok(d) => d,
+        Err(err) => return format::err(err),
+    };
+    let sdk = sdk_handle::sdk_snapshot();
+    match sdk
+        .put_deploy(deploy, verb(verbosity.as_deref()), rpc_address)
+        .await
+    {
+        Ok(resp) => format::serialize_ok(&resp.result),
+        Err(err) => format::err(err),
+    }
+}
+
+pub async fn deploy(
+    deploy_params_json: String,
+    session_params_json: String,
+    payment_params_json: String,
+    verbosity: Option<String>,
+    rpc_address: Option<String>,
+) -> ToolOutput {
+    let deploy_params = match parse_deploy_str_params(&deploy_params_json) {
+        Ok(p) => p,
+        Err(err) => return format::err(err),
+    };
+    let session_params = match parse_session_str_params(&session_params_json) {
+        Ok(p) => p,
+        Err(err) => return format::err(err),
+    };
+    let payment_params = match parse_payment_str_params(&payment_params_json) {
+        Ok(p) => p,
+        Err(err) => return format::err(err),
+    };
+    let sdk = sdk_handle::sdk_snapshot();
+    match sdk
+        .deploy(
+            deploy_params,
+            session_params,
+            payment_params,
+            verb(verbosity.as_deref()),
+            rpc_address,
+        )
+        .await
+    {
+        Ok(resp) => format::serialize_ok(&resp.result),
+        Err(err) => format::err(err),
+    }
+}
+
+pub async fn transfer(
+    amount: String,
+    target_account: String,
+    deploy_params_json: String,
+    payment_params_json: String,
+    transfer_id: Option<String>,
+    verbosity: Option<String>,
+    rpc_address: Option<String>,
+) -> ToolOutput {
+    let deploy_params = match parse_deploy_str_params(&deploy_params_json) {
+        Ok(p) => p,
+        Err(err) => return format::err(err),
+    };
+    let payment_params = match parse_payment_str_params(&payment_params_json) {
+        Ok(p) => p,
+        Err(err) => return format::err(err),
+    };
+    let sdk = sdk_handle::sdk_snapshot();
+    match sdk
+        .transfer(
+            &amount,
+            &target_account,
+            transfer_id,
+            deploy_params,
+            payment_params,
+            verb(verbosity.as_deref()),
+            rpc_address,
+        )
+        .await
+    {
+        Ok(resp) => format::serialize_ok(&resp.result),
+        Err(err) => format::err(err),
+    }
+}
+
+pub async fn install(
+    transaction_params_json: String,
+    wasm_hex: String,
+    rpc_address: Option<String>,
+) -> ToolOutput {
+    let params = match parse_transaction_str_params(&transaction_params_json) {
+        Ok(p) => p,
+        Err(err) => return format::err(err),
+    };
+    let bytes = helpers::hex_to_uint8_vec(&wasm_hex);
+    if bytes.is_empty() {
+        return format::err("wasm_hex decoded empty");
+    }
+    let sdk = sdk_handle::sdk_snapshot();
+    match sdk
+        .install(params, Bytes::from(bytes), rpc_address)
+        .await
+    {
+        Ok(resp) => format::serialize_ok(&resp.result),
+        Err(err) => format::err(err),
+    }
+}
+
+pub async fn install_deploy(
+    deploy_params_json: String,
+    session_params_json: String,
+    payment_amount: String,
+    rpc_address: Option<String>,
+) -> ToolOutput {
+    let deploy_params = match parse_deploy_str_params(&deploy_params_json) {
+        Ok(p) => p,
+        Err(err) => return format::err(err),
+    };
+    let session_params = match parse_session_str_params(&session_params_json) {
+        Ok(p) => p,
+        Err(err) => return format::err(err),
+    };
+    let sdk = sdk_handle::sdk_snapshot();
+    match sdk
+        .install_deploy(deploy_params, session_params, &payment_amount, rpc_address)
+        .await
+    {
+        Ok(resp) => format::serialize_ok(&resp.result),
+        Err(err) => format::err(err),
+    }
+}
+
+pub async fn call_entrypoint(
+    builder_params_json: String,
+    transaction_params_json: String,
+    rpc_address: Option<String>,
+) -> ToolOutput {
+    let builder = match parse_transaction_builder_params(&builder_params_json) {
+        Ok(b) => b,
+        Err(err) => return format::err(err),
+    };
+    let params = match parse_transaction_str_params(&transaction_params_json) {
+        Ok(p) => p,
+        Err(err) => return format::err(err),
+    };
+    let sdk = sdk_handle::sdk_snapshot();
+    match sdk
+        .call_entrypoint(builder, params, rpc_address)
+        .await
+    {
+        Ok(resp) => format::serialize_ok(&resp.result),
+        Err(err) => format::err(err),
+    }
+}
+
+pub async fn call_entrypoint_deploy(
+    deploy_params_json: String,
+    session_params_json: String,
+    payment_params_json: String,
+    rpc_address: Option<String>,
+) -> ToolOutput {
+    let deploy_params = match parse_deploy_str_params(&deploy_params_json) {
+        Ok(p) => p,
+        Err(err) => return format::err(err),
+    };
+    let session_params = match parse_session_str_params(&session_params_json) {
+        Ok(p) => p,
+        Err(err) => return format::err(err),
+    };
+    let payment_params = match parse_payment_str_params(&payment_params_json) {
+        Ok(p) => p,
+        Err(err) => return format::err(err),
+    };
+    let sdk = sdk_handle::sdk_snapshot();
+    match sdk
+        .call_entrypoint_deploy(deploy_params, session_params, payment_params, rpc_address)
+        .await
+    {
+        Ok(resp) => format::serialize_ok(&resp.result),
+        Err(err) => format::err(err),
+    }
+}
+
+pub async fn get_binary_try_accept_transaction(
+    transaction_json: String,
+    node_address: Option<String>,
+) -> ToolOutput {
+    let transaction = match Transaction::from_json_string(&transaction_json) {
+        Ok(t) => t,
+        Err(err) => return format::err(err),
+    };
+    let sdk = sdk_handle::sdk_snapshot();
+    match sdk
+        .get_binary_try_accept_transaction(node_address, transaction.into())
+        .await
+    {
+        Ok(()) => format::json_ok(&serde_json::json!({ "ok": true })),
+        Err(err) => format::err(err),
+    }
+}


### PR DESCRIPTION
## Summary
- Add workspace sidecar `mcp/` (`casper-rust-wasm-sdk-mcp`) exposing native SDK APIs as mcpkit tools (stdio + Streamable HTTP on **8790**).
- Feature groups: helpers, rpc, binary-port, transaction, deploy, contract, write; Docker image + Cursor config; `make mcp-*` / `make mcp-smoke`.
- Live-checked against NCTL 2.2; release image **`interchouette/casper-rust-wasm-sdk-mcp:2.2.2-mcp`** (also GHCR).

## Test plan
- [x] `make mcp-test`
- [x] `make mcp-test-live` (NCTL `:11101`)
- [x] `make mcp-smoke` (HTTP + Docker stdio)
- [x] Hub/GHCR images pushed for `2.2.2-mcp` + `latest`
- [ ] CI green on this PR

## Images
- `interchouette/casper-rust-wasm-sdk-mcp:2.2.2-mcp`
- `ghcr.io/groussac/casper-rust-wasm-sdk-mcp:2.2.2-mcp`
- `ghcr.io/interchouette-itc/casper-rust-wasm-sdk-mcp:2.2.2-mcp`

Related release branch / tag: `2.2.2-mcp` / `v2.2.2-mcp`.

Made with [Cursor](https://cursor.com)