### PR TITLE
Point desktop downloads at Releases; fix publish-docs CI

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -38,6 +38,8 @@ jobs:
           folder: docs # The folder the action should deploy.
 
   desktop-assets:
+    # Electron demos belong on product releases, not MCP sidecar tags.
+    if: ${{ !contains(github.event.release.tag_name, 'mcp') }}
     runs-on: ubuntu-latest
 
     steps:
@@ -91,11 +93,13 @@ jobs:
           set -euo pipefail
           RELEASE_DIR="examples/desktop/electron/release"
           TAG="${{ github.event.release.tag_name }}"
-          VERSION="${TAG#v}"
+          # electron-builder names files from package.json version, not the git tag
+          # (e.g. tag v2.2.2-mcp still builds Casper Webclient 2.2.2.exe).
+          PKG_VERSION=$(jq -r .version examples/desktop/electron/package.json)
 
-          EXE="$RELEASE_DIR/Casper Webclient ${VERSION}.exe"
-          APPIMAGE="$RELEASE_DIR/Casper Webclient-${VERSION}.AppImage"
-          SNAP="$RELEASE_DIR/casper-webclient_${VERSION}_amd64.snap"
+          EXE="$RELEASE_DIR/Casper Webclient ${PKG_VERSION}.exe"
+          APPIMAGE="$RELEASE_DIR/Casper Webclient-${PKG_VERSION}.AppImage"
+          SNAP="$RELEASE_DIR/casper-webclient_${PKG_VERSION}_amd64.snap"
 
           for f in "$EXE" "$APPIMAGE" "$SNAP"; do
             if [[ ! -f "$f" ]]; then
@@ -105,4 +109,16 @@ jobs:
             fi
           done
 
-          gh release upload "$TAG" "$EXE" "$APPIMAGE" "$SNAP" --clobber
+          # Stable names so README can use /releases/latest/download/... forever.
+          cp "$EXE" "$RELEASE_DIR/casper-webclient-windows.exe"
+          cp "$APPIMAGE" "$RELEASE_DIR/casper-webclient-linux.AppImage"
+          cp "$SNAP" "$RELEASE_DIR/casper-webclient-linux.snap"
+
+          gh release upload "$TAG" \
+            "$EXE" \
+            "$APPIMAGE" \
+            "$SNAP" \
+            "$RELEASE_DIR/casper-webclient-windows.exe" \
+            "$RELEASE_DIR/casper-webclient-linux.AppImage" \
+            "$RELEASE_DIR/casper-webclient-linux.snap" \
+            --clobber

--- a/docs/README.md
+++ b/docs/README.md
@@ -2361,11 +2361,11 @@ $ npm start
 $ npm build
 ```
 
-You can download a pre-built desktop alpha from the **`dev`** branch (these binaries are not shipped on `2.2.2` / `2.2.2-mcp`):
+Download pre-built desktop demos from the **[latest GitHub Release](https://github.com/casper-ecosystem/casper-rust-wasm-sdk/releases/latest)** (CI artifacts — not Git LFS / raw links):
 
-- [Microsoft Windows](https://raw.githubusercontent.com/casper-ecosystem/casper-rust-wasm-sdk/dev/examples/desktop/electron/release/Casper%20Webclient%202.2.0.exe)
-- [GNU/Linux AppImage](https://raw.githubusercontent.com/casper-ecosystem/casper-rust-wasm-sdk/dev/examples/desktop/electron/release/Casper%20Webclient-2.2.0.AppImage)
-- [GNU/Linux Snap](https://raw.githubusercontent.com/casper-ecosystem/casper-rust-wasm-sdk/dev/examples/desktop/electron/release/casper-webclient_2.2.0_amd64.snap)
+- [Microsoft Windows](https://github.com/casper-ecosystem/casper-rust-wasm-sdk/releases/latest/download/casper-webclient-windows.exe)
+- [GNU/Linux AppImage](https://github.com/casper-ecosystem/casper-rust-wasm-sdk/releases/latest/download/casper-webclient-linux.AppImage)
+- [GNU/Linux Snap](https://github.com/casper-ecosystem/casper-rust-wasm-sdk/releases/latest/download/casper-webclient-linux.snap)
 - [Mac][TODO]
 
 </details>

--- a/pkg-nodejs/README.md
+++ b/pkg-nodejs/README.md
@@ -2348,11 +2348,11 @@ $ npm start
 $ npm build
 ```
 
-You can download a pre-built desktop alpha from the **`dev`** branch (these binaries are not shipped on `2.2.2` / `2.2.2-mcp`):
+Download pre-built desktop demos from the **[latest GitHub Release](https://github.com/casper-ecosystem/casper-rust-wasm-sdk/releases/latest)** (CI artifacts — not Git LFS / raw links):
 
-- [Microsoft Windows](https://raw.githubusercontent.com/casper-ecosystem/casper-rust-wasm-sdk/dev/examples/desktop/electron/release/Casper%20Webclient%202.2.0.exe)
-- [GNU/Linux AppImage](https://raw.githubusercontent.com/casper-ecosystem/casper-rust-wasm-sdk/dev/examples/desktop/electron/release/Casper%20Webclient-2.2.0.AppImage)
-- [GNU/Linux Snap](https://raw.githubusercontent.com/casper-ecosystem/casper-rust-wasm-sdk/dev/examples/desktop/electron/release/casper-webclient_2.2.0_amd64.snap)
+- [Microsoft Windows](https://github.com/casper-ecosystem/casper-rust-wasm-sdk/releases/latest/download/casper-webclient-windows.exe)
+- [GNU/Linux AppImage](https://github.com/casper-ecosystem/casper-rust-wasm-sdk/releases/latest/download/casper-webclient-linux.AppImage)
+- [GNU/Linux Snap](https://github.com/casper-ecosystem/casper-rust-wasm-sdk/releases/latest/download/casper-webclient-linux.snap)
 - [Mac][TODO]
 
 </details>

--- a/pkg/README.md
+++ b/pkg/README.md
@@ -2348,11 +2348,11 @@ $ npm start
 $ npm build
 ```
 
-You can download a pre-built desktop alpha from the **`dev`** branch (these binaries are not shipped on `2.2.2` / `2.2.2-mcp`):
+Download pre-built desktop demos from the **[latest GitHub Release](https://github.com/casper-ecosystem/casper-rust-wasm-sdk/releases/latest)** (CI artifacts — not Git LFS / raw links):
 
-- [Microsoft Windows](https://raw.githubusercontent.com/casper-ecosystem/casper-rust-wasm-sdk/dev/examples/desktop/electron/release/Casper%20Webclient%202.2.0.exe)
-- [GNU/Linux AppImage](https://raw.githubusercontent.com/casper-ecosystem/casper-rust-wasm-sdk/dev/examples/desktop/electron/release/Casper%20Webclient-2.2.0.AppImage)
-- [GNU/Linux Snap](https://raw.githubusercontent.com/casper-ecosystem/casper-rust-wasm-sdk/dev/examples/desktop/electron/release/casper-webclient_2.2.0_amd64.snap)
+- [Microsoft Windows](https://github.com/casper-ecosystem/casper-rust-wasm-sdk/releases/latest/download/casper-webclient-windows.exe)
+- [GNU/Linux AppImage](https://github.com/casper-ecosystem/casper-rust-wasm-sdk/releases/latest/download/casper-webclient-linux.AppImage)
+- [GNU/Linux Snap](https://github.com/casper-ecosystem/casper-rust-wasm-sdk/releases/latest/download/casper-webclient-linux.snap)
 - [Mac][TODO]
 
 </details>


### PR DESCRIPTION
## Summary
- Point README desktop download links at GitHub `/releases/latest/download` stable asset aliases.
- Fix `publish-docs` CI: skip mcp tags, derive `PKG_VERSION` from `package.json` for electron filenames, and upload stable aliases.
- No version bump on `dev` (crate stays **2.2.0**).

## Test plan
- [ ] Confirm README links resolve to latest Release assets
- [ ] Confirm publish-docs workflow skips `*-mcp` tags and names electron assets from package.json version
- [ ] Confirm `Cargo.toml` on this branch remains `version = "2.2.0"`


Made with [Cursor](https://cursor.com)