### PR TITLE
fix(ci): unbreak dev-1.6 Docker Node and wasm instanceof

### DIFF
--- a/docker/Dockerfile.cicd
+++ b/docker/Dockerfile.cicd
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 node:22.13-alpine as build
+FROM --platform=linux/amd64 node:22.22-alpine AS build
 
 ENV NODE_ENV "development"
 ARG BUILD_CONFIGURATION=docker

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 node:22.13-alpine as build
+FROM --platform=linux/amd64 node:22.22-alpine AS build
 
 ENV NODE_ENV "development"
 ARG BUILD_CONFIGURATION=docker-dev

--- a/src/helpers/mod.rs
+++ b/src/helpers/mod.rs
@@ -441,7 +441,7 @@ pub fn insert_js_value_arg(
     args: &mut RuntimeArgs,
     js_value_arg: JsValue,
 ) -> Result<&RuntimeArgs, Box<SdkError>> {
-    if js_sys::Object::instanceof(&js_value_arg) {
+    if js_value_arg.is_instance_of::<js_sys::Object>() {
         let json_arg: JsonArg = js_value_arg
             .into_serde()
             .map_err(|err| SdkError::CustomError {

--- a/src/sdk/contract/mod.rs
+++ b/src/sdk/contract/mod.rs
@@ -102,5 +102,5 @@ async fn get_dictionary_item_params_input(key: &str) -> DictionaryItemInput {
 
     let mut params = DictionaryItemStrParams::new();
     params.set_contract_named_key(key, DICTIONARY_NAME, DICTIONARY_ITEM_KEY);
-    DictionaryItemInput::Params(params)
+    DictionaryItemInput::Params(Box::new(params))
 }

--- a/src/sdk/contract/query_contract_dict.rs
+++ b/src/sdk/contract/query_contract_dict.rs
@@ -241,7 +241,7 @@ mod tests {
         // Act
         let result = sdk
             .query_contract_dict(
-                DictionaryItemInput::Params(params),
+                DictionaryItemInput::Params(Box::new(params)),
                 Some(state_root_hash),
                 verbosity,
                 Some(node_address),

--- a/src/sdk/rpcs/get_dictionary_item.rs
+++ b/src/sdk/rpcs/get_dictionary_item.rs
@@ -142,7 +142,7 @@ impl SDK {
         let dictionary_item = if let Some(identifier) = dictionary_item_identifier {
             DictionaryItemInput::Identifier(identifier)
         } else if let Some(params) = dictionary_item_params {
-            DictionaryItemInput::Params(params)
+            DictionaryItemInput::Params(Box::new(params))
         } else {
             let err = "Error: Missing dictionary item identifier or params";
             return Err(JsError::new(err));
@@ -185,7 +185,7 @@ impl SDK {
 #[derive(Debug, Clone)]
 pub enum DictionaryItemInput {
     Identifier(DictionaryItemIdentifier),
-    Params(DictionaryItemStrParams),
+    Params(Box<DictionaryItemStrParams>),
 }
 
 impl SDK {
@@ -414,7 +414,7 @@ mod tests {
         // Act
         let result = sdk
             .get_dictionary_item(
-                DictionaryItemInput::Params(params),
+                DictionaryItemInput::Params(Box::new(params)),
                 Some(state_root_hash),
                 verbosity,
                 Some(node_address),

--- a/src/sdk/rpcs/mod.rs
+++ b/src/sdk/rpcs/mod.rs
@@ -24,7 +24,7 @@ use dotenvy::dotenv;
 #[cfg(test)]
 mod setup {
     use super::*;
-    #[ctor::ctor]
+    #[ctor::ctor(unsafe)]
     fn setup() {
         dotenv().ok();
     }

--- a/src/types/deploy_params/dictionary_item_str_params.rs
+++ b/src/types/deploy_params/dictionary_item_str_params.rs
@@ -213,25 +213,25 @@ pub fn dictionary_item_str_params_to_casper_client(
         let hash_addr = get_str_or_default(contract_named_key.key.get());
         let dictionary_name = get_str_or_default(contract_named_key.dictionary_name.get());
         let dictionary_item_key = get_str_or_default(contract_named_key.dictionary_item_key.get());
-        return _DictionaryItemStrParams::ContractNamedKey {
+        _DictionaryItemStrParams::ContractNamedKey {
             hash_addr,
             dictionary_name,
             dictionary_item_key,
-        };
+        }
     } else if let Some(uref_variant) = &dictionary_item_params.uref {
         let seed_uref = get_str_or_default(uref_variant.seed_uref.get());
         let dictionary_item_key = get_str_or_default(uref_variant.dictionary_item_key.get());
-        return _DictionaryItemStrParams::URef {
+        _DictionaryItemStrParams::URef {
             seed_uref,
             dictionary_item_key,
-        };
+        }
     } else if let Some(dictionary_variant) = &dictionary_item_params.dictionary {
         let value = get_str_or_default(dictionary_variant.value.get());
-        return _DictionaryItemStrParams::Dictionary(value);
+        _DictionaryItemStrParams::Dictionary(value)
     } else {
         // TODO Fix return type
         error("Error converting dictionary_item_params");
-        return _DictionaryItemStrParams::Dictionary("");
+        _DictionaryItemStrParams::Dictionary("")
     }
 }
 

--- a/tests/integration/rust/src/tests/helpers.rs
+++ b/tests/integration/rust/src/tests/helpers.rs
@@ -85,7 +85,7 @@ pub(crate) mod intern {
     ) -> String {
         let mut params = DictionaryItemStrParams::new();
         params.set_contract_named_key(contract_hash, dictionary_name, dictionary_item_key);
-        let dictionary_item = DictionaryItemInput::Params(params);
+        let dictionary_item = DictionaryItemInput::Params(Box::new(params));
         let get_dictionary_item = create_test_sdk(None)
             .get_dictionary_item(
                 dictionary_item,

--- a/tests/integration/rust/src/tests/integration/contract/mod.rs
+++ b/tests/integration/rust/src/tests/integration/contract/mod.rs
@@ -101,7 +101,7 @@ pub mod test_module {
 
         let mut params = DictionaryItemStrParams::new();
         params.set_dictionary(&config.dictionary_key);
-        let dictionary_item = DictionaryItemInput::Params(params);
+        let dictionary_item = DictionaryItemInput::Params(Box::new(params));
         let query_contract_dict = create_test_sdk(Some(config))
             .query_contract_dict(dictionary_item, Some(state_root_hash), None, None)
             .await;
@@ -140,7 +140,7 @@ pub mod test_module {
 
         let mut params = DictionaryItemStrParams::new();
         params.set_uref(&config.dictionary_uref, DICTIONARY_ITEM_KEY);
-        let dictionary_item = DictionaryItemInput::Params(params);
+        let dictionary_item = DictionaryItemInput::Params(Box::new(params));
 
         let query_contract_dict = create_test_sdk(Some(config))
             .query_contract_dict(dictionary_item, Some(state_root_hash), None, None)

--- a/tests/integration/rust/src/tests/integration/rpcs/mod.rs
+++ b/tests/integration/rust/src/tests/integration/rpcs/mod.rs
@@ -198,7 +198,7 @@ pub mod test_module {
             DICTIONARY_NAME,
             DICTIONARY_ITEM_KEY,
         );
-        let dictionary_item = DictionaryItemInput::Params(params);
+        let dictionary_item = DictionaryItemInput::Params(Box::new(params));
         let get_dictionary_item = create_test_sdk(Some(config))
             .get_dictionary_item(dictionary_item, Some(state_root_hash), None, None)
             .await;
@@ -231,7 +231,7 @@ pub mod test_module {
             DICTIONARY_NAME,
             DICTIONARY_ITEM_KEY,
         );
-        let dictionary_item = DictionaryItemInput::Params(params);
+        let dictionary_item = DictionaryItemInput::Params(Box::new(params));
         let get_dictionary_item = create_test_sdk(Some(config))
             .get_dictionary_item(dictionary_item, None::<&str>, None, None)
             .await;


### PR DESCRIPTION
## Summary
- Bump `docker/Dockerfile.cicd` and `Dockerfile.dev` from `node:22.13-alpine` to `node:22.22-alpine` so `npm install -g npm@latest` stops failing with `notsup`.
- Replace `js_sys::Object::instanceof` with `js_value_arg.is_instance_of::<js_sys::Object>()` to fix clippy/rustc `E0282`.

## Test plan
- [ ] `ci-rust-sdk` on this PR is green (`make check-lint` / clippy)
- [ ] `CI/CD Image 1.6` Docker build gets past the npm global install step
- [ ] After merge, align `origin` + `gRoussac` `dev-1.6` to `ecosystem/dev-1.6`


Made with [Cursor](https://cursor.com)