### PR TITLE
Trigger Render redeploy after webclient image push on dev

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -46,3 +46,18 @@ jobs:
         run: |
           docker push ${{ secrets.DOCKER_USERNAME }}/casper-webclient:latest
           docker push ${{ secrets.DOCKER_USERNAME_ITC }}/casper-webclient:latest
+
+      # Render does not watch Hub for new digests — call the service Deploy Hook
+      # after a successful push so it pulls interchouette/casper-webclient:latest.
+      - name: Trigger Render redeploy
+        env:
+          RENDER_DEPLOY_HOOK: ${{ secrets.RENDER_DEPLOY_HOOK }}
+        run: |
+          if [ -z "${RENDER_DEPLOY_HOOK}" ]; then
+            echo "RENDER_DEPLOY_HOOK secret not set; skipping Render redeploy"
+            exit 0
+          fi
+          echo "Triggering Render deploy hook…"
+          curl -fsS -X GET "${RENDER_DEPLOY_HOOK}"
+          echo
+          echo "Render deploy requested"


### PR DESCRIPTION
## Summary
- Mirror casper-deployer docker-build-push-dev.yml; needs repo secret RENDER_DEPLOY_HOOK (Render service Deploy Hook URL). Skips cleanly if unset.

## Test plan
- [ ] Confirm `RENDER_DEPLOY_HOOK` is set in repo secrets (or accept skip when unset)
- [ ] After merge to `dev`, verify the workflow runs the Trigger Render redeploy step after Hub push


Made with [Cursor](https://cursor.com)