### PR TITLE
fix(mcp): align docs/CI with webclient-embedded MCP

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -32,19 +32,12 @@ jobs:
             --build-arg APP_VERSION="$APP_VERSION" \
             --build-arg GIT_SHA="${{ github.sha }}"
 
+          # MCP binary is embedded in casper-webclient (ENABLE_MCP / entrypoint mcp).
+          # Do not build or push the deprecated slim casper-rust-wasm-sdk-mcp Hub image.
           for image in casper-webclient cors-anywhere ws-proxy; do
             docker tag "${image}:latest" "${{ secrets.DOCKER_USERNAME_ITC }}/${image}:latest"
             docker tag "${image}:latest" "${{ secrets.DOCKER_USERNAME_ITC }}/${image}:dev"
           done
-
-          # Slim MCP image (Cursor stdio / dedicated :8790). Tags match crate version.
-          make mcp-docker-build
-          docker tag "interchouette/casper-rust-wasm-sdk-mcp:2.2.2" \
-            "${{ secrets.DOCKER_USERNAME_ITC }}/casper-rust-wasm-sdk-mcp:2.2.2"
-          docker tag "interchouette/casper-rust-wasm-sdk-mcp:latest" \
-            "${{ secrets.DOCKER_USERNAME_ITC }}/casper-rust-wasm-sdk-mcp:latest"
-          docker tag "interchouette/casper-rust-wasm-sdk-mcp:dev" \
-            "${{ secrets.DOCKER_USERNAME_ITC }}/casper-rust-wasm-sdk-mcp:dev"
 
       - name: Push Docker images to Docker Hub
         run: |
@@ -52,9 +45,6 @@ jobs:
             docker push "${{ secrets.DOCKER_USERNAME_ITC }}/${image}:latest"
             docker push "${{ secrets.DOCKER_USERNAME_ITC }}/${image}:dev"
           done
-          docker push "${{ secrets.DOCKER_USERNAME_ITC }}/casper-rust-wasm-sdk-mcp:2.2.2"
-          docker push "${{ secrets.DOCKER_USERNAME_ITC }}/casper-rust-wasm-sdk-mcp:latest"
-          docker push "${{ secrets.DOCKER_USERNAME_ITC }}/casper-rust-wasm-sdk-mcp:dev"
 
       # Render does not watch Hub for new digests — call the service Deploy Hook
       # after a successful push so it pulls interchouette/casper-webclient:latest.

--- a/Makefile
+++ b/Makefile
@@ -123,78 +123,33 @@ docker-deploy-prod:
 
 .PHONY: docker-build docker-start docker-stop docker-start-prod docker-stop-prod
 
-# --- MCP sidecar (mcp/ — path-depends on casper-rust-wasm-sdk) ---
-# Image tags match the crate version (2.2.2). Legacy :2.2.2-mcp is archived.
+# --- MCP (mcp/ crate; runtime via casper-webclient image) ---
+# Hub: interchouette/casper-webclient:{dev,latest}. Slim casper-rust-wasm-sdk-mcp Hub image is deprecated.
 
-MCP_NAME ?= casper-rust-wasm-sdk-mcp
-MCP_VERSION ?= 2.2.2
-MCP_IMAGE ?= $(MCP_NAME):$(MCP_VERSION)
-MCP_HUB_IMAGE ?= interchouette/$(MCP_NAME)
-MCP_GHCR_PERSONAL_IMAGE ?= ghcr.io/groussac/$(MCP_NAME)
-MCP_GHCR_ORG_IMAGE ?= ghcr.io/interchouette-itc/$(MCP_NAME)
+WEBCLIENT_HUB_IMAGE ?= interchouette/casper-webclient
+CASPER_SDK_MCP_IMAGE ?= $(WEBCLIENT_HUB_IMAGE):dev
 COMPOSE_MCP ?= docker/docker-compose.mcp.yml
-DOCKER_BUILDKIT ?= 1
 
 mcp-build:
 	cargo build -p casper-rust-wasm-sdk-mcp --release
 
-mcp-docker-build:
-	DOCKER_BUILDKIT=$(DOCKER_BUILDKIT) docker build --network=host \
-		-t $(MCP_IMAGE) \
-		-t $(MCP_NAME):latest \
-		-t $(MCP_NAME):dev \
-		-t $(MCP_HUB_IMAGE):$(MCP_VERSION) \
-		-t $(MCP_HUB_IMAGE):latest \
-		-t $(MCP_HUB_IMAGE):dev \
-		-f mcp/Dockerfile \
-		.
-
-mcp-docker-push-hub:
-	docker push $(MCP_HUB_IMAGE):$(MCP_VERSION)
-	docker push $(MCP_HUB_IMAGE):latest
-	docker push $(MCP_HUB_IMAGE):dev
-
-mcp-docker-push-ghcr-personal:
-	docker tag $(MCP_HUB_IMAGE):$(MCP_VERSION) $(MCP_GHCR_PERSONAL_IMAGE):$(MCP_VERSION)
-	docker tag $(MCP_HUB_IMAGE):latest $(MCP_GHCR_PERSONAL_IMAGE):latest
-	docker tag $(MCP_HUB_IMAGE):dev $(MCP_GHCR_PERSONAL_IMAGE):dev
-	docker push $(MCP_GHCR_PERSONAL_IMAGE):$(MCP_VERSION)
-	docker push $(MCP_GHCR_PERSONAL_IMAGE):latest
-	docker push $(MCP_GHCR_PERSONAL_IMAGE):dev
-
-mcp-docker-push-ghcr-itc:
-	docker tag $(MCP_HUB_IMAGE):$(MCP_VERSION) $(MCP_GHCR_ORG_IMAGE):$(MCP_VERSION)
-	docker tag $(MCP_HUB_IMAGE):latest $(MCP_GHCR_ORG_IMAGE):latest
-	docker tag $(MCP_HUB_IMAGE):dev $(MCP_GHCR_ORG_IMAGE):dev
-	docker push $(MCP_GHCR_ORG_IMAGE):$(MCP_VERSION)
-	docker push $(MCP_GHCR_ORG_IMAGE):latest
-	docker push $(MCP_GHCR_ORG_IMAGE):dev
-
-mcp-docker-push: mcp-docker-push-hub mcp-docker-push-ghcr-personal mcp-docker-push-ghcr-itc
-
-# Prefer local/Hub image; build if missing.
+# Local HTTP via webclient (SPA :8080 + /mcp). Never binds host :8790 (NCTL).
 mcp-http:
-	-docker pull $(MCP_HUB_IMAGE):$(MCP_VERSION)
-	@if ! docker image inspect $(MCP_HUB_IMAGE):$(MCP_VERSION) >/dev/null 2>&1 \
-		&& ! docker image inspect $(MCP_IMAGE) >/dev/null 2>&1; then \
-		echo "MCP image missing; building locally…"; \
-		$(MAKE) mcp-docker-build; \
-	fi
-	CASPER_SDK_MCP_IMAGE=$$(docker image inspect $(MCP_HUB_IMAGE):$(MCP_VERSION) >/dev/null 2>&1 \
-		&& echo $(MCP_HUB_IMAGE):$(MCP_VERSION) \
-		|| echo $(MCP_IMAGE)) \
+	-docker pull $(CASPER_SDK_MCP_IMAGE)
+	CASPER_SDK_MCP_IMAGE=$(CASPER_SDK_MCP_IMAGE) \
 		docker compose -f $(COMPOSE_MCP) up -d --force-recreate
 
 mcp-http-stop:
 	-docker compose -f $(COMPOSE_MCP) down --remove-orphans
-	-docker stop casper-rust-wasm-sdk-mcp 2>/dev/null
-	-docker rm casper-rust-wasm-sdk-mcp 2>/dev/null
+	-docker stop casper-webclient-mcp 2>/dev/null
+	-docker rm casper-webclient-mcp 2>/dev/null
 
 run-mcp:
 	cargo run -p casper-rust-wasm-sdk-mcp --quiet --
 
+# Host cargo HTTP — use :8081 so we do not steal NCTL :8790.
 run-mcp-http:
-	cargo run -p casper-rust-wasm-sdk-mcp --quiet -- --http --listen 127.0.0.1:8790
+	cargo run -p casper-rust-wasm-sdk-mcp --quiet -- --http --listen 127.0.0.1:8081
 
 mcp-test:
 	cargo test -p casper-rust-wasm-sdk-mcp
@@ -206,8 +161,7 @@ mcp-test-live:
 
 # HTTP (compose) + Docker stdio against live NCTL. Requires: make mcp-http, NCTL up.
 mcp-smoke:
-	bash mcp/scripts/smoke_transports.sh
+	CASPER_SDK_MCP_IMAGE=$(CASPER_SDK_MCP_IMAGE) bash mcp/scripts/smoke_transports.sh
 
-.PHONY: mcp-build mcp-docker-build mcp-docker-push-hub mcp-docker-push-ghcr-personal \
-	mcp-docker-push-ghcr-itc mcp-docker-push mcp-http mcp-http-stop \
+.PHONY: mcp-build mcp-http mcp-http-stop \
 	run-mcp run-mcp-http mcp-test mcp-test-live mcp-smoke

--- a/docker/docker-compose.mcp.yml
+++ b/docker/docker-compose.mcp.yml
@@ -1,21 +1,19 @@
-# Slim MCP-only image (stdio / dedicated :8790).
-# Hosted webclient embeds MCP too — use https://casper-webclient.interchouette.net/mcp
+# MCP via unified webclient image (SPA :8080 + /mcp proxy).
+# Do not publish container :8790 to the host — that port is NCTL's.
 # Use: make mcp-http / make mcp-http-stop
+# Hosted: https://casper-webclient.interchouette.net/mcp
 services:
   sdk-mcp:
-    image: ${CASPER_SDK_MCP_IMAGE:-interchouette/casper-rust-wasm-sdk-mcp:2.2.2}
-    container_name: casper-rust-wasm-sdk-mcp
-    build:
-      context: ..
-      dockerfile: mcp/Dockerfile
+    image: ${CASPER_SDK_MCP_IMAGE:-interchouette/casper-webclient:dev}
+    container_name: casper-webclient-mcp
     ports:
-      - "8790:8790"
+      - "8080:8080"
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
-      CASPER_SDK_MCP_HTTP: "1"
-      CASPER_SDK_MCP_ADDR: "0.0.0.0:8790"
+      ENABLE_MCP: "1"
       CASPER_RPC_URL: ${CASPER_RPC_URL:-http://host.docker.internal:11101}
       CASPER_NODE_URL: ${CASPER_NODE_URL:-host.docker.internal:28101}
       RUST_LOG: ${RUST_LOG:-warn}
+    command: ["web"]
     restart: unless-stopped

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,14 +23,17 @@ Demo / development only — same warning as above.
 
 ## MCP
 
-The workspace package [`mcp/`](../mcp/) (`casper-rust-wasm-sdk-mcp`) exposes the native Rust SDK as [MCP](https://modelcontextprotocol.io/) tools for Cursor and other agents.
+The workspace package [`mcp/`](../mcp/) (`casper-rust-wasm-sdk-mcp`) exposes the native Rust SDK as [MCP](https://modelcontextprotocol.io/) tools for Cursor and other agents. The binary ships inside **`interchouette/casper-webclient`** (`:dev` / `:latest`).
 
-- **Hosted (with webclient):** https://casper-webclient.interchouette.net/mcp — same image as the SPA (`ENABLE_MCP=1`, evaluator-style `/mcp` proxy)
-- **Local slim image:** Streamable HTTP on **8790**, or stdio via Docker
+- **Hosted:** https://casper-webclient.interchouette.net/mcp (`ENABLE_MCP=1`, `/mcp` proxy on the SPA)
+- **Local Docker:** `make mcp-http` → http://127.0.0.1:8080/mcp
+- **Cursor stdio:** `interchouette/casper-webclient:dev` (see [`.cursor/mcp.json`](../.cursor/mcp.json))
+
+Do not bind host `:8790` for this product — that port is owned by casper-nctl-2-docker.
 
 ```bash
-make run-mcp      # stdio (host)
-make mcp-http     # Docker → http://127.0.0.1:8790/mcp
+make run-mcp      # stdio (host cargo)
+make mcp-http     # webclient → http://127.0.0.1:8080/mcp
 make mcp-test
 make mcp-test-live  # against live NCTL
 ```

--- a/mcp/Dockerfile
+++ b/mcp/Dockerfile
@@ -1,6 +1,6 @@
-# casper-rust-wasm-sdk-mcp — Streamable HTTP on :8790
-# Build context: repository root (path-depends on the SDK crate + workspace patches).
-#   docker build -f mcp/Dockerfile -t casper-rust-wasm-sdk-mcp:2.2.2 .
+# DEPRECATED for Hub / Cursor. Prefer interchouette/casper-webclient:{dev,latest}
+# which embeds the same binary (see docker/Dockerfile.cicd). Kept for local experiments only.
+#   docker build -f mcp/Dockerfile -t casper-rust-wasm-sdk-mcp:local .
 
 ARG RUST_IMAGE=rust:slim-bookworm
 ARG RUNTIME_IMAGE=debian:bookworm-slim

--- a/mcp/PATTERNS.md
+++ b/mcp/PATTERNS.md
@@ -106,43 +106,26 @@ assert!(include_str!("server.rs").contains(&needle));
 
 ---
 
-## Makefile targets (Phase 6)
+## Makefile targets
 
-| Target                      | Role                                     |
-| --------------------------- | ---------------------------------------- |
-| `mcp-build`                 | release build of mcp package             |
-| `run-mcp`                   | stdio                                    |
-| `run-mcp-http` / `mcp-http` | HTTP :8790                               |
-| `mcp-test`                  | `cargo test -p casper-rust-wasm-sdk-mcp` |
+| Target | Role |
+| --- | --- |
+| `mcp-build` | release build of mcp package |
+| `run-mcp` | stdio (host cargo) |
+| `mcp-http` | webclient Docker → `http://127.0.0.1:8080/mcp` |
+| `run-mcp-http` | host cargo HTTP on `127.0.0.1:8081` (not NCTL `:8790`) |
+| `mcp-test` | `cargo test -p casper-rust-wasm-sdk-mcp` |
 
----
-
-## mcp.json.example shape
-
-```json
-{
-  "mcpServers": {
-    "casper-rust-wasm-sdk-http": {
-      "url": "http://127.0.0.1:8790/mcp"
-    },
-    "casper-rust-wasm-sdk-stdio-cargo": {
-      "command": "cargo",
-      "args": ["run", "-p", "casper-rust-wasm-sdk-mcp", "--quiet", "--"],
-      "cwd": "${workspaceFolder}",
-      "env": { "RUST_LOG": "warn" }
-    }
-  }
-}
-```
+Runtime image: `interchouette/casper-webclient:{dev,latest}`. See [mcp.json.example](mcp.json.example).
 
 ---
 
 ## Copy vs differ
 
-| Copy from kms/nctl                           | Differ for rustSDK                         |
-| -------------------------------------------- | ------------------------------------------ |
-| Separate `mcp/` crate, mcpkit 0.7            | Path-dep on SDK lib (in-process)           |
-| clap `--http` / `--listen`                   | No Make/Docker lifecycle tools (Phase 1–7) |
-| stderr warn logging                          | No HTTP client to wrap an API              |
-| `run` / `run_http` + empty resources/prompts | Port 8790                                  |
-| Version sync test                            | Keep mcpkit off wasm root crate            |
+| Copy from kms/nctl | Differ for rustSDK |
+| --- | --- |
+| Separate `mcp/` crate, mcpkit 0.7 | Path-dep on SDK lib (in-process) |
+| clap `--http` / `--listen` | MCP embedded in webclient image |
+| stderr warn logging | No HTTP client to wrap an API |
+| `run` / `run_http` + empty resources/prompts | Host `:8790` is NCTL; use `:8080/mcp` |
+| Version sync test | Keep mcpkit off wasm root crate |

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -1,61 +1,61 @@
 # MCP server for casper-rust-wasm-sdk
 
-Rust **mcpkit** sidecar (`casper-rust-wasm-sdk-mcp`) exposing the native SDK API as MCP tools (in-process path dependency — not an HTTP proxy of the SDK).
+Rust **mcpkit** crate (`casper-rust-wasm-sdk-mcp`) exposing the native SDK API as MCP tools (in-process path dependency — not an HTTP proxy of the SDK).
 
-Inventory: [TOOLS.md](TOOLS.md). Patterns: [PATTERNS.md](PATTERNS.md). Cursor config sample: [mcp.json.example](mcp.json.example).
+**Runtime image:** MCP ships inside **`interchouette/casper-webclient`** (`:dev` / `:latest`). There is no separate Hub image for Cursor anymore; the slim `casper-rust-wasm-sdk-mcp` Hub repo is deprecated.
+
+Inventory: [TOOLS.md](TOOLS.md). Patterns: [PATTERNS.md](PATTERNS.md). Cursor sample: [mcp.json.example](mcp.json.example). Active Cursor config: [`.cursor/mcp.json`](../.cursor/mcp.json) (itc-cursor product branch).
 
 ## Transports
 
-| Mode               | Command                                            | Use                         |
-| ------------------ | -------------------------------------------------- | --------------------------- |
-| **stdio (Docker)** | see [mcp.json.example](mcp.json.example) `…-stdio` | Cursor spawn via image      |
-| **stdio (host)**   | `make run-mcp`                                     | Local Cursor spawn          |
-| **HTTP (Docker)**  | `make mcp-http`                                    | Streamable HTTP on **8790** |
-| **HTTP (host)**    | `make run-mcp-http`                                | Same URL without Docker     |
+| Mode | How | URL / notes |
+| --- | --- | --- |
+| **Hosted** | Render webclient | `https://casper-webclient.interchouette.net/mcp` |
+| **HTTP (Docker)** | `make mcp-http` → webclient SPA | `http://127.0.0.1:8080/mcp` (`ENABLE_MCP=1`) |
+| **stdio (Docker)** | Cursor / `docker run -i … --entrypoint casper-rust-wasm-sdk-mcp` | `interchouette/casper-webclient:dev` |
+| **stdio (host)** | `make run-mcp` | cargo; for local debug |
+| **HTTP (host)** | `make run-mcp-http` | cargo; **do not bind host `:8790`** (NCTL owns it) |
 
 ```bash
-make mcp-docker-build   # image …:2.2.2 + :latest + :dev
-make mcp-docker-push    # Hub + GHCR
-make mcp-http           # docker compose → http://127.0.0.1:8790/mcp
+make mcp-http           # webclient → http://127.0.0.1:8080/mcp
 make mcp-http-stop
-make run-mcp            # stdio (host)
-make run-mcp-http       # HTTP host
+make run-mcp            # stdio (host cargo)
+make run-mcp-http       # HTTP host on 127.0.0.1:8081 (avoids NCTL :8790)
 make mcp-test
 make mcp-test-live      # ignored tests vs live NCTL (CASPER_RPC_URL)
 ```
 
-Family ports: 8787 tvs / 8788 nctl / 8789 kms / **8790 sdk**.
-
-**Hosted webclient** embeds MCP (same image): `https://casper-webclient.interchouette.net/mcp` (`ENABLE_MCP=1`). Slim `:2.2.2` image remains for Cursor stdio / dedicated `:8790`. Legacy `:2.2.2-mcp` is archived — use `:2.2.2`.
+Shared host MCP HTTP ports: tvscreener `6790`, KMS `7790`, **NCTL `8790`**, evaluator `9790`. This product does **not** own a host MCP port; use webclient `:8080/mcp` or cargo `:8081`.
 
 ## Env
 
-| Variable              | Role                             | Default                  |
-| --------------------- | -------------------------------- | ------------------------ |
-| `CASPER_SDK_MCP_HTTP` | Use HTTP transport               | off (host) / on (image)  |
-| `CASPER_SDK_MCP_ADDR` | HTTP bind                        | `0.0.0.0:8790`           |
-| `CASPER_RPC_URL`      | JSON-RPC                         | `http://127.0.0.1:11101` |
-| `CASPER_NODE_URL`     | Binary port                      | `127.0.0.1:28101`        |
-| `CASPER_VERBOSITY`    | `low` / `medium` / `high`        | `low`                    |
-| `RUST_LOG`            | tracing filter (stderr, no ANSI) | `warn`                   |
+| Variable | Role | Default |
+| --- | --- | --- |
+| `ENABLE_MCP` | Start MCP inside webclient (`web` mode) | `1` |
+| `CASPER_SDK_MCP_HTTP` | Use HTTP transport (binary) | off (stdio) / on (web loopback) |
+| `CASPER_SDK_MCP_ADDR` | HTTP bind inside container | `127.0.0.1:8790` (loopback only) |
+| `CASPER_RPC_URL` | JSON-RPC | `http://127.0.0.1:11101` |
+| `CASPER_NODE_URL` | Binary port | `127.0.0.1:28101` |
+| `CASPER_VERBOSITY` | `low` / `medium` / `high` | `low` |
+| `RUST_LOG` | tracing filter (stderr, no ANSI) | `warn` |
 
-Docker containers reach host NCTL via `host.docker.internal` (compose sets `extra_hosts`).
+Docker containers reach host NCTL via `host.docker.internal`.
 
 ## Features
 
 MCP features enable the matching SDK features (`casper-rust-wasm-sdk` is `default-features = false`). Default is `full`.
 
-| Feature          | Tools                                                   | SDK feature                    |
-| ---------------- | ------------------------------------------------------- | ------------------------------ |
-| _(always)_       | `sdk_help`, `sdk_get_endpoints`, `sdk_set_endpoints`    | core RPC                       |
-| `helpers`        | utilities (keys, blake2b, motes, …)                     | `helpers`                      |
-| `rpc`            | JSON-RPC reads + speculative RPC                        | (always on in SDK)             |
-| `binary-port`    | binary-port queries (needs `CASPER_NODE_URL`)           | `binary-port`                  |
-| `transaction`    | make / speculative transaction builders                 | `transaction`                  |
-| `deploy`         | legacy make / speculative deploy builders               | `deploy`                       |
-| `contract`       | `query_contract_dict`, `query_contract_key`             | `contract`                     |
-| `write`          | sign/put/submit, install, call_entrypoint, `try_accept` | `transaction`+`deploy`+`contract` |
-| `full` (default) | all of the above                                        | all SDK optional features      |
+| Feature | Tools | SDK feature |
+| --- | --- | --- |
+| _(always)_ | `sdk_help`, `sdk_get_endpoints`, `sdk_set_endpoints` | core RPC |
+| `helpers` | utilities (keys, blake2b, motes, …) | `helpers` |
+| `rpc` | JSON-RPC reads + speculative RPC | (always on in SDK) |
+| `binary-port` | binary-port queries (needs `CASPER_NODE_URL`) | `binary-port` |
+| `transaction` | make / speculative transaction builders | `transaction` |
+| `deploy` | legacy make / speculative deploy builders | `deploy` |
+| `contract` | `query_contract_dict`, `query_contract_key` | `contract` |
+| `write` | sign/put/submit, install, call_entrypoint, `try_accept` | `transaction`+`deploy`+`contract` |
+| `full` (default) | all of the above | all SDK optional features |
 
 ```bash
 cargo build -p casper-rust-wasm-sdk-mcp
@@ -69,26 +69,15 @@ Complex inputs use JSON strings — see [TOOLS.md](TOOLS.md) and `tools/params.r
 
 ## Cursor
 
-**Active** [`.cursor/mcp.json`](../.cursor/mcp.json):
+| Server | Transport | Backing |
+| --- | --- | --- |
+| `casper-rust-wasm-sdk` | stdio | `interchouette/casper-webclient:dev` via `.cursor/scripts/sdk-mcp.sh` |
+| `casper-rust-wasm-sdk-http` | HTTP (mcp-remote) | same image; `http://127.0.0.1:8080/mcp` |
 
-| Server                              | Transport        | Backing                          |
-| ----------------------------------- | ---------------- | -------------------------------- |
-| `casper-rust-wasm-sdk`              | HTTP `:8790/mcp` | Docker image via `make mcp-http` |
-| `casper-rust-wasm-sdk-stdio-docker` | stdio            | Same image (`docker run -i …`)   |
-
-Both use image `interchouette/casper-rust-wasm-sdk-mcp:2.2.2`. Cargo stdio is optional in [mcp.json.example](mcp.json.example) only (slow cold start). Hosted: `https://casper-webclient.interchouette.net/mcp`.
-
-Prerequisite: `make mcp-docker-build` once; keep HTTP up with `make mcp-http`.
-
-Agents must use MCP for NCTL/chain access (`.cursor/rules/sdk-use-mcp-nctl.mdc`).
+Hub webclient tags: **`dev`**, **`latest`** only. See [mcp.json.example](mcp.json.example). Agents must use `CallMcpTool` (`.cursor/rules/casper-sdk-use-mcp.mdc`).
 
 ## Smoke
 
-| Check                                             | Result                          |
-| ------------------------------------------------- | ------------------------------- |
-| Feature-matrix builds + unit tests                | pass (Phase 7)                  |
-| HTTP `initialize` on `:8790/mcp`                  | pass                            |
-| Live NCTL `sdk_get_node_status` / `sdk_get_peers` | **pass** (NCTL 2.2 on `:11101`) |
-| Docker HTTP `make mcp-http` + `tools/call`        | **pass**                        |
-| Docker stdio `docker run -i` initialize           | **pass**                        |
-| Host / cargo stdio initialize                     | **pass**                        |
+```bash
+make mcp-smoke   # needs NCTL up + webclient image (make mcp-http)
+```

--- a/mcp/mcp.json.example
+++ b/mcp/mcp.json.example
@@ -1,26 +1,20 @@
 {
   "mcpServers": {
     "casper-rust-wasm-sdk": {
-      "url": "http://127.0.0.1:8790/mcp"
+      "command": "bash",
+      "args": [".cursor/scripts/sdk-mcp.sh"],
+      "env": {
+        "CASPER_SDK_MCP_IMAGE": "interchouette/casper-webclient:dev",
+        "RUST_LOG": "warn"
+      }
     },
-    "casper-rust-wasm-sdk-stdio-docker": {
-      "command": "docker",
-      "args": [
-        "run",
-        "--rm",
-        "-i",
-        "--add-host",
-        "host.docker.internal:host-gateway",
-        "-e",
-        "CASPER_RPC_URL=http://host.docker.internal:11101",
-        "-e",
-        "CASPER_NODE_URL=host.docker.internal:28101",
-        "-e",
-        "RUST_LOG=warn",
-        "--entrypoint",
-        "casper-rust-wasm-sdk-mcp",
-        "interchouette/casper-rust-wasm-sdk-mcp:2.2.2"
-      ]
+    "casper-rust-wasm-sdk-http": {
+      "command": "bash",
+      "args": [".cursor/scripts/sdk-mcp-http.sh"],
+      "env": {
+        "CASPER_SDK_MCP_IMAGE": "interchouette/casper-webclient:dev",
+        "CASPER_SDK_MCP_URL": "http://127.0.0.1:8080/mcp"
+      }
     },
     "casper-rust-wasm-sdk-stdio-cargo": {
       "command": "cargo",

--- a/mcp/scripts/smoke_transports.sh
+++ b/mcp/scripts/smoke_transports.sh
@@ -4,8 +4,8 @@
 set -euo pipefail
 
 RPC_URL="${CASPER_RPC_URL:-http://127.0.0.1:11101}"
-HTTP_URL="${CASPER_SDK_MCP_HTTP_URL:-http://127.0.0.1:8790/mcp}"
-IMAGE="${CASPER_SDK_MCP_IMAGE:-interchouette/casper-rust-wasm-sdk-mcp:2.2.2-mcp}"
+HTTP_URL="${CASPER_SDK_MCP_HTTP_URL:-http://127.0.0.1:8080/mcp}"
+IMAGE="${CASPER_SDK_MCP_IMAGE:-interchouette/casper-webclient:dev}"
 PASS=0
 FAIL=0
 TMP=$(mktemp -d)
@@ -124,7 +124,7 @@ fi
 # --- Docker stdio ---
 echo "== Docker stdio ($IMAGE) =="
 if ! docker image inspect "$IMAGE" >/dev/null 2>&1; then
-  bad "image $IMAGE missing — run: make mcp-docker-build"
+  bad "image $IMAGE missing — docker pull interchouette/casper-webclient:dev"
 else
   {
     json_rpc 1 initialize '{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"smoke-stdio","version":"0"}}'


### PR DESCRIPTION
## Summary
- Docs, compose, smoke, and Makefile now use \`interchouette/casper-webclient:{dev,latest}\` (\`:8080/mcp\`)
- CI no longer builds/pushes slim \`casper-rust-wasm-sdk-mcp\`
- Host \`:8790\` left to NCTL; cargo HTTP demo listens on \`:8081\`
- Cursor sample matches \`.cursor/mcp.json\` (stdio + HTTP)

## Test plan
- [ ] \`rg casper-rust-wasm-sdk-mcp: mcp/ docs/ Makefile .github\` shows no Hub tag pushes
- [ ] \`make mcp-http\` starts webclient; \`curl\` \`http://127.0.0.1:8080/mcp\` initialize works with NCTL up
- [ ] CI Image job no longer runs \`make mcp-docker-build\` / slim pushes


Made with [Cursor](https://cursor.com)