### PR TITLE
Align dev with casper-node v2.2.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "casper-rust-wasm-sdk"
-version = "2.2.0"
+version = "2.2.2"
 edition = "2021"
 description = "Casper Rust Wasm Web SDK"
 repository = "https://github.com/casper-ecosystem/casper-rust-wasm-sdk"
@@ -24,11 +24,11 @@ exclude = [
 ]
 
 [dependencies]
-casper-types = { version = "7.0.0", default-features = false, features = [
+casper-types = { version = "7.1.1", default-features = false, features = [
   "datasize",
 ] }
 casper-client = { version = "5", default-features = false }
-casper-binary-port = { version = "1.1.1" }
+casper-binary-port = { version = "1.2.1" }
 casper-binary-port-access = { version = "0.1.0" }
 rand = { version = "0.9.2", default-features = false, features = [
   "thread_rng",
@@ -79,6 +79,10 @@ dotenvy = "0.15.7"
 
 [patch.crates-io]
 casper-client = { version = "5", git = "https://github.com/casper-ecosystem/casper-client-rs", branch = "dev" }
-casper-types = { git = "https://github.com/casper-network/casper-node", branch = "dev" }
-casper-binary-port = { git = "https://github.com/casper-network/casper-node", branch = "dev" }
-casper-binary-port-access = { git = "https://github.com/gRoussac/casper-binary-port-client", branch = "casper_2.2.0" }
+# NOT a normal `dev` pin: casper-node's own `dev` branch still declares version
+# "2.2.0" (https://github.com/casper-network/casper-node/blob/dev/node/Cargo.toml#L3),
+# so we track release tag v2.2.2 until that line (and crates) move forward. Then
+# switch these back to `branch = "dev"` (and casper_2.2.2 → matching access branch).
+casper-types = { git = "https://github.com/casper-network/casper-node", tag = "v2.2.2" }
+casper-binary-port = { git = "https://github.com/casper-network/casper-node", tag = "v2.2.2" }
+casper-binary-port-access = { git = "https://github.com/gRoussac/casper-binary-port-client", branch = "casper_2.2.2" }

--- a/docker/Dockerfile.cicd
+++ b/docker/Dockerfile.cicd
@@ -25,7 +25,7 @@ RUN npm run build -- --configuration=$BUILD_CONFIGURATION --verbose
 ARG TARGETPLATFORM=linux/amd64
 FROM --platform=${TARGETPLATFORM} node:24-alpine
 
-ARG APP_VERSION=2.2.0
+ARG APP_VERSION=2.2.2
 ARG GIT_SHA=unknown
 ENV PORT=8080
 ENV APP_VERSION=$APP_VERSION

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-# Casper Rust/Wasm SDK 2.2.0
+# Casper Rust/Wasm SDK 2.2.2
 
 The Rust/Wasm SDK allows developers and users to interact with the Casper Blockchain using Rust or TypeScript. It provides a way to embed the [casper-client-rs](https://github.com/casper-ecosystem/casper-client-rs) into another application without the CLI interface. The SDK exposes a list of types and methods from a subset of the Casper client.
 
@@ -46,7 +46,7 @@ Add the SDK as a dependency of your project:
 > Cargo.toml
 
 ```toml
-casper-rust-wasm-sdk = { version = "2.2.0", git = "https://github.com/casper-ecosystem/casper-rust-wasm-sdk.git", branch = "dev" }
+casper-rust-wasm-sdk = { version = "2.2.2", git = "https://github.com/casper-ecosystem/casper-rust-wasm-sdk.git", branch = "dev" }
 ```
 
 ## Usage

--- a/examples/desktop/electron/package-lock.json
+++ b/examples/desktop/electron/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "casper-webclient",
-  "version": "2.2.0",
+  "version": "2.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "casper-webclient",
-      "version": "2.2.0",
+      "version": "2.2.2",
       "license": "ISC",
       "dependencies": {
         "ws": "^8.21.1"

--- a/examples/desktop/electron/package.json
+++ b/examples/desktop/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "casper-webclient",
-  "version": "2.2.0",
+  "version": "2.2.2",
   "description": "Casper Client Demo app",
   "main": "index.js",
   "scripts": {

--- a/examples/desktop/node/package-lock.json
+++ b/examples/desktop/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "casper",
-  "version": "2.2.0",
+  "version": "2.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "casper",
-      "version": "2.2.0",
+      "version": "2.2.2",
       "license": "ISC",
       "dependencies": {
         "casper-rust-wasm-sdk": "file:../../../pkg-nodejs"
@@ -18,7 +18,7 @@
     },
     "../../../pkg-nodejs": {
       "name": "casper-rust-wasm-sdk",
-      "version": "2.2.0",
+      "version": "2.2.2",
       "license": "Apache-2.0"
     },
     "node_modules/@types/node": {

--- a/examples/desktop/node/package.json
+++ b/examples/desktop/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "casper",
-  "version": "2.2.0",
+  "version": "2.2.2",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/examples/frontend/angular/package-lock.json
+++ b/examples/frontend/angular/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "casper-webclient",
-  "version": "2.2.0",
+  "version": "2.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "casper-webclient",
-      "version": "2.2.0",
+      "version": "2.2.2",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "~21.1.5",
@@ -65,7 +65,7 @@
     },
     "../../../pkg": {
       "name": "casper-rust-wasm-sdk",
-      "version": "2.2.0",
+      "version": "2.2.2",
       "license": "Apache-2.0"
     },
     "node_modules/@algolia/abtesting": {

--- a/examples/frontend/angular/package.json
+++ b/examples/frontend/angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "casper-webclient",
-  "version": "2.2.0",
+  "version": "2.2.2",
   "license": "MIT",
   "scripts": {
     "build-proxy-conf": "node build-proxy-conf.js",

--- a/examples/frontend/react/package-lock.json
+++ b/examples/frontend/react/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "my-react-app",
-  "version": "2.2.0",
+  "version": "2.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "my-react-app",
-      "version": "2.2.0",
+      "version": "2.2.2",
       "dependencies": {
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.3.0",
@@ -31,7 +31,7 @@
     },
     "../../../pkg": {
       "name": "casper-rust-wasm-sdk",
-      "version": "2.2.0",
+      "version": "2.2.2",
       "license": "Apache-2.0"
     },
     "node_modules/@adobe/css-tools": {

--- a/examples/frontend/react/package.json
+++ b/examples/frontend/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "my-react-app",
-  "version": "2.2.0",
+  "version": "2.2.2",
   "private": true,
   "dependencies": {
     "@testing-library/jest-dom": "^6.6.3",

--- a/pkg-nodejs/README.md
+++ b/pkg-nodejs/README.md
@@ -1,4 +1,4 @@
-# Casper Rust/Wasm SDK 2.2.0
+# Casper Rust/Wasm SDK 2.2.2
 
 The Rust/Wasm SDK allows developers and users to interact with the Casper Blockchain using Rust or TypeScript. It provides a way to embed the [casper-client-rs](https://github.com/casper-ecosystem/casper-client-rs) into another application without the CLI interface. The SDK exposes a list of types and methods from a subset of the Casper client.
 
@@ -33,7 +33,7 @@ Add the SDK as a dependency of your project:
 > Cargo.toml
 
 ```toml
-casper-rust-wasm-sdk = { version = "2.2.0", git = "https://github.com/casper-ecosystem/casper-rust-wasm-sdk.git", branch = "dev" }
+casper-rust-wasm-sdk = { version = "2.2.2", git = "https://github.com/casper-ecosystem/casper-rust-wasm-sdk.git", branch = "dev" }
 ```
 
 ## Usage

--- a/pkg-nodejs/package.json
+++ b/pkg-nodejs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "casper-rust-wasm-sdk",
   "description": "Casper Rust Wasm Web SDK",
-  "version": "2.2.0",
+  "version": "2.2.2",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/pkg/README.md
+++ b/pkg/README.md
@@ -1,4 +1,4 @@
-# Casper Rust/Wasm SDK 2.2.0
+# Casper Rust/Wasm SDK 2.2.2
 
 The Rust/Wasm SDK allows developers and users to interact with the Casper Blockchain using Rust or TypeScript. It provides a way to embed the [casper-client-rs](https://github.com/casper-ecosystem/casper-client-rs) into another application without the CLI interface. The SDK exposes a list of types and methods from a subset of the Casper client.
 
@@ -33,7 +33,7 @@ Add the SDK as a dependency of your project:
 > Cargo.toml
 
 ```toml
-casper-rust-wasm-sdk = { version = "2.2.0", git = "https://github.com/casper-ecosystem/casper-rust-wasm-sdk.git", branch = "dev" }
+casper-rust-wasm-sdk = { version = "2.2.2", git = "https://github.com/casper-ecosystem/casper-rust-wasm-sdk.git", branch = "dev" }
 ```
 
 ## Usage

--- a/pkg/package.json
+++ b/pkg/package.json
@@ -2,7 +2,7 @@
   "name": "casper-rust-wasm-sdk",
   "type": "module",
   "description": "Casper Rust Wasm Web SDK",
-  "version": "2.2.0",
+  "version": "2.2.2",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/tests/e2e/package-lock.json
+++ b/tests/e2e/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "e2e",
-  "version": "2.2.0",
+  "version": "2.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "e2e",
-      "version": "2.2.0",
+      "version": "2.2.2",
       "license": "ISC",
       "dependencies": {
         "casper-rust-wasm-sdk": "file:../../pkg-nodejs",
@@ -23,7 +23,7 @@
     },
     "../../pkg-nodejs": {
       "name": "casper-rust-wasm-sdk",
-      "version": "2.1.1",
+      "version": "2.2.2",
       "license": "Apache-2.0"
     },
     "node_modules/@babel/code-frame": {

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -1,6 +1,6 @@
 {
   "name": "e2e",
-  "version": "2.2.0",
+  "version": "2.2.2",
   "description": "e2e tests",
   "main": "index.js",
   "scripts": {

--- a/tests/integration/rust/Cargo.toml
+++ b/tests/integration/rust/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "sdk_tests"
-version = "2.2.0"
+version = "2.2.2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-casper-rust-wasm-sdk = { path = "../../../", version = "2.2.0" }
+casper-rust-wasm-sdk = { path = "../../../", version = "2.2.2" }
 tokio = { version = "1", features = ["full"] }
 once_cell = "*"
 chrono = "0.4"
@@ -24,6 +24,8 @@ path = "src/lib.rs"
 
 [patch.crates-io]
 casper-client = { version = "5", git = "https://github.com/casper-ecosystem/casper-client-rs", branch = "dev" }
-casper-types = { git = "https://github.com/casper-network/casper-node", branch = "dev" }
-casper-binary-port = { git = "https://github.com/casper-network/casper-node", branch = "dev" }
-casper-binary-port-access = { git = "https://github.com/gRoussac/casper-binary-port-client", branch = "casper_2.2.0" }
+# Same temporary pin as root Cargo.toml — see comment there. Revert to
+# branch = "dev" once casper-node/dev bumps past 2.2.0.
+casper-types = { git = "https://github.com/casper-network/casper-node", tag = "v2.2.2" }
+casper-binary-port = { git = "https://github.com/casper-network/casper-node", tag = "v2.2.2" }
+casper-binary-port-access = { git = "https://github.com/gRoussac/casper-binary-port-client", branch = "casper_2.2.2" }


### PR DESCRIPTION
## Summary
- Pin `[patch.crates-io]` `casper-types` / `casper-binary-port` to casper-node **`tag = v2.2.2`** (and binary-port-access `casper_2.2.2`) because [casper-node/dev `node/Cargo.toml` still says `version = "2.2.0"`](https://github.com/casper-network/casper-node/blob/dev/node/Cargo.toml#L3)
- Bump SDK / examples / docs / Docker `APP_VERSION` from **2.2.0 → 2.2.2**
- Comment in `Cargo.toml` that this is **not** a normal `branch = "dev"` pin until that line is updated

## Test plan
- [ ] CI `cargo` / tests resolve patches from `tag=v2.2.2`
- [ ] After merge, Docker push reports `APP_VERSION=2.2.2`
- [ ] When casper-node/dev bumps past 2.2.0, revert patches to `branch = "dev"`


Made with [Cursor](https://cursor.com)