### PR TITLE
fix(ci): Docker Hub login as user + login-action v4

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -18,10 +18,11 @@ jobs:
       - name: Set up Make
         run: sudo apt-get install -y make
 
+      # Login as a Hub user with write access to the interchouette org namespace.
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
-          username: ${{ secrets.DOCKER_USERNAME_ITC }}
+          username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Build Docker images for dev


### PR DESCRIPTION
## Summary
- Log in with `DOCKER_USERNAME` (user with org write access), not `DOCKER_USERNAME_ITC` (org namespace).
- Bump `docker/login-action` to v4 so the action runs on Node 24 and drops the Node 20 deprecation warning.
- Keep tag/push only to `interchouette/...`.

## Test plan
- [ ] CI/CD Image dev succeeds on merge to `dev` at Log in to Docker Hub
- [ ] Images push to `interchouette/{casper-webclient,cors-anywhere,ws-proxy}:latest`
- [ ] No Node 20 deprecation warning from `docker/login-action`


Made with [Cursor](https://cursor.com)