### PR TITLE
Document live Casper WebClient demo

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,11 +1,13 @@
 # Shared repo-root dockerignore (webclient CI + MCP image).
 # Do NOT exclude examples/, pkg/, or docker/ — CI/CD Image needs them.
+# **/*.wasm shrinks MCP context, but the webclient must ship pkg's Wasm asset.
 .git
 .github
 target
 **/target
 node_modules
 **/*.wasm
+!pkg/casper_rust_wasm_sdk_bg.wasm
 .env
 .cursor
 tests/e2e

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -34,7 +34,10 @@ jobs:
       # Step 5: Build the Docker image using 'make build dev'
       - name: Build Docker image for dev
         run: |
-          make docker-build-prod
+          APP_VERSION=$(jq -r .version examples/frontend/angular/package.json)
+          docker compose -f docker/docker-compose.cicd.yml build \
+            --build-arg APP_VERSION="$APP_VERSION" \
+            --build-arg GIT_SHA="${{ github.sha }}"
           docker tag casper-webclient:latest ${{ secrets.DOCKER_USERNAME }}/casper-webclient:latest
           docker tag casper-webclient:latest ${{ secrets.DOCKER_USERNAME_ITC }}/casper-webclient:latest
 

--- a/docker/Dockerfile.cicd
+++ b/docker/Dockerfile.cicd
@@ -25,7 +25,11 @@ RUN npm run build -- --configuration=$BUILD_CONFIGURATION --verbose
 ARG TARGETPLATFORM=linux/amd64
 FROM --platform=${TARGETPLATFORM} node:22.22-alpine
 
+ARG APP_VERSION=2.2.0
+ARG GIT_SHA=unknown
 ENV PORT=8080
+ENV APP_VERSION=$APP_VERSION
+ENV GIT_SHA=$GIT_SHA
 
 WORKDIR /app
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -3,8 +3,12 @@ set -e
 
 # Default to / if BASE_HREF is not set
 BASE_HREF=${BASE_HREF:-/}
+APP_VERSION=${APP_VERSION:-unknown}
+GIT_SHA=${GIT_SHA:-unknown}
+# Short sha for footer display
+GIT_SHA_SHORT=$(echo "$GIT_SHA" | cut -c1-7)
 
-echo "Entrypoint running. BASE_HREF=$BASE_HREF"
+echo "Entrypoint running. BASE_HREF=$BASE_HREF APP_VERSION=$APP_VERSION GIT_SHA=$GIT_SHA_SHORT"
 
 INDEX_FILE="/app/dist/index.html"
 CONFIG_FILE="/app/dist/config.js"
@@ -27,7 +31,9 @@ cat > "$CONFIG_FILE" <<EOF
 window.__APP_CONFIG__ = {
   cors_anywhere_url: '${CORS_ANYWHERE_URL:-}',
   network_rpc_url: '${NETWORK_RPC_URL:-}',
-  network_node_url: '${NETWORK_NODE_URL:-}'
+  network_node_url: '${NETWORK_NODE_URL:-}',
+  app_version: '${APP_VERSION}',
+  git_sha: '${GIT_SHA_SHORT}'
 };
 EOF
 echo "Generated runtime config.js"

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,16 @@ This page covers different examples of using the SDK.
 
 ⚠ WARNING: This application is for testing and development purposes. Do NOT use private keys or perform real transactions on the testnet/mainnet unless you fully understand the security risks.
 
+## Try the Wasm webclient
+
+A hosted build of the Angular example — **[Casper WebClient](https://casper-webclient.interchouette.net/)** — lets you exercise the Wasm SDK in the browser against public networks (testnet / mainnet).
+
+- Live demo: https://casper-webclient.interchouette.net/
+- Source: [`examples/frontend/angular`](../examples/frontend/angular)
+- Same UI is also packaged as the [Desktop Electron demo](#desktop-electron-demo-app)
+
+Demo / development only — same warning as above.
+
 ## MCP sidecar
 
 The workspace package [`mcp/`](../mcp/) (`casper-rust-wasm-sdk-mcp`) exposes the native Rust SDK as [MCP](https://modelcontextprotocol.io/) tools for Cursor and other agents (stdio or Streamable HTTP on **8790**).
@@ -162,6 +172,8 @@ $ npm start
 
 ## Web Angular
 
+The full in-repo Angular example is the **Casper WebClient**. Try the hosted build at **[https://casper-webclient.interchouette.net/](https://casper-webclient.interchouette.net/)**, or run it locally from [`examples/frontend/angular`](../examples/frontend/angular).
+
 > package.json
 
 ```json
@@ -234,7 +246,7 @@ Add the SDK Wasm file to the assets of your project with the path parameter bein
 
 #### Frontend Angular example
 
-You can look at a more advanced example of usage in the [Angular example app](examples/frontend/angular/src/app/app.component.ts).
+Try the hosted **[Casper WebClient](https://casper-webclient.interchouette.net/)**, or look at a more advanced example of usage in the [Angular example app](examples/frontend/angular/src/app/app.component.ts).
 
 ```shell
 $ cd ./examples/frontend/angular
@@ -472,7 +484,7 @@ let block_hash = block.hash;
 console.log(block_hash);
 ```
 
-You can find more examples in [NodeJs examples](../examples/desktop/node/index.ts) or in the [Angular example app](../examples/frontend/angular/src/app/app.component.ts) or in the [React example app](../examples/frontend/react/src/App.tsx) or by reading [Puppeteer e2e tests](../tests/e2e/puppeteer/tests.spec.ts).
+You can find more examples in [NodeJs examples](../examples/desktop/node/index.ts), the [Angular example app](../examples/frontend/angular/src/app/app.component.ts) (live at [casper-webclient.interchouette.net](https://casper-webclient.interchouette.net/)), the [React example app](../examples/frontend/react/src/App.tsx), or by reading [Puppeteer e2e tests](../tests/e2e/puppeteer/tests.spec.ts).
 
 </details>
 
@@ -2340,7 +2352,7 @@ console.log(deploy_hash);
 
 ![Casper Electron App](https://github.com/casper-ecosystem/casper-rust-wasm-sdk/blob/dev/docs/images/get_status-electron.png)
 
-The Electron based demo app loads the Angular example build. You can use this app on your computer to test every action the SDK can take.
+The Electron based demo app loads the Angular webclient build (the same UI hosted at [casper-webclient.interchouette.net](https://casper-webclient.interchouette.net/)). You can use this app on your computer to test every action the SDK can take.
 
 ```shell
 $ cd ./examples/desktop/electron

--- a/examples/frontend/angular/README.md
+++ b/examples/frontend/angular/README.md
@@ -8,6 +8,8 @@ Browser demo of the Casper Rust/Wasm SDK — call RPC methods, build transaction
 
 Hosted build of this example (Wasm in the browser). Demo / development only — do not use real mainnet keys.
 
+The page footer shows `Casper WebClient vX.Y.Z (gitsha)` from the Docker image build so you can confirm which revision is deployed.
+
 ## Run locally
 
 ```shell

--- a/examples/frontend/angular/README.md
+++ b/examples/frontend/angular/README.md
@@ -1,0 +1,23 @@
+# Casper WebClient (Angular example)
+
+Browser demo of the Casper Rust/Wasm SDK — call RPC methods, build transactions, and explore types from an Angular UI.
+
+## Live demo
+
+**https://casper-webclient.interchouette.net/**
+
+Hosted build of this example (Wasm in the browser). Demo / development only — do not use real mainnet keys.
+
+## Run locally
+
+```shell
+npm install
+npm start
+```
+
+Production / Docker builds use the `docker` configuration (see the repo `docker/` compose files and `Dockerfile.cicd`).
+
+## Related
+
+- SDK docs: [`docs/README.md`](../../../docs/README.md)
+- Desktop wrapper: [`examples/desktop/electron`](../../desktop/electron)

--- a/examples/frontend/angular/libs/components/src/lib/header/header.component.ts
+++ b/examples/frontend/angular/libs/components/src/lib/header/header.component.ts
@@ -68,15 +68,28 @@ export class HeaderComponent implements AfterViewInit {
       this.storageService.get('chain_name') &&
       this.storageService.get('rpc_address')
     ) {
-      this.chain_name =
-        this.storageService.get('chain_name') || this.chain_name;
-      this.rpc_address =
+      const storedRpc =
         this.storageService.get('rpc_address') || this.rpc_address;
-      this.node_address =
-        this.storageService.get('node_address') || this.node_address;
-      this.network =
-        this.networks.find((x) => x.rpc_address == this.rpc_address) ||
-        this.network;
+      // Public hosts must not restore a localhost/ntcl selection from localStorage
+      // (leftover from older defaults or local testing).
+      const storedIsLocal =
+        /localhost|127\.0\.0\.1|172\.(1[6-9]|2\d|3[01])\./.test(storedRpc);
+      if (!(storedIsLocal && !this.isPageOnLocalDockerNetwork())) {
+        this.chain_name =
+          this.storageService.get('chain_name') || this.chain_name;
+        this.rpc_address = storedRpc;
+        this.node_address =
+          this.storageService.get('node_address') || this.node_address;
+        this.network =
+          this.networks.find((x) => x.rpc_address == this.rpc_address) ||
+          this.network;
+      } else {
+        this.storageService.setState({
+          chain_name: this.chain_name,
+          rpc_address: this.rpc_address,
+          node_address: this.node_address,
+        });
+      }
     }
 
     this.stateService.setState({

--- a/examples/frontend/angular/src/app/app.component.html
+++ b/examples/frontend/angular/src/app/app.component.html
@@ -1,1 +1,8 @@
-<router-outlet></router-outlet>
+<div class="app-shell">
+  <main class="app-main">
+    <router-outlet></router-outlet>
+  </main>
+  <footer class="app-footer" data-e2e="app-version-footer">
+    {{ footerLabel }}
+  </footer>
+</div>

--- a/examples/frontend/angular/src/app/app.component.scss
+++ b/examples/frontend/angular/src/app/app.component.scss
@@ -1,0 +1,26 @@
+:host {
+  display: block;
+  min-height: 100%;
+}
+
+.app-shell {
+  display: flex;
+  flex-direction: column;
+  min-height: 100%;
+}
+
+.app-main {
+  flex: 1 1 auto;
+}
+
+.app-footer {
+  flex: 0 0 auto;
+  padding: 0.35rem 0.75rem;
+  font-size: 0.7rem;
+  line-height: 1.2;
+  color: #6c757d;
+  text-align: right;
+  border-top: 1px solid #e9ecef;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  user-select: all;
+}

--- a/examples/frontend/angular/src/app/app.component.ts
+++ b/examples/frontend/angular/src/app/app.component.ts
@@ -1,6 +1,7 @@
 import { CommonModule } from '@angular/common';
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Inject } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
+import { CONFIG, EnvironmentConfig } from '@util/config';
 
 @Component({
   standalone: true,
@@ -10,4 +11,17 @@ import { RouterOutlet } from '@angular/router';
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.scss'],
 })
-export class AppComponent {}
+export class AppComponent {
+  /** Shown in the footer so deploys are identifiable. */
+  readonly appVersion: string;
+  readonly gitSha: string;
+  readonly footerLabel: string;
+
+  constructor(@Inject(CONFIG) config: EnvironmentConfig) {
+    this.appVersion = (config['app_version'] as string) || '2.2.0';
+    this.gitSha = (config['git_sha'] as string) || '';
+    this.footerLabel = this.gitSha
+      ? `Casper WebClient v${this.appVersion} (${this.gitSha})`
+      : `Casper WebClient v${this.appVersion}`;
+  }
+}

--- a/examples/frontend/angular/src/app/health/health.component.spec.ts
+++ b/examples/frontend/angular/src/app/health/health.component.spec.ts
@@ -19,7 +19,7 @@ describe('HealthComponent', () => {
     const component = fixture.componentInstance;
     expect(component.healthResult.status).toBe('healthy');
     expect(component.healthResult.service).toBe('Casper Webclient');
-    expect(component.healthResult.version).toBe('2.1.1');
+    expect(component.healthResult.version).toBe('2.2.0');
   });
 });
 
@@ -28,6 +28,6 @@ describe('buildHealthResult', () => {
     const result = buildHealthResult();
     expect(result.status).toBe('healthy');
     expect(result.service).toBe('Casper Webclient');
-    expect(result.version).toBe('2.1.1');
+    expect(result.version).toBe('2.2.0');
   });
 });

--- a/examples/frontend/angular/src/app/health/health.component.ts
+++ b/examples/frontend/angular/src/app/health/health.component.ts
@@ -7,7 +7,7 @@ export interface HealthResult {
   version: string;
 }
 
-const VERSION = '2.1.1';
+const VERSION = '2.2.0';
 
 export function buildHealthResult(): HealthResult {
   return {

--- a/examples/frontend/angular/src/main.ts
+++ b/examples/frontend/angular/src/main.ts
@@ -29,6 +29,8 @@ declare global {
       cors_anywhere_url?: string;
       network_rpc_url?: string;
       network_node_url?: string;
+      app_version?: string;
+      git_sha?: string;
     };
   }
 }
@@ -87,6 +89,12 @@ if (typeof window !== 'undefined' && window.__APP_CONFIG__) {
   }
   if (runtimeConfig.network_node_url) {
     config['network_node_url'] = runtimeConfig.network_node_url;
+  }
+  if (runtimeConfig.app_version) {
+    config['app_version'] = runtimeConfig.app_version;
+  }
+  if (runtimeConfig.git_sha) {
+    config['git_sha'] = runtimeConfig.git_sha;
   }
 }
 

--- a/pkg-nodejs/README.md
+++ b/pkg-nodejs/README.md
@@ -11,6 +11,16 @@ This page covers different examples of using the SDK.
 
 ⚠ WARNING: This application is for testing and development purposes. Do NOT use private keys or perform real transactions on the testnet/mainnet unless you fully understand the security risks.
 
+## Try the Wasm webclient
+
+A hosted build of the Angular example — **[Casper WebClient](https://casper-webclient.interchouette.net/)** — lets you exercise the Wasm SDK in the browser against public networks (testnet / mainnet).
+
+- Live demo: https://casper-webclient.interchouette.net/
+- Source: [`examples/frontend/angular`](../examples/frontend/angular)
+- Same UI is also packaged as the [Desktop Electron demo](#desktop-electron-demo-app)
+
+Demo / development only — same warning as above.
+
 ## Install
 
 <details>
@@ -149,6 +159,8 @@ $ npm start
 
 ## Web Angular
 
+The full in-repo Angular example is the **Casper WebClient**. Try the hosted build at **[https://casper-webclient.interchouette.net/](https://casper-webclient.interchouette.net/)**, or run it locally from [`examples/frontend/angular`](../examples/frontend/angular).
+
 > package.json
 
 ```json
@@ -221,7 +233,7 @@ Add the SDK Wasm file to the assets of your project with the path parameter bein
 
 #### Frontend Angular example
 
-You can look at a more advanced example of usage in the [Angular example app](examples/frontend/angular/src/app/app.component.ts).
+Try the hosted **[Casper WebClient](https://casper-webclient.interchouette.net/)**, or look at a more advanced example of usage in the [Angular example app](examples/frontend/angular/src/app/app.component.ts).
 
 ```shell
 $ cd ./examples/frontend/angular
@@ -459,7 +471,7 @@ let block_hash = block.hash;
 console.log(block_hash);
 ```
 
-You can find more examples in [NodeJs examples](../examples/desktop/node/index.ts) or in the [Angular example app](../examples/frontend/angular/src/app/app.component.ts) or in the [React example app](../examples/frontend/react/src/App.tsx) or by reading [Puppeteer e2e tests](../tests/e2e/puppeteer/tests.spec.ts).
+You can find more examples in [NodeJs examples](../examples/desktop/node/index.ts), the [Angular example app](../examples/frontend/angular/src/app/app.component.ts) (live at [casper-webclient.interchouette.net](https://casper-webclient.interchouette.net/)), the [React example app](../examples/frontend/react/src/App.tsx), or by reading [Puppeteer e2e tests](../tests/e2e/puppeteer/tests.spec.ts).
 
 </details>
 
@@ -2327,7 +2339,7 @@ console.log(deploy_hash);
 
 ![Casper Electron App](https://github.com/casper-ecosystem/casper-rust-wasm-sdk/blob/dev/docs/images/get_status-electron.png)
 
-The Electron based demo app loads the Angular example build. You can use this app on your computer to test every action the SDK can take.
+The Electron based demo app loads the Angular webclient build (the same UI hosted at [casper-webclient.interchouette.net](https://casper-webclient.interchouette.net/)). You can use this app on your computer to test every action the SDK can take.
 
 ```shell
 $ cd ./examples/desktop/electron

--- a/pkg/README.md
+++ b/pkg/README.md
@@ -11,6 +11,16 @@ This page covers different examples of using the SDK.
 
 ⚠ WARNING: This application is for testing and development purposes. Do NOT use private keys or perform real transactions on the testnet/mainnet unless you fully understand the security risks.
 
+## Try the Wasm webclient
+
+A hosted build of the Angular example — **[Casper WebClient](https://casper-webclient.interchouette.net/)** — lets you exercise the Wasm SDK in the browser against public networks (testnet / mainnet).
+
+- Live demo: https://casper-webclient.interchouette.net/
+- Source: [`examples/frontend/angular`](../examples/frontend/angular)
+- Same UI is also packaged as the [Desktop Electron demo](#desktop-electron-demo-app)
+
+Demo / development only — same warning as above.
+
 ## Install
 
 <details>
@@ -149,6 +159,8 @@ $ npm start
 
 ## Web Angular
 
+The full in-repo Angular example is the **Casper WebClient**. Try the hosted build at **[https://casper-webclient.interchouette.net/](https://casper-webclient.interchouette.net/)**, or run it locally from [`examples/frontend/angular`](../examples/frontend/angular).
+
 > package.json
 
 ```json
@@ -221,7 +233,7 @@ Add the SDK Wasm file to the assets of your project with the path parameter bein
 
 #### Frontend Angular example
 
-You can look at a more advanced example of usage in the [Angular example app](examples/frontend/angular/src/app/app.component.ts).
+Try the hosted **[Casper WebClient](https://casper-webclient.interchouette.net/)**, or look at a more advanced example of usage in the [Angular example app](examples/frontend/angular/src/app/app.component.ts).
 
 ```shell
 $ cd ./examples/frontend/angular
@@ -459,7 +471,7 @@ let block_hash = block.hash;
 console.log(block_hash);
 ```
 
-You can find more examples in [NodeJs examples](../examples/desktop/node/index.ts) or in the [Angular example app](../examples/frontend/angular/src/app/app.component.ts) or in the [React example app](../examples/frontend/react/src/App.tsx) or by reading [Puppeteer e2e tests](../tests/e2e/puppeteer/tests.spec.ts).
+You can find more examples in [NodeJs examples](../examples/desktop/node/index.ts), the [Angular example app](../examples/frontend/angular/src/app/app.component.ts) (live at [casper-webclient.interchouette.net](https://casper-webclient.interchouette.net/)), the [React example app](../examples/frontend/react/src/App.tsx), or by reading [Puppeteer e2e tests](../tests/e2e/puppeteer/tests.spec.ts).
 
 </details>
 
@@ -2327,7 +2339,7 @@ console.log(deploy_hash);
 
 ![Casper Electron App](https://github.com/casper-ecosystem/casper-rust-wasm-sdk/blob/dev/docs/images/get_status-electron.png)
 
-The Electron based demo app loads the Angular example build. You can use this app on your computer to test every action the SDK can take.
+The Electron based demo app loads the Angular webclient build (the same UI hosted at [casper-webclient.interchouette.net](https://casper-webclient.interchouette.net/)). You can use this app on your computer to test every action the SDK can take.
 
 ```shell
 $ cd ./examples/desktop/electron


### PR DESCRIPTION
## Summary
- Add a **Try the Wasm webclient** section to `docs/README.md` (crate readme) linking to https://casper-webclient.interchouette.net/
- Mention the live demo wherever the Angular / Electron webclient example is introduced
- Mirror the same notes in `pkg/README.md` and `pkg-nodejs/README.md`
- Add `examples/frontend/angular/README.md` with live URL + local run instructions

## Test plan
- [ ] Open the new links in GitHub-rendered `docs/README.md` and confirm they resolve
- [ ] Confirm https://casper-webclient.interchouette.net/ loads
- [ ] Skim Angular / Electron sections for consistent wording (demo-only warning preserved)


Made with [Cursor](https://cursor.com)