### PR TITLE
feat: webclient embeds MCP + /mcp proxy; archive 2.2.2-mcp tag

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -34,13 +34,27 @@ jobs:
 
           for image in casper-webclient cors-anywhere ws-proxy; do
             docker tag "${image}:latest" "${{ secrets.DOCKER_USERNAME_ITC }}/${image}:latest"
+            docker tag "${image}:latest" "${{ secrets.DOCKER_USERNAME_ITC }}/${image}:dev"
           done
+
+          # Slim MCP image (Cursor stdio / dedicated :8790). Tags match crate version.
+          make mcp-docker-build
+          docker tag "interchouette/casper-rust-wasm-sdk-mcp:2.2.2" \
+            "${{ secrets.DOCKER_USERNAME_ITC }}/casper-rust-wasm-sdk-mcp:2.2.2"
+          docker tag "interchouette/casper-rust-wasm-sdk-mcp:latest" \
+            "${{ secrets.DOCKER_USERNAME_ITC }}/casper-rust-wasm-sdk-mcp:latest"
+          docker tag "interchouette/casper-rust-wasm-sdk-mcp:dev" \
+            "${{ secrets.DOCKER_USERNAME_ITC }}/casper-rust-wasm-sdk-mcp:dev"
 
       - name: Push Docker images to Docker Hub
         run: |
           for image in casper-webclient cors-anywhere ws-proxy; do
             docker push "${{ secrets.DOCKER_USERNAME_ITC }}/${image}:latest"
+            docker push "${{ secrets.DOCKER_USERNAME_ITC }}/${image}:dev"
           done
+          docker push "${{ secrets.DOCKER_USERNAME_ITC }}/casper-rust-wasm-sdk-mcp:2.2.2"
+          docker push "${{ secrets.DOCKER_USERNAME_ITC }}/casper-rust-wasm-sdk-mcp:latest"
+          docker push "${{ secrets.DOCKER_USERNAME_ITC }}/casper-rust-wasm-sdk-mcp:dev"
 
       # Render does not watch Hub for new digests — call the service Deploy Hook
       # after a successful push so it pulls interchouette/casper-webclient:latest.

--- a/Makefile
+++ b/Makefile
@@ -124,9 +124,10 @@ docker-deploy-prod:
 .PHONY: docker-build docker-start docker-stop docker-start-prod docker-stop-prod
 
 # --- MCP sidecar (mcp/ — path-depends on casper-rust-wasm-sdk) ---
+# Image tags match the crate version (2.2.2). Legacy :2.2.2-mcp is archived.
 
 MCP_NAME ?= casper-rust-wasm-sdk-mcp
-MCP_VERSION ?= 2.2.2-mcp
+MCP_VERSION ?= 2.2.2
 MCP_IMAGE ?= $(MCP_NAME):$(MCP_VERSION)
 MCP_HUB_IMAGE ?= interchouette/$(MCP_NAME)
 MCP_GHCR_PERSONAL_IMAGE ?= ghcr.io/groussac/$(MCP_NAME)
@@ -141,26 +142,33 @@ mcp-docker-build:
 	DOCKER_BUILDKIT=$(DOCKER_BUILDKIT) docker build --network=host \
 		-t $(MCP_IMAGE) \
 		-t $(MCP_NAME):latest \
+		-t $(MCP_NAME):dev \
 		-t $(MCP_HUB_IMAGE):$(MCP_VERSION) \
 		-t $(MCP_HUB_IMAGE):latest \
+		-t $(MCP_HUB_IMAGE):dev \
 		-f mcp/Dockerfile \
 		.
 
 mcp-docker-push-hub:
 	docker push $(MCP_HUB_IMAGE):$(MCP_VERSION)
 	docker push $(MCP_HUB_IMAGE):latest
+	docker push $(MCP_HUB_IMAGE):dev
 
 mcp-docker-push-ghcr-personal:
 	docker tag $(MCP_HUB_IMAGE):$(MCP_VERSION) $(MCP_GHCR_PERSONAL_IMAGE):$(MCP_VERSION)
 	docker tag $(MCP_HUB_IMAGE):latest $(MCP_GHCR_PERSONAL_IMAGE):latest
+	docker tag $(MCP_HUB_IMAGE):dev $(MCP_GHCR_PERSONAL_IMAGE):dev
 	docker push $(MCP_GHCR_PERSONAL_IMAGE):$(MCP_VERSION)
 	docker push $(MCP_GHCR_PERSONAL_IMAGE):latest
+	docker push $(MCP_GHCR_PERSONAL_IMAGE):dev
 
 mcp-docker-push-ghcr-itc:
 	docker tag $(MCP_HUB_IMAGE):$(MCP_VERSION) $(MCP_GHCR_ORG_IMAGE):$(MCP_VERSION)
 	docker tag $(MCP_HUB_IMAGE):latest $(MCP_GHCR_ORG_IMAGE):latest
+	docker tag $(MCP_HUB_IMAGE):dev $(MCP_GHCR_ORG_IMAGE):dev
 	docker push $(MCP_GHCR_ORG_IMAGE):$(MCP_VERSION)
 	docker push $(MCP_GHCR_ORG_IMAGE):latest
+	docker push $(MCP_GHCR_ORG_IMAGE):dev
 
 mcp-docker-push: mcp-docker-push-hub mcp-docker-push-ghcr-personal mcp-docker-push-ghcr-itc
 

--- a/docker/Dockerfile.cicd
+++ b/docker/Dockerfile.cicd
@@ -1,5 +1,30 @@
 ARG TARGETPLATFORM=linux/amd64
-FROM --platform=${TARGETPLATFORM} node:24-alpine AS build
+
+# --- Rust MCP binary (same crate as mcp/Dockerfile) ---
+ARG RUST_IMAGE=rust:slim-bookworm
+FROM --platform=${TARGETPLATFORM} ${RUST_IMAGE} AS mcp-builder
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    pkg-config \
+    libssl-dev \
+    git \
+    binutils \
+  && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /src
+COPY Cargo.toml Cargo.lock ./
+COPY src ./src
+COPY mcp ./mcp
+COPY tests/integration/rust ./tests/integration/rust
+
+RUN cargo build -p casper-rust-wasm-sdk-mcp --release \
+  && strip -s target/release/casper-rust-wasm-sdk-mcp \
+  && cp target/release/casper-rust-wasm-sdk-mcp /casper-rust-wasm-sdk-mcp
+
+# --- Angular SPA ---
+FROM --platform=${TARGETPLATFORM} node:24-bookworm-slim AS build
 
 ENV NODE_ENV=development
 ARG BUILD_CONFIGURATION=docker
@@ -7,7 +32,6 @@ ENV BUILD_CONFIGURATION=$BUILD_CONFIGURATION
 
 WORKDIR /app
 
-# Update npm to the latest version
 RUN npm install -g npm@latest
 
 COPY ./examples/frontend/angular .
@@ -22,28 +46,36 @@ RUN npm install --ignore-scripts --verbose && npm update
 
 RUN npm run build -- --configuration=$BUILD_CONFIGURATION --verbose
 
-ARG TARGETPLATFORM=linux/amd64
-FROM --platform=${TARGETPLATFORM} node:24-alpine
+# --- Runtime: SPA + optional MCP (ENABLE_MCP=1) ---
+FROM --platform=${TARGETPLATFORM} node:24-bookworm-slim
 
 ARG APP_VERSION=2.2.2
 ARG GIT_SHA=unknown
 ENV PORT=8080
 ENV APP_VERSION=$APP_VERSION
 ENV GIT_SHA=$GIT_SHA
+ENV ENABLE_MCP=1
+ENV ENABLE_MCP_PROXY=1
+ENV CASPER_SDK_MCP_ADDR=127.0.0.1:8790
+ENV MCP_UPSTREAM=http://127.0.0.1:8790
+ENV RUST_LOG=warn
+ENV SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
 
 WORKDIR /app
 
-# Install serve globally (better SPA support with automatic fallback)
-RUN npm install -g serve
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends ca-certificates libssl3 \
+  && rm -rf /var/lib/apt/lists/*
 
 COPY --from=build --chown=node:node /app/dist/casper ./dist/
-
-# Copy and set up entrypoint script
+COPY --from=mcp-builder /casper-rust-wasm-sdk-mcp /usr/local/bin/casper-rust-wasm-sdk-mcp
 COPY --chown=node:node docker/entrypoint.sh /app/entrypoint.sh
-RUN chmod +x /app/entrypoint.sh
+COPY --chown=node:node docker/serve.mjs /app/serve.mjs
+RUN chmod +x /app/entrypoint.sh /usr/local/bin/casper-rust-wasm-sdk-mcp
 
-EXPOSE 8080
+EXPOSE 8080 8790
 
-# Use entrypoint to set BASE_HREF dynamically, then serve
+# web (default): SPA on :8080 + MCP on :8790, /mcp proxied on :8080
+# mcp: run the MCP binary only (stdio or --http)
 ENTRYPOINT ["/app/entrypoint.sh"]
-CMD ["serve", "-s", "/app/dist", "-l", "8080"]
+CMD ["web"]

--- a/docker/docker-compose.cicd.yml
+++ b/docker/docker-compose.cicd.yml
@@ -21,12 +21,19 @@ services:
       # NETWORK_NODE_URL: Optional, overrides selected network's node_address
       # Example: ws://casper-nctl.casper-box:4300/?targetPort=28101&targetHost=...
       - NETWORK_NODE_URL=${NETWORK_NODE_URL:-}
+      # MCP in-process (evaluator-style). DISABLE with ENABLE_MCP=0.
+      - ENABLE_MCP=${ENABLE_MCP:-1}
+      - CASPER_RPC_URL=${CASPER_RPC_URL:-http://host.docker.internal:11101}
+      - CASPER_NODE_URL=${CASPER_NODE_URL:-host.docker.internal:28101}
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     networks:
       - casper-network
 
   # Build and run image with Dockerfile
   # docker build -t casper-webclient . --force-rm
   # docker container run -t -i --rm -h casper-webclient -p 8080:8080 casper-webclient
+  # MCP via same host: http://localhost:8080/mcp
 
   cors-anywhere:
     image: cors-anywhere:latest

--- a/docker/docker-compose.mcp.yml
+++ b/docker/docker-compose.mcp.yml
@@ -1,9 +1,9 @@
-# Slim MCP sidecar (Streamable HTTP on :8790).
+# Slim MCP-only image (stdio / dedicated :8790).
+# Hosted webclient embeds MCP too — use https://casper-webclient.interchouette.net/mcp
 # Use: make mcp-http / make mcp-http-stop
-# Build context is the repo root (SDK path dep + [patch.crates-io]).
 services:
   sdk-mcp:
-    image: ${CASPER_SDK_MCP_IMAGE:-interchouette/casper-rust-wasm-sdk-mcp:2.2.2-mcp}
+    image: ${CASPER_SDK_MCP_IMAGE:-interchouette/casper-rust-wasm-sdk-mcp:2.2.2}
     container_name: casper-rust-wasm-sdk-mcp
     build:
       context: ..
@@ -17,5 +17,5 @@ services:
       CASPER_SDK_MCP_ADDR: "0.0.0.0:8790"
       CASPER_RPC_URL: ${CASPER_RPC_URL:-http://host.docker.internal:11101}
       CASPER_NODE_URL: ${CASPER_NODE_URL:-host.docker.internal:28101}
-      CASPER_VERBOSITY: ${CASPER_VERBOSITY:-low}
       RUST_LOG: ${RUST_LOG:-warn}
+    restart: unless-stopped

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -4,6 +4,10 @@ services:
     container_name: casper-webclient
     ports:
       - "8080:8080"
+    environment:
+      ENABLE_MCP: ${ENABLE_MCP:-1}
+      CASPER_RPC_URL: ${CASPER_RPC_URL:-http://host.docker.internal:11101}
+      CASPER_NODE_URL: ${CASPER_NODE_URL:-host.docker.internal:28101}
     networks:
       - casper-network
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -8,7 +8,10 @@ GIT_SHA=${GIT_SHA:-unknown}
 # Short sha for footer display
 GIT_SHA_SHORT=$(echo "$GIT_SHA" | cut -c1-7)
 
-echo "Entrypoint running. BASE_HREF=$BASE_HREF APP_VERSION=$APP_VERSION GIT_SHA=$GIT_SHA_SHORT"
+ENABLE_MCP=${ENABLE_MCP:-1}
+CASPER_SDK_MCP_ADDR=${CASPER_SDK_MCP_ADDR:-127.0.0.1:8790}
+
+echo "Entrypoint running. BASE_HREF=$BASE_HREF APP_VERSION=$APP_VERSION GIT_SHA=$GIT_SHA_SHORT ENABLE_MCP=$ENABLE_MCP"
 
 INDEX_FILE="/app/dist/index.html"
 CONFIG_FILE="/app/dist/config.js"
@@ -58,5 +61,42 @@ else
   echo "Added <base href> tag: $BASE_HREF"
 fi
 
-# Execute the original command (serve)
-exec "$@"
+mcp_enabled() {
+  [ "$ENABLE_MCP" = "1" ] || [ "$ENABLE_MCP" = "true" ]
+}
+
+start_mcp() {
+  if ! command -v casper-rust-wasm-sdk-mcp >/dev/null 2>&1; then
+    echo "[entrypoint] MCP binary missing; continuing without MCP" >&2
+    return 0
+  fi
+  echo "[entrypoint] starting MCP on ${CASPER_SDK_MCP_ADDR}" >&2
+  casper-rust-wasm-sdk-mcp --http --listen "${CASPER_SDK_MCP_ADDR}" &
+}
+
+# Optional: MCP-only mode (slim Cursor / stdio-adjacent HTTP)
+cmd="${1:-web}"
+if [ "$#" -gt 0 ]; then
+  shift
+fi
+
+case "$cmd" in
+  mcp)
+    exec casper-rust-wasm-sdk-mcp "$@"
+    ;;
+  web | serve)
+    if mcp_enabled; then
+      start_mcp
+      export ENABLE_MCP_PROXY=1
+      export MCP_UPSTREAM="http://${CASPER_SDK_MCP_ADDR}"
+    else
+      echo "[entrypoint] ENABLE_MCP=0 — web only" >&2
+      export ENABLE_MCP_PROXY=0
+    fi
+    exec node /app/serve.mjs
+    ;;
+  *)
+    # Back-compat: raw command (e.g. legacy `serve …`)
+    exec "$cmd" "$@"
+    ;;
+esac

--- a/docker/serve.mjs
+++ b/docker/serve.mjs
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+/**
+ * SPA host + optional MCP proxy (evaluator-style).
+ * Serves /app/dist on PORT (default 8080).
+ * When ENABLE_MCP_PROXY=1, proxies /mcp → http://127.0.0.1:8790/mcp
+ */
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+const { URL } = require('url');
+
+const PORT = Number(process.env.PORT || 8080);
+const DIST = process.env.DIST_DIR || '/app/dist';
+const MCP_UPSTREAM = process.env.MCP_UPSTREAM || 'http://127.0.0.1:8790';
+const ENABLE_MCP_PROXY =
+  process.env.ENABLE_MCP_PROXY === '1' ||
+  process.env.ENABLE_MCP_PROXY === 'true' ||
+  process.env.ENABLE_MCP === '1' ||
+  process.env.ENABLE_MCP === 'true';
+
+const MIME = {
+  '.html': 'text/html; charset=utf-8',
+  '.js': 'application/javascript; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.json': 'application/json',
+  '.svg': 'image/svg+xml',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.webp': 'image/webp',
+  '.ico': 'image/x-icon',
+  '.wasm': 'application/wasm',
+  '.map': 'application/json',
+  '.woff': 'font/woff',
+  '.woff2': 'font/woff2',
+  '.ttf': 'font/ttf',
+};
+
+function contentType(filePath) {
+  return MIME[path.extname(filePath).toLowerCase()] || 'application/octet-stream';
+}
+
+function sendFile(res, filePath) {
+  const stream = fs.createReadStream(filePath);
+  stream.on('error', () => {
+    res.writeHead(404);
+    res.end('Not found');
+  });
+  res.writeHead(200, { 'Content-Type': contentType(filePath) });
+  stream.pipe(res);
+}
+
+function serveStatic(req, res, urlPath) {
+  let rel = decodeURIComponent(urlPath.split('?')[0]);
+  if (rel === '/' || rel === '') rel = '/index.html';
+  const filePath = path.normalize(path.join(DIST, rel));
+  if (!filePath.startsWith(DIST)) {
+    res.writeHead(403);
+    res.end('Forbidden');
+    return;
+  }
+  fs.stat(filePath, (err, st) => {
+    if (!err && st.isFile()) {
+      sendFile(res, filePath);
+      return;
+    }
+    // SPA fallback
+    sendFile(res, path.join(DIST, 'index.html'));
+  });
+}
+
+function proxyMcp(req, res) {
+  const upstream = new URL(MCP_UPSTREAM);
+  const incoming = new URL(req.url || '/', `http://${req.headers.host || 'localhost'}`);
+  // Preserve /mcp prefix for the MCP server
+  const targetPath = incoming.pathname.startsWith('/mcp')
+    ? incoming.pathname + incoming.search
+    : '/mcp' + incoming.pathname + incoming.search;
+
+  const headers = { ...req.headers, host: upstream.host };
+  delete headers['connection'];
+
+  const preq = http.request(
+    {
+      protocol: upstream.protocol,
+      hostname: upstream.hostname,
+      port: upstream.port || 80,
+      path: targetPath,
+      method: req.method,
+      headers,
+    },
+    (pres) => {
+      res.writeHead(pres.statusCode || 502, pres.headers);
+      pres.pipe(res);
+    },
+  );
+  preq.on('error', (err) => {
+    console.error('[serve] MCP proxy error:', err.message);
+    if (!res.headersSent) {
+      res.writeHead(502, { 'Content-Type': 'text/plain' });
+    }
+    res.end('MCP upstream unavailable');
+  });
+  req.pipe(preq);
+}
+
+const server = http.createServer((req, res) => {
+  const urlPath = req.url || '/';
+  if (ENABLE_MCP_PROXY && (urlPath === '/mcp' || urlPath.startsWith('/mcp/'))) {
+    proxyMcp(req, res);
+    return;
+  }
+  serveStatic(req, res, urlPath);
+});
+
+server.listen(PORT, '0.0.0.0', () => {
+  console.error(
+    `[serve] listening on :${PORT} dist=${DIST} mcp_proxy=${ENABLE_MCP_PROXY ? MCP_UPSTREAM : 'off'}`,
+  );
+});

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,9 +21,12 @@ A hosted build of the Angular example — **[Casper WebClient](https://casper-we
 
 Demo / development only — same warning as above.
 
-## MCP sidecar
+## MCP
 
-The workspace package [`mcp/`](../mcp/) (`casper-rust-wasm-sdk-mcp`) exposes the native Rust SDK as [MCP](https://modelcontextprotocol.io/) tools for Cursor and other agents (stdio or Streamable HTTP on **8790**).
+The workspace package [`mcp/`](../mcp/) (`casper-rust-wasm-sdk-mcp`) exposes the native Rust SDK as [MCP](https://modelcontextprotocol.io/) tools for Cursor and other agents.
+
+- **Hosted (with webclient):** https://casper-webclient.interchouette.net/mcp — same image as the SPA (`ENABLE_MCP=1`, evaluator-style `/mcp` proxy)
+- **Local slim image:** Streamable HTTP on **8790**, or stdio via Docker
 
 ```bash
 make run-mcp      # stdio (host)

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -14,7 +14,7 @@ Inventory: [TOOLS.md](TOOLS.md). Patterns: [PATTERNS.md](PATTERNS.md). Cursor co
 | **HTTP (host)**    | `make run-mcp-http`                                | Same URL without Docker     |
 
 ```bash
-make mcp-docker-build   # image …:2.2.2-mcp (+ Hub tags)
+make mcp-docker-build   # image …:2.2.2 + :latest + :dev
 make mcp-docker-push    # Hub + GHCR
 make mcp-http           # docker compose → http://127.0.0.1:8790/mcp
 make mcp-http-stop
@@ -25,6 +25,8 @@ make mcp-test-live      # ignored tests vs live NCTL (CASPER_RPC_URL)
 ```
 
 Family ports: 8787 tvs / 8788 nctl / 8789 kms / **8790 sdk**.
+
+**Hosted webclient** embeds MCP (same image): `https://casper-webclient.interchouette.net/mcp` (`ENABLE_MCP=1`). Slim `:2.2.2` image remains for Cursor stdio / dedicated `:8790`. Legacy `:2.2.2-mcp` is archived — use `:2.2.2`.
 
 ## Env
 
@@ -74,7 +76,7 @@ Complex inputs use JSON strings — see [TOOLS.md](TOOLS.md) and `tools/params.r
 | `casper-rust-wasm-sdk`              | HTTP `:8790/mcp` | Docker image via `make mcp-http` |
 | `casper-rust-wasm-sdk-stdio-docker` | stdio            | Same image (`docker run -i …`)   |
 
-Both use image `interchouette/casper-rust-wasm-sdk-mcp:2.2.2-mcp`. Cargo stdio is optional in [mcp.json.example](mcp.json.example) only (slow cold start).
+Both use image `interchouette/casper-rust-wasm-sdk-mcp:2.2.2`. Cargo stdio is optional in [mcp.json.example](mcp.json.example) only (slow cold start). Hosted: `https://casper-webclient.interchouette.net/mcp`.
 
 Prerequisite: `make mcp-docker-build` once; keep HTTP up with `make mcp-http`.
 

--- a/mcp/mcp.json.example
+++ b/mcp/mcp.json.example
@@ -19,7 +19,7 @@
         "RUST_LOG=warn",
         "--entrypoint",
         "casper-rust-wasm-sdk-mcp",
-        "interchouette/casper-rust-wasm-sdk-mcp:2.2.2-mcp"
+        "interchouette/casper-rust-wasm-sdk-mcp:2.2.2"
       ]
     },
     "casper-rust-wasm-sdk-stdio-cargo": {


### PR DESCRIPTION
## Summary
- **One webclient image** (evaluator/tvscreener-style): SPA + `casper-rust-wasm-sdk-mcp` with `ENABLE_MCP=1` (default). Public path: `/mcp` on port 8080 → local MCP `:8790`.
- **Docker tags:** slim MCP image is `2.2.2` / `latest` / `dev` (archive `2.2.2-mcp`).
- **CI** (`docker-build-push.yml`): pushes webclient (`:latest` + `:dev`) and MCP (`:2.2.2` / `:latest` / `:dev`).

Hosted target after Render redeploy: `https://casper-webclient.interchouette.net/mcp`

Slim MCP image remains for Cursor stdio (`docker run -i … mcp:2.2.2`).

## Test plan
- [ ] `make mcp-docker-build` tags `:2.2.2` `:latest` `:dev`
- [ ] CI image workflow builds webclient + MCP and pushes
- [ ] `curl -sS https://casper-webclient.interchouette.net/mcp` (or local `:8080/mcp`) responds after deploy
- [ ] `ENABLE_MCP=0` serves SPA only


Made with [Cursor](https://cursor.com)