### PR TITLE
Fix LFS desktop download links (media.githubusercontent.com)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2361,12 +2361,14 @@ $ npm start
 $ npm build
 ```
 
-You can download a pre-built desktop alpha from the **`dev`** branch (these binaries are not shipped on `2.2.2` / `2.2.2-mcp`):
+You can download a pre-built desktop alpha from the **`dev`** branch (Git LFS — use `media.githubusercontent.com`, not `raw.githubusercontent.com`, or you only get the LFS pointer text). These binaries are not shipped on `2.2.2` / `2.2.2-mcp`:
 
-- [Microsoft Windows](https://raw.githubusercontent.com/casper-ecosystem/casper-rust-wasm-sdk/dev/examples/desktop/electron/release/Casper%20Webclient%202.2.0.exe)
-- [GNU/Linux AppImage](https://raw.githubusercontent.com/casper-ecosystem/casper-rust-wasm-sdk/dev/examples/desktop/electron/release/Casper%20Webclient-2.2.0.AppImage)
-- [GNU/Linux Snap](https://raw.githubusercontent.com/casper-ecosystem/casper-rust-wasm-sdk/dev/examples/desktop/electron/release/casper-webclient_2.2.0_amd64.snap)
+- [Microsoft Windows](https://media.githubusercontent.com/media/casper-ecosystem/casper-rust-wasm-sdk/dev/examples/desktop/electron/release/Casper%20Webclient%202.2.0.exe)
+- [GNU/Linux AppImage](https://media.githubusercontent.com/media/casper-ecosystem/casper-rust-wasm-sdk/dev/examples/desktop/electron/release/Casper%20Webclient-2.2.0.AppImage)
+- [GNU/Linux Snap](https://media.githubusercontent.com/media/casper-ecosystem/casper-rust-wasm-sdk/dev/examples/desktop/electron/release/casper-webclient_2.2.0_amd64.snap)
 - [Mac][TODO]
+
+Release builds are also attached to [GitHub Release v2.2.2](https://github.com/casper-ecosystem/casper-rust-wasm-sdk/releases/tag/v2.2.2).
 
 </details>
 

--- a/pkg-nodejs/README.md
+++ b/pkg-nodejs/README.md
@@ -2348,12 +2348,14 @@ $ npm start
 $ npm build
 ```
 
-You can download a pre-built desktop alpha from the **`dev`** branch (these binaries are not shipped on `2.2.2` / `2.2.2-mcp`):
+You can download a pre-built desktop alpha from the **`dev`** branch (Git LFS — use `media.githubusercontent.com`, not `raw.githubusercontent.com`, or you only get the LFS pointer text). These binaries are not shipped on `2.2.2` / `2.2.2-mcp`:
 
-- [Microsoft Windows](https://raw.githubusercontent.com/casper-ecosystem/casper-rust-wasm-sdk/dev/examples/desktop/electron/release/Casper%20Webclient%202.2.0.exe)
-- [GNU/Linux AppImage](https://raw.githubusercontent.com/casper-ecosystem/casper-rust-wasm-sdk/dev/examples/desktop/electron/release/Casper%20Webclient-2.2.0.AppImage)
-- [GNU/Linux Snap](https://raw.githubusercontent.com/casper-ecosystem/casper-rust-wasm-sdk/dev/examples/desktop/electron/release/casper-webclient_2.2.0_amd64.snap)
+- [Microsoft Windows](https://media.githubusercontent.com/media/casper-ecosystem/casper-rust-wasm-sdk/dev/examples/desktop/electron/release/Casper%20Webclient%202.2.0.exe)
+- [GNU/Linux AppImage](https://media.githubusercontent.com/media/casper-ecosystem/casper-rust-wasm-sdk/dev/examples/desktop/electron/release/Casper%20Webclient-2.2.0.AppImage)
+- [GNU/Linux Snap](https://media.githubusercontent.com/media/casper-ecosystem/casper-rust-wasm-sdk/dev/examples/desktop/electron/release/casper-webclient_2.2.0_amd64.snap)
 - [Mac][TODO]
+
+Release builds are also attached to [GitHub Release v2.2.2](https://github.com/casper-ecosystem/casper-rust-wasm-sdk/releases/tag/v2.2.2).
 
 </details>
 

--- a/pkg/README.md
+++ b/pkg/README.md
@@ -2348,12 +2348,14 @@ $ npm start
 $ npm build
 ```
 
-You can download a pre-built desktop alpha from the **`dev`** branch (these binaries are not shipped on `2.2.2` / `2.2.2-mcp`):
+You can download a pre-built desktop alpha from the **`dev`** branch (Git LFS — use `media.githubusercontent.com`, not `raw.githubusercontent.com`, or you only get the LFS pointer text). These binaries are not shipped on `2.2.2` / `2.2.2-mcp`:
 
-- [Microsoft Windows](https://raw.githubusercontent.com/casper-ecosystem/casper-rust-wasm-sdk/dev/examples/desktop/electron/release/Casper%20Webclient%202.2.0.exe)
-- [GNU/Linux AppImage](https://raw.githubusercontent.com/casper-ecosystem/casper-rust-wasm-sdk/dev/examples/desktop/electron/release/Casper%20Webclient-2.2.0.AppImage)
-- [GNU/Linux Snap](https://raw.githubusercontent.com/casper-ecosystem/casper-rust-wasm-sdk/dev/examples/desktop/electron/release/casper-webclient_2.2.0_amd64.snap)
+- [Microsoft Windows](https://media.githubusercontent.com/media/casper-ecosystem/casper-rust-wasm-sdk/dev/examples/desktop/electron/release/Casper%20Webclient%202.2.0.exe)
+- [GNU/Linux AppImage](https://media.githubusercontent.com/media/casper-ecosystem/casper-rust-wasm-sdk/dev/examples/desktop/electron/release/Casper%20Webclient-2.2.0.AppImage)
+- [GNU/Linux Snap](https://media.githubusercontent.com/media/casper-ecosystem/casper-rust-wasm-sdk/dev/examples/desktop/electron/release/casper-webclient_2.2.0_amd64.snap)
 - [Mac][TODO]
+
+Release builds are also attached to [GitHub Release v2.2.2](https://github.com/casper-ecosystem/casper-rust-wasm-sdk/releases/tag/v2.2.2).
 
 </details>
 


### PR DESCRIPTION
## Summary
Those desktop files are **Git LFS**. `raw.githubusercontent.com/...` only serves the pointer:

```text
version https://git-lfs.github.com/spec/v1
oid sha256:…
size …
```

Switch README links to **`media.githubusercontent.com/media/...`**, which returns the real binaries (`application/octet-stream`). Also point at [Release v2.2.2](https://github.com/casper-ecosystem/casper-rust-wasm-sdk/releases/tag/v2.2.2) assets.

## Test plan
- [ ] Click Windows / AppImage / Snap links → download starts (not a tiny text file)
- [ ] `curl -sI` shows `content-type: application/octet-stream` and a large `content-length`


Made with [Cursor](https://cursor.com)