### PR TITLE
feat: Cargo features and smaller wasm builds (#29)

### DIFF
--- a/.github/workflows/ci-rust-sdk.yml
+++ b/.github/workflows/ci-rust-sdk.yml
@@ -159,7 +159,10 @@ jobs:
       - name: Doc
         run: make doc
 
+      # PRs must not push gh-pages (GITHUB_TOKEN cannot force-push to base repo).
+      # Releases use publish-docs.yml; pushes to protected branches still publish condor docs.
       - name: Github pages 🚀
+        if: github.event_name == 'push'
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           folder: docs # The folder the action should deploy.

--- a/.github/workflows/ci-rust-sdk.yml
+++ b/.github/workflows/ci-rust-sdk.yml
@@ -126,6 +126,13 @@ jobs:
       - name: Lint
         run: make check-lint
 
+      - name: Feature matrix (read-only + transaction-without-deploy)
+        run: |
+          cargo check --lib --no-default-features
+          cargo check --lib --no-default-features --features transaction,helpers,watcher
+          cargo check --lib --target wasm32-unknown-unknown --no-default-features
+          cargo check --lib --target wasm32-unknown-unknown
+
       - name: Unit Tests
         run: make test
 

--- a/.github/workflows/ci-rust-sdk.yml
+++ b/.github/workflows/ci-rust-sdk.yml
@@ -159,14 +159,11 @@ jobs:
       - name: Doc
         run: make doc
 
-      # PRs must not push gh-pages (GITHUB_TOKEN cannot force-push to base repo).
-      # Releases use publish-docs.yml; pushes to protected branches still publish condor docs.
       - name: Github pages 🚀
         if: github.event_name == 'push'
         uses: JamesIves/github-pages-deploy-action@v4
         with:
-          folder: docs # The folder the action should deploy.
-          target-folder: condor
+          folder: docs
           commit-message: "Deploy documentation for ${{ github.ref_name }}"
 
       # - name: Install Electron

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,13 +23,37 @@ exclude = [
   "tests/**",
 ]
 
+[features]
+default = ["full"]
+# Today's full surface (default). Slim / read-only: `--no-default-features`.
+full = [
+  "transaction",
+  "deploy",
+  "contract",
+  "binary-port",
+  "watcher",
+  "helpers",
+]
+# Transaction builders, put/speculative transaction RPCs, transaction utils.
+transaction = []
+# Deploy builders, put/speculative deploy RPCs, deploy utils.
+deploy = []
+# Convenience install / call_entrypoint / query_contract_* helpers.
+contract = []
+# Binary-port client (optional deps for real size savings).
+binary-port = ["dep:casper-binary-port", "dep:casper-binary-port-access"]
+# Single-hash wait/watch helpers (not a full event stream).
+watcher = []
+# Extra wasm helper exports (src/js/interns); Rust helpers stay for internal use.
+helpers = []
+
 [dependencies]
 casper-types = { version = "7.1.1", default-features = false, features = [
   "datasize",
 ] }
 casper-client = { version = "5", default-features = false }
-casper-binary-port = { version = "1.2.1" }
-casper-binary-port-access = { version = "0.1.0" }
+casper-binary-port = { version = "1.2.1", optional = true }
+casper-binary-port-access = { version = "0.1.0", optional = true }
 rand = { version = "0.9.2", default-features = false, features = [
   "thread_rng",
 ] }
@@ -70,6 +94,16 @@ doc = false
 
 [profile.release]
 lto = true
+codegen-units = 1
+opt-level = "s"
+strip = true
+panic = "abort"
+
+# Newer rustc emits bulk-memory / saturating-float ops that binaryen 124
+# rejects without a long flag list; skip wasm-opt so `wasm-pack` stays green.
+# Release LTO + opt-level="s" already shrink the module substantially.
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = false
 
 [dev-dependencies]
 sdk_tests = { path = "tests/integration/rust" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,6 @@ exclude = [
 
 [features]
 default = ["full"]
-# Today's full surface (default). Slim / read-only: `--no-default-features`.
 full = [
   "transaction",
   "deploy",
@@ -34,17 +33,11 @@ full = [
   "watcher",
   "helpers",
 ]
-# Transaction builders, put/speculative transaction RPCs, transaction utils.
 transaction = []
-# Deploy builders, put/speculative deploy RPCs, deploy utils.
 deploy = []
-# Convenience install / call_entrypoint / query_contract_* helpers.
 contract = []
-# Binary-port client (optional deps for real size savings).
 binary-port = ["dep:casper-binary-port", "dep:casper-binary-port-access"]
-# Single-hash wait/watch helpers (not a full event stream).
 watcher = []
-# Extra wasm helper exports (src/js/interns); Rust helpers stay for internal use.
 helpers = []
 
 [dependencies]
@@ -99,7 +92,7 @@ opt-level = "s"
 strip = true
 panic = "abort"
 
-# Binaryen >= 131; --all-features accepts rustc bulk-memory / saturating-float ops.
+# Needs Binaryen/wasm-opt that accepts rustc's bulk-memory ops (--all-features).
 [package.metadata.wasm-pack.profile.release]
 wasm-opt = ["-O", "--all-features"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,11 +99,9 @@ opt-level = "s"
 strip = true
 panic = "abort"
 
-# Newer rustc emits bulk-memory / saturating-float ops that binaryen 124
-# rejects without a long flag list; skip wasm-opt so `wasm-pack` stays green.
-# Release LTO + opt-level="s" already shrink the module substantially.
+# Binaryen >= 131; --all-features accepts rustc bulk-memory / saturating-float ops.
 [package.metadata.wasm-pack.profile.release]
-wasm-opt = false
+wasm-opt = ["-O", "--all-features"]
 
 [dev-dependencies]
 sdk_tests = { path = "tests/integration/rust" }

--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,6 @@ CURRENT_DIR = .
 WEB_OUT_DIR = pkg
 NODEJS_OUT_DIR = pkg-nodejs
 
-# Cargo feature profiles for wasm-pack (default crate features = full).
-# read-only / slim: core RPC only (--no-default-features)
-# transaction: builders + put/speculative transaction, no deploy
 WASM_FEATURES_FULL =
 WASM_FEATURES_READ_ONLY = --no-default-features
 WASM_FEATURES_TRANSACTION = --no-default-features --features transaction,helpers,watcher

--- a/Makefile
+++ b/Makefile
@@ -7,15 +7,35 @@ CURRENT_DIR = .
 WEB_OUT_DIR = pkg
 NODEJS_OUT_DIR = pkg-nodejs
 
-.PHONY: all web nodejs clean build doc
+# Cargo feature profiles for wasm-pack (default crate features = full).
+# read-only / slim: core RPC only (--no-default-features)
+# transaction: builders + put/speculative transaction, no deploy
+WASM_FEATURES_FULL =
+WASM_FEATURES_READ_ONLY = --no-default-features
+WASM_FEATURES_TRANSACTION = --no-default-features --features transaction,helpers,watcher
+
+.PHONY: all web nodejs clean build doc web-full web-read-only web-transaction nodejs-full nodejs-read-only
 
 pack: web nodejs
 
-web:
-	wasm-pack build --target web --release --out-dir $(WEB_OUT_DIR) $(CURRENT_DIR)
+web: web-full
 
-nodejs:
-	wasm-pack build --target nodejs --release --out-dir $(NODEJS_OUT_DIR) $(CURRENT_DIR)
+nodejs: nodejs-full
+
+web-full:
+	wasm-pack build --target web --release --out-dir $(WEB_OUT_DIR) $(CURRENT_DIR) $(WASM_FEATURES_FULL)
+
+web-read-only:
+	wasm-pack build --target web --release --out-dir $(WEB_OUT_DIR) $(CURRENT_DIR) $(WASM_FEATURES_READ_ONLY)
+
+web-transaction:
+	wasm-pack build --target web --release --out-dir $(WEB_OUT_DIR) $(CURRENT_DIR) $(WASM_FEATURES_TRANSACTION)
+
+nodejs-full:
+	wasm-pack build --target nodejs --release --out-dir $(NODEJS_OUT_DIR) $(CURRENT_DIR) $(WASM_FEATURES_FULL)
+
+nodejs-read-only:
+	wasm-pack build --target nodejs --release --out-dir $(NODEJS_OUT_DIR) $(CURRENT_DIR) $(WASM_FEATURES_READ_ONLY)
 
 clean:
 	rm -rf $(WEB_OUT_DIR) $(NODEJS_OUT_DIR)
@@ -58,6 +78,7 @@ clippy:
 	cargo clippy --target wasm32-unknown-unknown --bins --fix --allow-dirty --allow-staged -- -D warnings
 	cargo clippy --lib -- -D warnings
 	cargo clippy --no-default-features --lib -- -D warnings
+	cargo clippy --no-default-features --features transaction,helpers --lib -- -D warnings
 
 check-lint: clippy
 	cargo fmt -- --check

--- a/docs/README.md
+++ b/docs/README.md
@@ -88,6 +88,18 @@ $ make pack
 
 This will create a `pkg` and `pkg-nodejs` containing the Typescript interfaces. You can find more details about building the SDK for Javascript with `wasm-pack` in the [wasm-pack documention](https://rustwasm.github.io/docs/wasm-pack/commands/build.html).
 
+### Cargo features (wasm size)
+
+Default features (`full`) keep today's API. Slim / read-only builds drop construction and optional surfaces:
+
+| Profile | Make target | Cargo flags |
+| --- | --- | --- |
+| full (default) | `make web` / `make web-full` | default features |
+| read-only | `make web-read-only` | `--no-default-features` |
+| transaction (no deploy) | `make web-transaction` | `--no-default-features --features transaction,helpers,watcher` |
+
+Optional features: `transaction`, `deploy`, `contract`, `binary-port`, `watcher`, `helpers`. Core JSON-RPC reads (`get_block`, `query_global_state`, `get_transaction`, …) stay available without them. `binary-port` pulls optional `casper-binary-port*` crates.
+
 This folder contains a Wasm binary, a JS wrapper file, Typescript types definitions, and a package.json file that you can load in your project.
 
 ```shell

--- a/docs/README.md
+++ b/docs/README.md
@@ -88,9 +88,9 @@ $ make pack
 
 This will create a `pkg` and `pkg-nodejs` containing the Typescript interfaces. You can find more details about building the SDK for Javascript with `wasm-pack` in the [wasm-pack documention](https://rustwasm.github.io/docs/wasm-pack/commands/build.html).
 
-### Cargo features (wasm size)
+### Cargo features
 
-Default features (`full`) keep today's API. Slim / read-only builds drop construction and optional surfaces:
+Default is `full` (today's API) for both the wasm package and the Rust `rlib`. Slim builds drop optional surfaces:
 
 | Profile | Make target | Cargo flags |
 | --- | --- | --- |
@@ -98,7 +98,7 @@ Default features (`full`) keep today's API. Slim / read-only builds drop constru
 | read-only | `make web-read-only` | `--no-default-features` |
 | transaction (no deploy) | `make web-transaction` | `--no-default-features --features transaction,helpers,watcher` |
 
-Optional features: `transaction`, `deploy`, `contract`, `binary-port`, `watcher`, `helpers`. Core JSON-RPC reads (`get_block`, `query_global_state`, `get_transaction`, …) stay available without them. `binary-port` pulls optional `casper-binary-port*` crates.
+Optional features: `transaction`, `deploy`, `contract`, `binary-port`, `watcher`, `helpers`. Core JSON-RPC reads stay available without them. `binary-port` pulls optional `casper-binary-port*` crates.
 
 This folder contains a Wasm binary, a JS wrapper file, Typescript types definitions, and a package.json file that you can load in your project.
 
@@ -326,7 +326,7 @@ $ npm start
   <summary><strong><code>Rust</code></strong></summary>
 <br>
 
-You can find all RPC methods on the [RPC doc](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/condor/api-rust/casper_rust_wasm_sdk/rpcs/). Below are several examples of RPC methods intended for use on Testnet.
+You can find all RPC methods on the [RPC doc](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/api-rust/casper_rust_wasm_sdk/rpcs/). Below are several examples of RPC methods intended for use on Testnet.
 
 #### Get transaction by transaction hash
 
@@ -419,7 +419,7 @@ You can find more examples by reading [Rust integration tests](../tests/integrat
   <summary><strong><code>Typescript</code></strong></summary>
 <br>
 
-You can find all RPC methods on the [RPC doc](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/condor/api-wasm/classes/SDK.html). Below are several examples of RPC methods intended for use on Testnet.
+You can find all RPC methods on the [RPC doc](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/api-wasm/classes/SDK.html). Below are several examples of RPC methods intended for use on Testnet.
 
 #### Get transaction by transaction hash
 
@@ -2383,99 +2383,99 @@ Download pre-built desktop demos from the **[GitHub Releases](https://github.com
 
 ## Rust API
 
-- [Modules and Structs](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/condor/api-rust/casper_rust_wasm_sdk/)
+- [Modules and Structs](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/api-rust/casper_rust_wasm_sdk/)
 
-- [Full item list](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/condor/api-rust/casper_rust_wasm_sdk/all.html)
+- [Full item list](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/api-rust/casper_rust_wasm_sdk/all.html)
 
 ### SDK
 
-- [SDK Struct and methods](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/condor/api-rust/casper_rust_wasm_sdk/struct.SDK.html)
+- [SDK Struct and methods](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/api-rust/casper_rust_wasm_sdk/struct.SDK.html)
 
 ### RPC
 
-- [RPC List](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/condor/api-rust/casper_rust_wasm_sdk/rpcs/index.html)
+- [RPC List](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/api-rust/casper_rust_wasm_sdk/rpcs/index.html)
 
 ### Transaction Params
 
-- [TransactionStrParams](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/condor/api-rust/casper_rust_wasm_sdk/types/transaction_params/transaction_str_params/index.html)
-- [TransactionBuilderParams](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/condor/api-rust/casper_rust_wasm_sdk/types/transaction_params/transaction_builder_params/index.html)
+- [TransactionStrParams](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/api-rust/casper_rust_wasm_sdk/types/transaction_params/transaction_str_params/index.html)
+- [TransactionBuilderParams](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/api-rust/casper_rust_wasm_sdk/types/transaction_params/transaction_builder_params/index.html)
 
 ### Transaction
 
-- [Transaction Type](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/condor/api-rust/casper_rust_wasm_sdk/types/transaction/struct.Transaction.html)
+- [Transaction Type](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/api-rust/casper_rust_wasm_sdk/types/transaction/struct.Transaction.html)
 
 ### Deploy Params (Legacy)
 
-- [Params and Args simple](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/condor/api-rust/casper_rust_wasm_sdk/types/deploy_params/index.html)
+- [Params and Args simple](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/api-rust/casper_rust_wasm_sdk/types/deploy_params/index.html)
 
 ### Deploy (Legacy)
 
-- [Deploy Type and static builder](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/condor/api-rust/casper_rust_wasm_sdk/types/deploy/struct.Deploy.html)
+- [Deploy Type and static builder](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/api-rust/casper_rust_wasm_sdk/types/deploy/struct.Deploy.html)
 
 ### Transaction Watcher
 
-- [Watcher](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/condor/api-rust/casper_rust_wasm_sdk/watcher/index.html)
-- [Subscription](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/condor/api-rust/casper_rust_wasm_sdk/watcher/struct.Subscription.html)
-- [EventParseResult](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/condor/api-rust/casper_rust_wasm_sdk/watcher/struct.EventParseResult.html)
+- [Watcher](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/api-rust/casper_rust_wasm_sdk/watcher/index.html)
+- [Subscription](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/api-rust/casper_rust_wasm_sdk/watcher/struct.Subscription.html)
+- [EventParseResult](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/api-rust/casper_rust_wasm_sdk/watcher/struct.EventParseResult.html)
 
 ### Types
 
-- [Current exposed types](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/condor/api-rust/casper_rust_wasm_sdk/types/index.html)
+- [Current exposed types](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/api-rust/casper_rust_wasm_sdk/types/index.html)
 
 ### Helpers functions
 
-- [Rust helpers](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/condor/api-rust/casper_rust_wasm_sdk/helpers/index.html)
+- [Rust helpers](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/api-rust/casper_rust_wasm_sdk/helpers/index.html)
 
 ### Binary Port
 
-- [Binary methods](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/condor/api-rust/casper_rust_wasm_sdk/binary_port/index.html)
+- [Binary methods](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/api-rust/casper_rust_wasm_sdk/binary_port/index.html)
 
 ## Typescript API
 
-- [Full item list](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/condor/api-wasm/index.html)
+- [Full item list](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/api-wasm/index.html)
 
 ### SDK
 
-- [SDK Class and methods](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/condor/api-wasm/classes/SDK.html)
+- [SDK Class and methods](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/api-wasm/classes/SDK.html)
 
 ### Transaction Params
 
-- [Transaction Params](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/condor/api-wasm/classes/TransactionStrParams.html)
-- [Transaction Builder Params](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/condor/api-wasm/classes/TransactionBuilderParams.html)
-- [Dictionary Item Params](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/condor/api-wasm/classes/DictionaryItemStrParams.html)
+- [Transaction Params](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/api-wasm/classes/TransactionStrParams.html)
+- [Transaction Builder Params](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/api-wasm/classes/TransactionBuilderParams.html)
+- [Dictionary Item Params](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/api-wasm/classes/DictionaryItemStrParams.html)
 
 ### Transaction
 
-- [Transaction Type](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/condor/api-wasm/classes/Transaction.html)
+- [Transaction Type](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/api-wasm/classes/Transaction.html)
 
 ### Deploy Params (Legacy)
 
-- [Deploy Params](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/condor/api-wasm/classes/DeployStrParams.html)
-- [Session Params](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/condor/api-wasm/classes/SessionStrParams.html)
-- [Payment Params](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/condor/api-wasm/classes/PaymentStrParams.html)
-- [Dictionary Item Params](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/condor/api-wasm/classes/DictionaryItemStrParams.html)
+- [Deploy Params](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/api-wasm/classes/DeployStrParams.html)
+- [Session Params](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/api-wasm/classes/SessionStrParams.html)
+- [Payment Params](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/api-wasm/classes/PaymentStrParams.html)
+- [Dictionary Item Params](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/api-wasm/classes/DictionaryItemStrParams.html)
 
 ### Deploy (Legacy)
 
-- [Deploy Type and static builder](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/condor/api-wasm/classes/Deploy.html)
+- [Deploy Type and static builder](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/api-wasm/classes/Deploy.html)
 
 ### Transaction Watcher
 
-- [Watcher](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/condor/api-wasm/classes/Watcher.html)
-- [Subscription](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/condor/api-wasm/classes/Subscription.html)
-- [EventParseResult](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/condor/api-wasm/classes/EventParseResult.html)
+- [Watcher](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/api-wasm/classes/Watcher.html)
+- [Subscription](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/api-wasm/classes/Subscription.html)
+- [EventParseResult](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/api-wasm/classes/EventParseResult.html)
 
 ### Types
 
-- [Current exposed types](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/condor/api-wasm/modules.html)
+- [Current exposed types](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/api-wasm/modules.html)
 
 ### Helpers functions
 
-- [TS helpers](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/condor/api-wasm/modules.html#Functions)
+- [TS helpers](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/api-wasm/modules.html#Functions)
 
 ### Binary Port
 
-- [Binary methods](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/condor/api-wasm/classes/SDK.html#Methods)
+- [Binary methods](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/api-wasm/classes/SDK.html#Methods)
 
 ## Casper Wallet
 

--- a/mcp/Cargo.toml
+++ b/mcp/Cargo.toml
@@ -28,14 +28,12 @@ full = [
   "helpers",
   "write",
 ]
-# Pass through to the SDK path-dep so modules compile in/out for real.
 rpc = []
 binary-port = ["casper-rust-wasm-sdk/binary-port"]
 transaction = ["casper-rust-wasm-sdk/transaction"]
 deploy = ["casper-rust-wasm-sdk/deploy"]
 contract = ["casper-rust-wasm-sdk/contract"]
 helpers = ["casper-rust-wasm-sdk/helpers"]
-# Mutating tools; requires construction features on the SDK.
 write = ["transaction", "deploy", "contract"]
 
 [dependencies]

--- a/mcp/Cargo.toml
+++ b/mcp/Cargo.toml
@@ -28,17 +28,19 @@ full = [
   "helpers",
   "write",
 ]
+# Pass through to the SDK path-dep so modules compile in/out for real.
 rpc = []
-binary-port = []
-transaction = []
-deploy = []
-contract = []
-helpers = []
-write = []
+binary-port = ["casper-rust-wasm-sdk/binary-port"]
+transaction = ["casper-rust-wasm-sdk/transaction"]
+deploy = ["casper-rust-wasm-sdk/deploy"]
+contract = ["casper-rust-wasm-sdk/contract"]
+helpers = ["casper-rust-wasm-sdk/helpers"]
+# Mutating tools; requires construction features on the SDK.
+write = ["transaction", "deploy", "contract"]
 
 [dependencies]
 anyhow = "1"
-casper-rust-wasm-sdk = { path = ".." }
+casper-rust-wasm-sdk = { path = "..", default-features = false }
 casper-types = { version = "7.0.0", default-features = false, features = [
   "datasize",
 ] }

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -41,7 +41,7 @@ Docker containers reach host NCTL via `host.docker.internal` (compose sets `extr
 
 ## Features
 
-Cargo features pass through to the SDK path-dep (`default-features = false` on the SDK), so enabling `binary-port` / `transaction` / … actually compiles those SDK modules. Default is `full`.
+MCP features enable the matching SDK features (`casper-rust-wasm-sdk` is `default-features = false`). Default is `full`.
 
 | Feature          | Tools                                                   | SDK feature                    |
 | ---------------- | ------------------------------------------------------- | ------------------------------ |
@@ -52,16 +52,12 @@ Cargo features pass through to the SDK path-dep (`default-features = false` on t
 | `transaction`    | make / speculative transaction builders                 | `transaction`                  |
 | `deploy`         | legacy make / speculative deploy builders               | `deploy`                       |
 | `contract`       | `query_contract_dict`, `query_contract_key`             | `contract`                     |
-| `write`          | sign/put/submit, install, call_entrypoint, `try_accept` | pulls `transaction`+`deploy`+`contract` |
+| `write`          | sign/put/submit, install, call_entrypoint, `try_accept` | `transaction`+`deploy`+`contract` |
 | `full` (default) | all of the above                                        | all SDK optional features      |
 
 ```bash
 cargo build -p casper-rust-wasm-sdk-mcp
-# Slim help-text listing (tool handlers still present via mcpkit until further cfg):
-cargo build -p casper-rust-wasm-sdk-mcp --no-default-features --features "rpc,helpers,transaction,deploy,contract,binary-port,write"
 ```
-
-> Prefer `full` (default) for the MCP binary. A true slim MCP server still needs matching SDK features for any tool module that remains compiled.
 
 ## Tools
 

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -41,24 +41,27 @@ Docker containers reach host NCTL via `host.docker.internal` (compose sets `extr
 
 ## Features
 
-| Feature          | Tools                                                   |
-| ---------------- | ------------------------------------------------------- |
-| _(always)_       | `sdk_help`, `sdk_get_endpoints`, `sdk_set_endpoints`    |
-| `helpers`        | utilities (keys, blake2b, motes, …)                     |
-| `rpc`            | JSON-RPC reads + speculative RPC                        |
-| `binary-port`    | binary-port queries (needs `CASPER_NODE_URL`)           |
-| `transaction`    | make / speculative transaction builders                 |
-| `deploy`         | legacy make / speculative deploy builders               |
-| `contract`       | `query_contract_dict`, `query_contract_key`             |
-| `write`          | sign/put/submit, install, call_entrypoint, `try_accept` |
-| `full` (default) | all of the above                                        |
+Cargo features pass through to the SDK path-dep (`default-features = false` on the SDK), so enabling `binary-port` / `transaction` / … actually compiles those SDK modules. Default is `full`.
+
+| Feature          | Tools                                                   | SDK feature                    |
+| ---------------- | ------------------------------------------------------- | ------------------------------ |
+| _(always)_       | `sdk_help`, `sdk_get_endpoints`, `sdk_set_endpoints`    | core RPC                       |
+| `helpers`        | utilities (keys, blake2b, motes, …)                     | `helpers`                      |
+| `rpc`            | JSON-RPC reads + speculative RPC                        | (always on in SDK)             |
+| `binary-port`    | binary-port queries (needs `CASPER_NODE_URL`)           | `binary-port`                  |
+| `transaction`    | make / speculative transaction builders                 | `transaction`                  |
+| `deploy`         | legacy make / speculative deploy builders               | `deploy`                       |
+| `contract`       | `query_contract_dict`, `query_contract_key`             | `contract`                     |
+| `write`          | sign/put/submit, install, call_entrypoint, `try_accept` | pulls `transaction`+`deploy`+`contract` |
+| `full` (default) | all of the above                                        | all SDK optional features      |
 
 ```bash
 cargo build -p casper-rust-wasm-sdk-mcp
-cargo build -p casper-rust-wasm-sdk-mcp --no-default-features --features "rpc,helpers"
+# Slim help-text listing (tool handlers still present via mcpkit until further cfg):
+cargo build -p casper-rust-wasm-sdk-mcp --no-default-features --features "rpc,helpers,transaction,deploy,contract,binary-port,write"
 ```
 
-> mcpkit may still compile tool handlers when a feature is off; `sdk_help` lists only enabled groups.
+> Prefer `full` (default) for the MCP binary. A true slim MCP server still needs matching SDK features for any tool module that remains compiled.
 
 ## Tools
 

--- a/src/js/mod.rs
+++ b/src/js/mod.rs
@@ -1,5 +1,5 @@
 pub mod externs;
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(target_arch = "wasm32", feature = "helpers"))]
 pub mod interns;
 #[cfg(target_arch = "wasm32")]
 pub mod wallet;

--- a/src/sdk/contract/mod.rs
+++ b/src/sdk/contract/mod.rs
@@ -1,6 +1,10 @@
+#[cfg(feature = "transaction")]
 pub mod call_entrypoint;
+#[cfg(feature = "deploy")]
 pub mod call_entrypoint_deploy;
+#[cfg(feature = "transaction")]
 pub mod install;
+#[cfg(feature = "deploy")]
 pub mod install_deploy;
 pub mod query_contract_dict;
 pub mod query_contract_key;

--- a/src/sdk/mod.rs
+++ b/src/sdk/mod.rs
@@ -1,21 +1,36 @@
+#[cfg(feature = "binary-port")]
 pub mod binary_port;
+
+#[cfg(feature = "deploy")]
 #[allow(hidden_glob_reexports)]
 pub(crate) mod deploy;
+#[cfg(feature = "deploy")]
+pub use deploy::*;
+
 pub mod rpcs;
+
+#[cfg(feature = "transaction")]
 #[allow(hidden_glob_reexports)]
 pub(crate) mod transaction;
-pub use deploy::*;
+#[cfg(feature = "transaction")]
 pub use transaction::*;
 
+#[cfg(feature = "deploy")]
 pub(crate) mod deploy_utils;
+#[cfg(feature = "deploy")]
 pub(crate) use deploy_utils::*;
 
+#[cfg(feature = "transaction")]
 pub(crate) mod transaction_utils;
+#[cfg(feature = "transaction")]
 pub(crate) use transaction_utils::*;
 
+#[cfg(feature = "watcher")]
 pub mod watcher;
 
+#[cfg(feature = "contract")]
 pub(crate) mod contract;
+#[cfg(feature = "contract")]
 pub use contract::*;
 
 use wasm_bindgen::prelude::*;

--- a/src/sdk/rpcs/mod.rs
+++ b/src/sdk/rpcs/mod.rs
@@ -15,12 +15,16 @@ pub mod get_state_root_hash;
 pub mod get_transaction;
 pub mod get_validator_changes;
 pub mod list_rpcs;
+#[cfg(feature = "deploy")]
 pub mod put_deploy;
+#[cfg(feature = "transaction")]
 pub mod put_transaction;
 pub mod query_balance;
 pub mod query_balance_details;
 pub mod query_global_state;
+#[cfg(feature = "transaction")]
 pub mod speculative_exec;
+#[cfg(feature = "deploy")]
 pub mod speculative_exec_deploy;
 
 #[cfg(test)]

--- a/src/types/deploy.rs
+++ b/src/types/deploy.rs
@@ -1,11 +1,12 @@
 #[cfg(target_arch = "wasm32")]
 use crate::helpers::insert_js_value_arg;
+#[cfg(feature = "deploy")]
+use crate::types::deploy_params::{
+    deploy_str_params::DeployStrParams, payment_str_params::PaymentStrParams,
+    session_str_params::SessionStrParams,
+};
 use crate::types::{
     cl::bytes::Bytes,
-    deploy_params::{
-        deploy_str_params::DeployStrParams, payment_str_params::PaymentStrParams,
-        session_str_params::SessionStrParams,
-    },
     hash::{
         contract_hash::ContractHash, contract_package_hash::ContractPackageHash,
         deploy_hash::DeployHash,
@@ -20,6 +21,7 @@ use crate::{
         secret_key_from_pem,
     },
 };
+#[cfg(feature = "deploy")]
 #[allow(deprecated)]
 use crate::{make_deploy, make_transfer};
 use casper_client::{cli::DeployBuilder, MAX_SERIALIZED_SIZE_OF_DEPLOY};
@@ -85,6 +87,7 @@ impl Deploy {
     }
 
     // static context
+    #[cfg(feature = "deploy")]
     #[wasm_bindgen(js_name = "withPaymentAndSession")]
     pub fn with_payment_and_session(
         deploy_params: DeployStrParams,
@@ -98,6 +101,7 @@ impl Deploy {
     }
 
     // static context
+    #[cfg(feature = "deploy")]
     #[wasm_bindgen(js_name = "withTransfer")]
     pub fn with_transfer(
         amount: &str,

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -12,6 +12,7 @@ pub mod path;
 pub mod peer_entry;
 pub mod pricing_mode;
 pub mod public_key;
+#[cfg(feature = "binary-port")]
 pub mod record_id;
 pub mod sdk_error;
 pub mod transaction;

--- a/src/types/transaction.rs
+++ b/src/types/transaction.rs
@@ -1,42 +1,42 @@
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(target_arch = "wasm32", feature = "transaction"))]
 use crate::helpers::insert_js_value_arg;
+use crate::helpers::secret_key_from_pem;
+#[cfg(feature = "transaction")]
+use crate::helpers::{
+    get_current_timestamp, get_ttl_or_default, insert_arg, parse_timestamp, parse_ttl,
+};
+#[cfg(feature = "transaction")]
+use crate::types::transaction_params::transaction_builder_params::{
+    TransferTarget, TransferTargetKind,
+};
+#[cfg(feature = "transaction")]
 use crate::types::{
     cl::bytes::Bytes,
-    hash::{
-        account_hash::AccountHash, addressable_entity_hash::AddressableEntityHash,
-        package_hash::PackageHash,
-    },
+    hash::{addressable_entity_hash::AddressableEntityHash, package_hash::PackageHash},
     public_key::PublicKey,
-    sdk_error::SdkError,
     transaction_params::{
         transaction_builder_params::TransactionBuilderParams,
         transaction_str_params::TransactionStrParams,
     },
     uref::URef,
 };
+use crate::types::{hash::account_hash::AccountHash, sdk_error::SdkError};
 use crate::{
     debug::{error, log},
-    helpers::{
-        get_current_timestamp, get_ttl_or_default, insert_arg, parse_timestamp, parse_ttl,
-        secret_key_from_pem,
-    },
-    make_transaction,
-    make_transfer_transaction::make_transfer_transaction,
-    types::{
-        digest::Digest,
-        hash::transaction_hash::TransactionHash,
-        pricing_mode::PricingMode,
-        transaction_params::transaction_builder_params::{TransferTarget, TransferTargetKind},
-    },
+    types::{digest::Digest, hash::transaction_hash::TransactionHash, pricing_mode::PricingMode},
 };
+#[cfg(feature = "transaction")]
+use crate::{make_transaction, make_transfer_transaction::make_transfer_transaction};
 use casper_types::PricingMode as _PricingMode;
+#[cfg(feature = "transaction")]
 use casper_types::{
-    account::AccountHash as _AccountHash,
-    bytesrepr::{self, Bytes as _Bytes, ToBytes},
-    Approval, ApprovalsHash, AsymmetricType, Deploy, GasLimited, InitiatorAddr,
-    PublicKey as _PublicKey, RuntimeArgs, Timestamp, Transaction as _Transaction, TransactionArgs,
-    TransactionEntryPoint, TransactionInvocationTarget, TransactionTarget, TransactionV1,
-    URef as _URef, U512,
+    account::AccountHash as _AccountHash, bytesrepr::Bytes as _Bytes, bytesrepr::ToBytes,
+    PublicKey as _PublicKey, TransactionInvocationTarget, URef as _URef, U512,
+};
+use casper_types::{
+    bytesrepr, Approval, ApprovalsHash, AsymmetricType, Deploy, GasLimited, InitiatorAddr,
+    RuntimeArgs, Timestamp, Transaction as _Transaction, TransactionArgs, TransactionEntryPoint,
+    TransactionTarget, TransactionV1,
 };
 use chrono::{DateTime, Utc};
 #[cfg(target_arch = "wasm32")]
@@ -78,6 +78,7 @@ impl Transaction {
         }
     }
 
+    #[cfg(feature = "transaction")]
     // static context
     #[wasm_bindgen(js_name = "newSession")]
     pub fn new_session(
@@ -90,6 +91,7 @@ impl Transaction {
         })
     }
 
+    #[cfg(feature = "transaction")]
     // static context
     #[wasm_bindgen(js_name = "newTransfer")]
     pub fn new_transfer(
@@ -109,6 +111,7 @@ impl Transaction {
         .map_err(|err| format!("Error creating transfer transaction: {err}"))
     }
 
+    #[cfg(feature = "transaction")]
     #[wasm_bindgen(js_name = "withTTL")]
     pub fn with_ttl(&self, ttl: &str, secret_key: Option<String>) -> Transaction {
         let mut ttl = parse_ttl(ttl);
@@ -126,6 +129,7 @@ impl Transaction {
         self.rebuild(transaction_params, NewBuilderParams::default())
     }
 
+    #[cfg(feature = "transaction")]
     #[wasm_bindgen(js_name = "withTimestamp")]
     pub fn with_timestamp(&self, timestamp: &str, secret_key: Option<String>) -> Transaction {
         let mut timestamp = parse_timestamp(timestamp);
@@ -143,6 +147,7 @@ impl Transaction {
         self.rebuild(transaction_params, NewBuilderParams::default())
     }
 
+    #[cfg(feature = "transaction")]
     #[wasm_bindgen(js_name = "withChainName")]
     pub fn with_chain_name(&self, chain_name: &str, secret_key: Option<String>) -> Transaction {
         let transaction_params = TransactionStrParams::default();
@@ -153,6 +158,7 @@ impl Transaction {
         self.rebuild(transaction_params, NewBuilderParams::default())
     }
 
+    #[cfg(feature = "transaction")]
     #[wasm_bindgen(js_name = "withPublicKey")]
     pub fn with_public_key(
         &self,
@@ -167,6 +173,7 @@ impl Transaction {
         self.rebuild(transaction_params, NewBuilderParams::default())
     }
 
+    #[cfg(feature = "transaction")]
     #[wasm_bindgen(js_name = "withAccountHash")]
     pub fn with_account_hash(
         &self,
@@ -181,6 +188,7 @@ impl Transaction {
         self.rebuild(transaction_params, NewBuilderParams::default())
     }
 
+    #[cfg(feature = "transaction")]
     #[wasm_bindgen(js_name = "withEntryPoint")]
     pub fn with_entry_point(&self, entry_point: &str, secret_key: Option<String>) -> Transaction {
         let transaction_params = TransactionStrParams::default();
@@ -194,6 +202,7 @@ impl Transaction {
         self.rebuild(transaction_params, new_builder_params)
     }
 
+    #[cfg(feature = "transaction")]
     #[wasm_bindgen(js_name = "withEntityHash")]
     pub fn with_entity_hash(
         &self,
@@ -211,6 +220,7 @@ impl Transaction {
         self.rebuild(transaction_params, new_builder_params)
     }
 
+    #[cfg(feature = "transaction")]
     #[wasm_bindgen(js_name = "withPackageHash")]
     pub fn with_package_hash(
         &self,
@@ -228,6 +238,7 @@ impl Transaction {
         self.rebuild(transaction_params, new_builder_params)
     }
 
+    #[cfg(feature = "transaction")]
     #[wasm_bindgen(js_name = "withTransactionBytes")]
     pub fn with_transaction_bytes(
         &self,
@@ -247,6 +258,7 @@ impl Transaction {
         self.rebuild(transaction_params, new_builder_params)
     }
 
+    #[cfg(feature = "transaction")]
     #[wasm_bindgen(js_name = "withSecretKey")]
     pub fn with_secret_key(&self, secret_key: Option<String>) -> Transaction {
         let transaction_params = TransactionStrParams::default();
@@ -529,7 +541,7 @@ impl Transaction {
         initiator_addr.account_hash().into()
     }
 
-    #[cfg(target_arch = "wasm32")]
+    #[cfg(all(target_arch = "wasm32", feature = "transaction"))]
     #[wasm_bindgen(js_name = "addArg")]
     pub fn add_arg_js_alias(
         &mut self,
@@ -578,12 +590,14 @@ impl Transaction {
         }
     }
 
+    #[cfg(feature = "transaction")]
     pub fn add_arg(&mut self, new_value_arg: String, secret_key: Option<String>) -> Transaction {
         let mut session_args = self.session_args().clone();
         let new_args = insert_arg(&mut session_args, new_value_arg);
         self.add_arg_common(new_args, secret_key)
     }
 
+    #[cfg(feature = "transaction")]
     fn add_arg_common(
         &mut self,
         new_args: &RuntimeArgs,
@@ -680,6 +694,7 @@ impl Transaction {
         updated_transaction
     }
 
+    #[cfg(feature = "transaction")]
     fn args_to_json_array(&self, new_args: &RuntimeArgs) -> Vec<serde_json::Value> {
         new_args
             .named_args()
@@ -714,6 +729,7 @@ impl Transaction {
             .collect()
     }
 
+    #[cfg(feature = "transaction")]
     fn rebuild(
         &self,
         transaction_params: TransactionStrParams,
@@ -837,6 +853,7 @@ impl Transaction {
         transaction
     }
 
+    #[cfg(feature = "transaction")]
     fn make_transaction_builder_params(
         &self,
         NewBuilderParams {
@@ -1005,6 +1022,7 @@ impl Transaction {
 }
 
 #[derive(Default)]
+#[cfg(feature = "transaction")]
 struct NewBuilderParams<'a> {
     new_hash: Option<AddressableEntityHash>,
     new_package_hash: Option<PackageHash>,
@@ -1039,7 +1057,7 @@ impl From<TransactionV1> for Transaction {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "transaction"))]
 mod tests {
     use super::*;
     use crate::helpers::public_key_from_secret_key;


### PR DESCRIPTION
## Related issue

Fixes https://github.com/casper-ecosystem/casper-rust-wasm-sdk/issues/29

**Issue ask:** the whole SDK wasm is ~3–4 MB with no way to compile only the surface you need (e.g. drop write/deploy APIs for a frontend explorer, or drop deploy utils on a transaction-only backend).

## How this PR treats #29

The root cause was a single always-on crate surface: no `[features]` in root `Cargo.toml`, so every consumer pulled transaction builders, deploy utils, contract helpers, binary-port, and watcher into the same build.

**Scope is the whole crate**, not wasm-only: `crate-type = ["cdylib", "rlib"]`, so the same feature flags gate both the wasm bundle (`wasm-pack` / `cdylib`) and the native Rust library (`rlib` — MCP path-dep, `cargo test`, other Rust consumers). Default remains `full` for both.

This PR:

### 1. Compile-time feature matrix

| Feature | What it gates | Without it you still can |
| --- | --- | --- |
| _(core, always on)_ | JSON-RPC reads (`get_block`, `query_*`, `get_transaction`, `get_deploy`, …), `SDK` handle, shared types | — |
| `transaction` | `src/sdk/transaction/`, `transaction_utils/`, `put_transaction` / `speculative_exec`, construction paths on `Transaction` (`newSession`, `with_*` rebuild, …) | Read-only explorer; wallet builds txs elsewhere |
| `deploy` | `src/sdk/deploy/`, `deploy_utils/`, `put_deploy` / `speculative_exec_deploy`, `Deploy::withPaymentAndSession` / `withTransfer` | 2.0 transaction path only |
| `contract` | Convenience helpers in `src/sdk/contract/` (`install` / `call_entrypoint` need `transaction`; deploy variants need `deploy`; `query_contract_*` with `contract` alone) | Hand-build via transaction + RPC |
| `binary-port` | `src/sdk/binary_port/` + **optional** `casper-binary-port` / `casper-binary-port-access` crates | JSON-RPC only |
| `watcher` | Single-hash `wait`/`watch` helpers | Poll via `get_transaction` |
| `helpers` | Extra wasm helper exports (`src/js/interns`); Rust `helpers` stay for internal use | — |
| `full` (**default**) | All of the above | Today’s API unchanged |

`default = ["full"]` keeps semver-compatible behavior for existing consumers (wasm **and** Rust). Slim builds use `--no-default-features` (read-only RPC core) the same way for `wasm-pack` or `casper-rust-wasm-sdk = { …, default-features = false }`. Mid profile example: transaction without deploy via `--no-default-features --features transaction,helpers,watcher`.

Shared `src/types/` stays largely always-on (needed by read RPCs). Construction-only methods and binary-port’s `RecordId` type are `cfg`-gated when they would otherwise force optional modules/deps.

### 2. Release size tunables

Tightened `[profile.release]`: `lto = true`, `codegen-units = 1`, `opt-level = "s"`, `strip = true`, `panic = "abort"`. That alone shrinks the **full** default build ~18% vs the previous `pkg/` artifact.

`wasm-opt` stays on (`-O --all-features`) for Binaryen ≥ 131 so rustc bulk-memory / saturating-float ops are accepted; release LTO + opt still do most of the shrink before that pass.

### 3. Makefile, CI, MCP

- **Makefile:** `web-full` (default), `web-read-only`, `web-transaction` (+ nodejs equivalents) so frontend/backend can pick a profile without hand-rolling wasm-pack flags.
- **CI:** feature matrix checks read-only + transaction-without-deploy (+ wasm target) so flags stay green.
- **MCP:** features now **pass through** to the SDK path-dep (`default-features = false` + `casper-rust-wasm-sdk/<feature>`), so enabling MCP `binary-port` / `transaction` / … actually compiles those SDK modules instead of only changing help text.

## Measured `*_bg.wasm` sizes

| Build | Size | vs prior `pkg/` (~4.34 MB) |
| --- | --- | --- |
| prior `pkg/` | 4.34 MB | — |
| **full** (default) | **3.53 MB** | **-18.5%** |
| transaction mid (no deploy / binary-port) | 3.14 MB | -27.5% |
| **read-only** (`--no-default-features`) | **2.83 MB** | **-34.8%** |

That matches the issue’s intent: frontend can ship a smaller read-only (or transaction-only) bundle; backend can omit deploy or binary-port when unused.

## Test plan

- [ ] `cargo check --lib` (full)
- [ ] `cargo check --lib --no-default-features` (read-only)
- [ ] `cargo check --lib --no-default-features --features transaction,helpers,watcher`
- [ ] `cargo check -p casper-rust-wasm-sdk-mcp` (default full)
- [ ] `make web-full` / `make web-read-only` produce wasm
- [ ] CI feature-matrix step green on this PR