### PR TITLE
ci: modernize Actions and move everything to Node 24

### DIFF
--- a/.github/workflows/ci-rust-sdk.yml
+++ b/.github/workflows/ci-rust-sdk.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node-version: [22.x]
+        node-version: [24.x]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -26,20 +26,15 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y pkg-config libssl-dev
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Swatinem cache
         uses: Swatinem/rust-cache@v2
 
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
-          profile: minimal
           components: rustfmt, clippy
-          target: wasm32-unknown-unknown
-
-      - name: Add wasm32 target
-        run: rustup target add wasm32-unknown-unknown
+          targets: wasm32-unknown-unknown
 
       - name: Install cargo-audit
         run: cargo install cargo-audit
@@ -138,10 +133,11 @@ jobs:
         run: make integration-test
 
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node-version }}
           registry-url: "https://registry.npmjs.org"
+          package-manager-cache: false
 
       - name: Disable AppArmor
         run: echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
@@ -151,16 +147,13 @@ jobs:
           make e2e-test
 
       - name: Build lib for all targets
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --lib --all-targets
+        run: cargo build --lib --all-targets
 
       - name: Doc
         run: make doc
 
       - name: Github pages 🚀
-        uses: JamesIves/github-pages-deploy-action@ba1486788b0490a235422264426c45848eac35c6 #v4.4.1
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
           folder: docs # The folder the action should deploy.
           target-folder: condor

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -12,40 +12,36 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      # Step 1: Checkout the repository
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
 
-      # Step 2: Set up Docker Buildx
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-
-      # Step 3: Set up Make
       - name: Set up Make
         run: sudo apt-get install -y make
 
-      # Step 4: Log in to Docker Hub
       - name: Log in to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      # Step 5: Build the Docker image using 'make build dev'
-      - name: Build Docker image for dev
+      - name: Build Docker images for dev
         run: |
           APP_VERSION=$(jq -r .version examples/frontend/angular/package.json)
           docker compose -f docker/docker-compose.cicd.yml build \
             --build-arg APP_VERSION="$APP_VERSION" \
             --build-arg GIT_SHA="${{ github.sha }}"
-          docker tag casper-webclient:latest ${{ secrets.DOCKER_USERNAME }}/casper-webclient:latest
-          docker tag casper-webclient:latest ${{ secrets.DOCKER_USERNAME_ITC }}/casper-webclient:latest
 
-      # Step 6: Push the Docker image to Docker Hub
-      - name: Push Docker image to Docker Hub
+          for image in casper-webclient cors-anywhere ws-proxy; do
+            docker tag "${image}:latest" "${{ secrets.DOCKER_USERNAME }}/${image}:latest"
+            docker tag "${image}:latest" "${{ secrets.DOCKER_USERNAME_ITC }}/${image}:latest"
+          done
+
+      - name: Push Docker images to Docker Hub
         run: |
-          docker push ${{ secrets.DOCKER_USERNAME }}/casper-webclient:latest
-          docker push ${{ secrets.DOCKER_USERNAME_ITC }}/casper-webclient:latest
+          for image in casper-webclient cors-anywhere ws-proxy; do
+            docker push "${{ secrets.DOCKER_USERNAME }}/${image}:latest"
+            docker push "${{ secrets.DOCKER_USERNAME_ITC }}/${image}:latest"
+          done
 
       # Render does not watch Hub for new digests — call the service Deploy Hook
       # after a successful push so it pulls interchouette/casper-webclient:latest.

--- a/.github/workflows/nightly-scheduled-test.yml
+++ b/.github/workflows/nightly-scheduled-test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node-version: [22.x]
+        node-version: [24.x]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -20,7 +20,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y pkg-config libssl-dev
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Free up disk space
         run: |
@@ -35,15 +35,10 @@ jobs:
       - name: Swatinem cache
         uses: Swatinem/rust-cache@v2
 
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
-          profile: minimal
           components: rustfmt, clippy
-          target: wasm32-unknown-unknown
-
-      - name: Add wasm32 target
-        run: rustup target add wasm32-unknown-unknown
+          targets: wasm32-unknown-unknown
 
       - name: Install cargo-audit
         run: cargo install cargo-audit
@@ -132,19 +127,17 @@ jobs:
         run: make integration-test
 
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node-version }}
           registry-url: "https://registry.npmjs.org"
+          package-manager-cache: false
 
       - name: Disable AppArmor
         run: echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
 
       - name: Build lib for all targets
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --lib --all-targets
+        run: cargo build --lib --all-targets
 
       # - name: Slack Notification
       #   uses: ravsamhq/notify-slack-action@4ed28566c2bdcdaee6dca2b46b9666d01b4ed8a4 #v1.10.0

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -12,17 +12,19 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node-version: [22.x]
+        node-version: [24.x]
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
-          profile: minimal
           components: rustfmt, clippy
-          target: wasm32-unknown-unknown
+          targets: wasm32-unknown-unknown
+      - uses: actions/setup-node@v5
+        with:
+          node-version: ${{ matrix.node-version }}
+          package-manager-cache: false
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 
@@ -33,7 +35,7 @@ jobs:
         run: make doc
 
       - name: Github pages 🚀
-        uses: JamesIves/github-pages-deploy-action@ba1486788b0490a235422264426c45848eac35c6 #v4.4.1
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
           folder: docs # The folder the action should deploy.
 
@@ -44,7 +46,7 @@ jobs:
 
     steps:
       - name: Checkout release tag
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.release.tag_name }}
 
@@ -55,16 +57,15 @@ jobs:
           sudo snap install snapcraft --classic
 
       - name: Setup Rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
-          profile: minimal
-          target: wasm32-unknown-unknown
+          targets: wasm32-unknown-unknown
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
-          node-version: '22'
+          node-version: "24"
+          package-manager-cache: false
 
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh

--- a/.github/workflows/publish-rust-sdk-rs.yml
+++ b/.github/workflows/publish-rust-sdk-rs.yml
@@ -4,21 +4,15 @@ name: publish-rust-sdk-rs
 on:
   push:
     tags:
-      - 'v*.*.*'
+      - "v*.*.*"
 
 jobs:
   publish:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@stable
 
       - name: Crate Publish
-        uses: actions-rs/cargo@v1
-        with:
-          command: publish
-          args: --token ${{ secrets.crates_io_token }}
+        run: cargo publish --token ${{ secrets.crates_io_token }}

--- a/.github/workflows/publish-rust-sdk-ts.yml
+++ b/.github/workflows/publish-rust-sdk-ts.yml
@@ -14,22 +14,21 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.x]
+        node-version: [24.x]
 
     steps:
-      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b #v3.0.2
+      - uses: actions/checkout@v5
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@5b949b50c3461bbcd5a540b150c368278160234a #v3.4.0
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node-version }}
-          registry-url: 'https://registry.npmjs.org'
+          registry-url: "https://registry.npmjs.org"
+          package-manager-cache: false
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
-          profile: minimal
-          target: wasm32-unknown-unknown
+          targets: wasm32-unknown-unknown
       - run: make build
 
       # - name: Publish pkg to NPM

--- a/docker/Dockerfile.cicd
+++ b/docker/Dockerfile.cicd
@@ -1,5 +1,5 @@
 ARG TARGETPLATFORM=linux/amd64
-FROM --platform=${TARGETPLATFORM} node:22.22-alpine AS build
+FROM --platform=${TARGETPLATFORM} node:24-alpine AS build
 
 ENV NODE_ENV=development
 ARG BUILD_CONFIGURATION=docker
@@ -23,7 +23,7 @@ RUN npm install --ignore-scripts --verbose && npm update
 RUN npm run build -- --configuration=$BUILD_CONFIGURATION --verbose
 
 ARG TARGETPLATFORM=linux/amd64
-FROM --platform=${TARGETPLATFORM} node:22.22-alpine
+FROM --platform=${TARGETPLATFORM} node:24-alpine
 
 ARG APP_VERSION=2.2.0
 ARG GIT_SHA=unknown

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 node:22.22-alpine as build
+FROM --platform=linux/amd64 node:24-alpine AS build
 
 ENV NODE_ENV "development"
 ARG BUILD_CONFIGURATION=docker-dev

--- a/docker/cors-anywhere.Dockerfile
+++ b/docker/cors-anywhere.Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14-alpine
+FROM node:24-alpine
 
 # Set environment variables for production
 ENV NODE_ENV=production

--- a/docker/docker-compose.cicd.yml
+++ b/docker/docker-compose.cicd.yml
@@ -51,6 +51,7 @@ services:
       - casper-network
 
   ws-proxy:
+    image: ws-proxy:latest
     container_name: ws-proxy
     build:
       context: ../

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -6,7 +6,7 @@ services:
       dockerfile: ./docker/Dockerfile.dev
       context: ../
     ports:
-      - '4200:4200'
+      - "4200:4200"
     networks:
       - casper-network
 
@@ -15,6 +15,7 @@ services:
   # docker container run -t -i --rm -h casper-webclient -p 4200:4200 casper-webclient
 
   ws-proxy:
+    image: ws-proxy:latest
     container_name: ws-proxy
     build:
       context: ../

--- a/docker/ws-proxy.Dockerfile
+++ b/docker/ws-proxy.Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14-alpine
+FROM node:24-alpine
 
 # Set environment variables for production
 ENV NODE_ENV=production


### PR DESCRIPTION
## Summary
- Move CI, publish workflows, and all Docker images (webclient + cors-anywhere + ws-proxy) to **Node 24**
- Replace archived `actions-rs/*` with `dtolnay/rust-toolchain` and plain `cargo`; bump `checkout`/`setup-node` to v5 and Docker login to v3
- Push `cors-anywhere` and `ws-proxy` from the `dev` Docker workflow (they were built locally / Hub tags were never updated by CI)

## Test plan
- [ ] `ci-rust-sdk` passes on this PR (Node 24 + e2e)
- [ ] After merge to `dev`, `CI/CD Image dev` builds and pushes `casper-webclient`, `cors-anywhere`, and `ws-proxy` to both Hub accounts
- [ ] Confirm Hub tags for `interchouette/ws-proxy` and `interchouette/cors-anywhere` update and still start via `docker/docker-compose.yml`
- [ ] Spot-check that Node 20 deprecation / “Post job cleanup” warnings are gone


Made with [Cursor](https://cursor.com)