### PR TITLE
Quiet e2e CI test noise

### DIFF
--- a/tests/e2e/jest.config.ts
+++ b/tests/e2e/jest.config.ts
@@ -178,7 +178,8 @@ const config: Config = {
 
   // A map from regular expressions to paths to transformers
   transform: {
-    '^.+\\.[tj]sx?$': ['ts-jest', { useESM: true }],
+    // Only TypeScript — avoid ts-jest compiling pkg-nodejs/*.js (allowJs noise).
+    '^.+\\.tsx?$': ['ts-jest', { useESM: true }],
   },
 
   // An array of regexp pattern strings that are matched against all source file paths, matched files will skip transformation

--- a/tests/e2e/puppeteer/config.ts
+++ b/tests/e2e/puppeteer/config.ts
@@ -1,5 +1,5 @@
 import dotenv from 'dotenv';
-dotenv.config({ path: '../../.env' });
+dotenv.config({ path: '../../.env', quiet: true });
 
 export const key_name_default = 'secret_key.pem';
 export const key_path_default =

--- a/tests/e2e/puppeteer/helpers.ts
+++ b/tests/e2e/puppeteer/helpers.ts
@@ -216,9 +216,6 @@ export function deleteFile(filePathToDelete: string) {
   try {
     if (fs.existsSync(filePathToDelete)) {
       fs.unlinkSync(filePathToDelete);
-      console.info(`Deleted file: ${filePathToDelete}`);
-    } else {
-      console.info(`File not found: ${filePathToDelete}`);
     }
   } catch (error) {
     console.error(`Error deleting file: ${filePathToDelete}`, error);
@@ -261,7 +258,6 @@ function readPEMFile(key_path?: string, copy?: boolean): string {
 function copyFile(src: string, dest: string) {
   try {
     fs.copyFileSync(src, dest);
-    console.info(`Copied ${src} to ${dest}`);
   } catch (error) {
     console.error(`Error copying ${src} to ${dest}:`, error);
   }
@@ -270,7 +266,6 @@ function copyFile(src: string, dest: string) {
 function writeFile(content: string, dest: string) {
   try {
     fs.writeFileSync(dest, content);
-    console.info(`Written content to ${dest}`);
   } catch (error) {
     console.error(`Error writing content to ${dest}:`, error);
   }

--- a/tests/e2e/puppeteer/tests.spec.ts
+++ b/tests/e2e/puppeteer/tests.spec.ts
@@ -1129,7 +1129,6 @@ describe('Angular App Tests', () => {
       call = await test.page.evaluate(() => {
         return document.querySelector('[e2e-id="error"]')?.textContent;
       });
-      console.log(call);
       await test.page.waitForSelector('[e2e-id="result"]');
       call = await test.page.evaluate(() => {
         return document.querySelector('[e2e-id="result"]')?.textContent;


### PR DESCRIPTION
## Summary
- Silence dotenv 17 injected-env tips via `{ quiet: true }`.
- Limit ts-jest to `.ts`/`.tsx` so `pkg-nodejs/*.js` is not compiled (removes `allowJs` warning).
- Remove e2e helper `console.info` and a leftover `console.log(call)` that printed `undefined`.

## Test plan
- [ ] CI `ci-rust-sdk` e2e job log no longer shows dotenv tip / ts-jest allowJs warn / Written content to secret_key.pem / `undefined` from tests.spec.ts


Made with [Cursor](https://cursor.com)