### PR TITLE
Stop uploading duplicate stable desktop release aliases

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -109,16 +109,5 @@ jobs:
             fi
           done
 
-          # Stable names so README can use /releases/latest/download/... forever.
-          cp "$EXE" "$RELEASE_DIR/casper-webclient-windows.exe"
-          cp "$APPIMAGE" "$RELEASE_DIR/casper-webclient-linux.AppImage"
-          cp "$SNAP" "$RELEASE_DIR/casper-webclient-linux.snap"
-
-          gh release upload "$TAG" \
-            "$EXE" \
-            "$APPIMAGE" \
-            "$SNAP" \
-            "$RELEASE_DIR/casper-webclient-windows.exe" \
-            "$RELEASE_DIR/casper-webclient-linux.AppImage" \
-            "$RELEASE_DIR/casper-webclient-linux.snap" \
-            --clobber
+          # Upload versioned electron-builder names only (docs link to the Releases page).
+          gh release upload "$TAG" "$EXE" "$APPIMAGE" "$SNAP" --clobber

--- a/docs/README.md
+++ b/docs/README.md
@@ -2361,7 +2361,9 @@ $ npm start
 $ npm build
 ```
 
-Download pre-built desktop demos from the **[latest GitHub Release](https://github.com/casper-ecosystem/casper-rust-wasm-sdk/releases/latest)** (CI artifacts — not Git LFS / raw links):
+Download pre-built desktop demos from the **[GitHub Releases](https://github.com/casper-ecosystem/casper-rust-wasm-sdk/releases)** page (CI artifacts — Windows portable, Linux AppImage, Snap).
+
+- [Mac][TODO](https://github.com/casper-ecosystem/casper-rust-wasm-sdk/releases/latest)** (CI artifacts — not Git LFS / raw links):
 
 - [Microsoft Windows](https://github.com/casper-ecosystem/casper-rust-wasm-sdk/releases/latest/download/casper-webclient-windows.exe)
 - [GNU/Linux AppImage](https://github.com/casper-ecosystem/casper-rust-wasm-sdk/releases/latest/download/casper-webclient-linux.AppImage)

--- a/pkg-nodejs/README.md
+++ b/pkg-nodejs/README.md
@@ -2348,7 +2348,9 @@ $ npm start
 $ npm build
 ```
 
-Download pre-built desktop demos from the **[latest GitHub Release](https://github.com/casper-ecosystem/casper-rust-wasm-sdk/releases/latest)** (CI artifacts — not Git LFS / raw links):
+Download pre-built desktop demos from the **[GitHub Releases](https://github.com/casper-ecosystem/casper-rust-wasm-sdk/releases)** page (CI artifacts — Windows portable, Linux AppImage, Snap).
+
+- [Mac][TODO](https://github.com/casper-ecosystem/casper-rust-wasm-sdk/releases/latest)** (CI artifacts — not Git LFS / raw links):
 
 - [Microsoft Windows](https://github.com/casper-ecosystem/casper-rust-wasm-sdk/releases/latest/download/casper-webclient-windows.exe)
 - [GNU/Linux AppImage](https://github.com/casper-ecosystem/casper-rust-wasm-sdk/releases/latest/download/casper-webclient-linux.AppImage)

--- a/pkg/README.md
+++ b/pkg/README.md
@@ -2348,7 +2348,9 @@ $ npm start
 $ npm build
 ```
 
-Download pre-built desktop demos from the **[latest GitHub Release](https://github.com/casper-ecosystem/casper-rust-wasm-sdk/releases/latest)** (CI artifacts — not Git LFS / raw links):
+Download pre-built desktop demos from the **[GitHub Releases](https://github.com/casper-ecosystem/casper-rust-wasm-sdk/releases)** page (CI artifacts — Windows portable, Linux AppImage, Snap).
+
+- [Mac][TODO](https://github.com/casper-ecosystem/casper-rust-wasm-sdk/releases/latest)** (CI artifacts — not Git LFS / raw links):
 
 - [Microsoft Windows](https://github.com/casper-ecosystem/casper-rust-wasm-sdk/releases/latest/download/casper-webclient-windows.exe)
 - [GNU/Linux AppImage](https://github.com/casper-ecosystem/casper-rust-wasm-sdk/releases/latest/download/casper-webclient-linux.AppImage)


### PR DESCRIPTION
## Summary
- `publish-docs.yml` on `dev` still uploaded both versioned electron-builder names and `casper-webclient-*` aliases.
- Match branch `2.2.2`: upload versioned assets only; README points at the Releases page.
- Manual cleanup of the live `v2.2.2` release assets is done separately.

## Test plan
- [ ] Workflow text review
- [ ] Confirm `v2.2.2` release no longer lists `casper-webclient-windows.exe` / linux aliases

Made with [Cursor](https://cursor.com)