### PR TITLE
ci: pull interchouette NCTL 2.2 image in tests

### DIFF
--- a/.github/workflows/ci-rust-sdk.yml
+++ b/.github/workflows/ci-rust-sdk.yml
@@ -3,14 +3,14 @@ name: ci-rust-sdk
 
 on:
   push:
-    branches: [dev, cid_cd_tests, 'feat*', 'release-*']
+    branches: [dev, cid_cd_tests, "feat*", "release-*"]
     paths-ignore:
-      - '**.md'
+      - "**.md"
 
   pull_request:
-    branches: [dev, cid_cd_tests, 'feat*', 'release-*']
+    branches: [dev, cid_cd_tests, "feat*", "release-*"]
     paths-ignore:
-      - '**.md'
+      - "**.md"
 
 jobs:
   build_and_test:
@@ -63,7 +63,7 @@ jobs:
             -p 28101-28105:28101-28105 \
             -v $PWD/assets/users:/app/casper-nctl/assets/net-1/users/ \
             -v $PWD/assets/faucet:/app/casper-nctl/assets/net-1/faucet/ \
-            gregoshop/casper-nctl:2.0
+            interchouette/casper-nctl-2-docker:2.2
 
       - name: Wait for the service to be ready
         run: |
@@ -141,7 +141,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-          registry-url: 'https://registry.npmjs.org'
+          registry-url: "https://registry.npmjs.org"
 
       - name: Disable AppArmor
         run: echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
@@ -164,7 +164,7 @@ jobs:
         with:
           folder: docs # The folder the action should deploy.
           target-folder: condor
-          commit-message: 'Deploy documentation for ${{ github.ref_name }}'
+          commit-message: "Deploy documentation for ${{ github.ref_name }}"
 
       # - name: Install Electron
       #   run: |

--- a/tests/e2e/jest.config.ts
+++ b/tests/e2e/jest.config.ts
@@ -178,8 +178,8 @@ const config: Config = {
 
   // A map from regular expressions to paths to transformers
   transform: {
-    // Only TypeScript — avoid ts-jest compiling pkg-nodejs/*.js (allowJs noise).
-    '^.+\\.tsx?$': ['ts-jest', { useESM: true }],
+    // Include .js so puppeteer ESM under node_modules is transformed.
+    '^.+\\.[tj]sx?$': ['ts-jest', { useESM: true }],
   },
 
   // An array of regexp pattern strings that are matched against all source file paths, matched files will skip transformation
@@ -201,8 +201,9 @@ const config: Config = {
   // watchman: true,
 
   extensionsToTreatAsEsm: ['.ts', '.tsx'],
+  // Transform puppeteer ESM; leave pkg-nodejs (CJS via file:) alone to avoid ts-jest allowJs noise.
   transformIgnorePatterns: [
-    '/node_modules/(?!casper-rust-wasm-sdk|puppeteer(?:-core)?|@puppeteer)/',
+    '/node_modules/(?!puppeteer(?:-core)?|@puppeteer)/',
   ],
 };
 


### PR DESCRIPTION
## Summary
- Replace deprecated `gregoshop/casper-nctl:2.0` with published `interchouette/casper-nctl-2-docker:2.2` in `ci-rust-sdk.yml` so CI can pull the active NCTL family image.

## Test plan
- [ ] CI job pulls the image without `pull access denied`
- [ ] NCTL readiness checks on ports `11101` / `18101` still pass
- [ ] Integration tests run against the 2.2 NCTL container


Made with [Cursor](https://cursor.com)