### PR TITLE
ci: stop pushing Docker images to gregoshop

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
+          username: ${{ secrets.DOCKER_USERNAME_ITC }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Build Docker images for dev
@@ -32,14 +32,12 @@ jobs:
             --build-arg GIT_SHA="${{ github.sha }}"
 
           for image in casper-webclient cors-anywhere ws-proxy; do
-            docker tag "${image}:latest" "${{ secrets.DOCKER_USERNAME }}/${image}:latest"
             docker tag "${image}:latest" "${{ secrets.DOCKER_USERNAME_ITC }}/${image}:latest"
           done
 
       - name: Push Docker images to Docker Hub
         run: |
           for image in casper-webclient cors-anywhere ws-proxy; do
-            docker push "${{ secrets.DOCKER_USERNAME }}/${image}:latest"
             docker push "${{ secrets.DOCKER_USERNAME_ITC }}/${image}:latest"
           done
 


### PR DESCRIPTION
## Summary
- Drop Hub tag/push for `DOCKER_USERNAME` (gregoshop) while gregoshop images are archived
- Login and push only under `DOCKER_USERNAME_ITC` (interchouette) for `casper-webclient`, `cors-anywhere`, and `ws-proxy`

## Test plan
- [ ] Confirm `DOCKER_USERNAME_ITC` / `DOCKER_PASSWORD` secrets still work
- [ ] Run **CI/CD Image dev** (workflow_dispatch or push to `dev`) and verify only `interchouette/*:latest` is pushed
- [ ] Confirm Render redeploy step still runs after a successful push


Made with [Cursor](https://cursor.com)