### PR TITLE
Hide localhost network options on public WebClient hosts

### DIFF
--- a/examples/frontend/angular/libs/components/src/lib/header/header.component.html
+++ b/examples/frontend/angular/libs/components/src/lib/header/header.component.html
@@ -40,7 +40,7 @@
               [value]="network?.name"
               [selected]="network.rpc_address === rpc_address"
               *ngFor="let network of networks; index as i"
-              [hidden]="network.name === 'custom' && !isCustomNetworkAllowed()"
+              [hidden]="!isNetworkOptionVisible(network)"
             >
               {{ network?.name }} ({{ network.rpc_address }})
             </option>

--- a/examples/frontend/angular/libs/components/src/lib/header/header.component.ts
+++ b/examples/frontend/angular/libs/components/src/lib/header/header.component.ts
@@ -72,8 +72,7 @@ export class HeaderComponent implements AfterViewInit {
         this.storageService.get('rpc_address') || this.rpc_address;
       // Public hosts must not restore a localhost/ntcl selection from localStorage
       // (leftover from older defaults or local testing).
-      const storedIsLocal =
-        /localhost|127\.0\.0\.1|172\.(1[6-9]|2\d|3[01])\./.test(storedRpc);
+      const storedIsLocal = this.isLocalRpcAddress(storedRpc);
       if (!(storedIsLocal && !this.isPageOnLocalDockerNetwork())) {
         this.chain_name =
           this.storageService.get('chain_name') || this.chain_name;
@@ -90,6 +89,26 @@ export class HeaderComponent implements AfterViewInit {
           node_address: this.node_address,
         });
       }
+    }
+
+    // Public hosts must never keep a localhost network selected (even without
+    // localStorage), e.g. older images that defaulted to ntcl.
+    if (
+      !this.isPageOnLocalDockerNetwork() &&
+      this.isLocalRpcAddress(this.rpc_address)
+    ) {
+      this.network =
+        this.networks.find((x) => x.name === this.env['default_network']) ||
+        this.networks.find((x) => !this.isLocalRpcAddress(x.rpc_address)) ||
+        this.network;
+      this.chain_name = this.network.chain_name;
+      this.rpc_address = this.network.rpc_address;
+      this.node_address = this.network.node_address;
+      this.storageService.setState({
+        chain_name: this.chain_name,
+        rpc_address: this.rpc_address,
+        node_address: this.node_address,
+      });
     }
 
     this.stateService.setState({
@@ -189,6 +208,23 @@ export class HeaderComponent implements AfterViewInit {
   isCustomNetworkAllowed() {
     // Allow custom networks only in dev and electron (not in production/docker for security)
     return !this.is_docker && (!this.is_production || this.is_electron);
+  }
+
+  /** Hide localhost/ntcl options on public hosts; keep them for local compose. */
+  isNetworkOptionVisible(network: Network): boolean {
+    if (network.name === 'custom' && !this.isCustomNetworkAllowed()) {
+      return false;
+    }
+    if (this.isPageOnLocalDockerNetwork()) {
+      return true;
+    }
+    return !this.isLocalRpcAddress(network.rpc_address);
+  }
+
+  private isLocalRpcAddress(rpcAddress: string): boolean {
+    return /localhost|127\.0\.0\.1|172\.(1[6-9]|2\d|3[01])\./.test(
+      rpcAddress || '',
+    );
   }
 
   onCcustomChainChange($event: Event) {


### PR DESCRIPTION
## Summary
- Previous public-host fix only skipped restoring a localhost RPC from localStorage and defaulted the Docker webclient to testnet.
- The network select still listed **ntcl** (`http://localhost:11101`) and other local RPC options on public hosts.
- This change hides local RPC options when the page host is not local, and forces `default_network` if the current selection is still a localhost RPC.

## Test plan
- [ ] On a public host (non-localhost), open WebClient and confirm localhost/ntcl options are not shown in the network select
- [ ] On localhost, confirm local RPC options (including ntcl) still appear and work
- [ ] With a stale localStorage localhost RPC on a public host, confirm selection falls back to the default public network


Made with [Cursor](https://cursor.com)