### PR TITLE
feat(demo): gate Load Secret Key behind config (#46)

### DIFF
--- a/examples/frontend/angular/libs/util/config/src/config.ts
+++ b/examples/frontend/angular/libs/util/config/src/config.ts
@@ -87,8 +87,11 @@ export const config: EnvironmentConfig = {
   docker_gateway: '172.18.0.1',
   cors_anywhere_port: '11100',
   enable_addressable_entity: false,
+  // Allow PEM "Load Secret Key" in local/dev; main.ts turns this off for prod/docker.
+  allow_secret_key_load: true,
   // Runtime config properties (populated from window.__APP_CONFIG__ in Docker builds):
   // cors_anywhere_url: optional public CORS proxy base URL
   // network_rpc_url: optional, overrides selected network's rpc_address (ntcl/dev)
   // network_node_url: optional, overrides selected network's node_address
+  // allow_secret_key_load: optional boolean override
 };

--- a/examples/frontend/angular/src/app/home/home.component.html
+++ b/examples/frontend/angular/src/app/home/home.component.html
@@ -23,7 +23,10 @@
       class="col-12 col-md-6 col-lg-7 my-1 my-md-0 d-flex justify-content-end ps-md-0"
     >
       <comp-public-key class="input-group"></comp-public-key>
-      <div class="d-flex justify-content-end ms-1 ms-sm-2 ms-xl-3">
+      <div
+        class="d-flex justify-content-end ms-1 ms-sm-2 ms-xl-3"
+        *ngIf="config['allow_secret_key_load']"
+      >
         <comp-secret-key></comp-secret-key>
       </div>
     </div>
@@ -31,7 +34,10 @@
   <comp-error></comp-error>
   <comp-form [form]="form" (wasm_selected)="onWasmSelected($event)"></comp-form>
   <comp-submit-action
-    *ngIf="['sign_deploy', 'sign_transaction'].includes(action)"
+    *ngIf="
+      config['allow_secret_key_load'] &&
+      ['sign_deploy', 'sign_transaction'].includes(action)
+    "
     (submit_action)="submitAction($event)"
     [class]="'btn-warning mt-3'"
     [e2e]="'sign'"

--- a/examples/frontend/angular/src/app/home/home.component.ts
+++ b/examples/frontend/angular/src/app/home/home.component.ts
@@ -135,8 +135,12 @@ export class HomeComponent implements OnInit, AfterViewInit, OnDestroy {
     }
   }
 
-  async walletSign(_$event: Event, _action: string) {
-    this.clientService.wallet_sign_deploy();
+  async walletSign(_$event: Event, action: string) {
+    if (action === 'sign_transaction') {
+      await this.clientService.wallet_sign_transaction();
+      return;
+    }
+    await this.clientService.wallet_sign_deploy();
   }
 
   private async handleAction(action: string, exec = false) {

--- a/examples/frontend/angular/src/main.ts
+++ b/examples/frontend/angular/src/main.ts
@@ -31,6 +31,7 @@ declare global {
       network_node_url?: string;
       app_version?: string;
       git_sha?: string;
+      allow_secret_key_load?: boolean;
     };
   }
 }
@@ -78,6 +79,11 @@ config['network'] = networks.find(
   (x) => x.name == environment['default_network'].toString(),
 ) as object;
 
+// Public prod/docker demos: force wallet signing (no PEM load) unless overridden.
+if (environment.production || environment.is_docker) {
+  config['allow_secret_key_load'] = false;
+}
+
 // Read runtime configuration from window.__APP_CONFIG__ if available
 if (typeof window !== 'undefined' && window.__APP_CONFIG__) {
   const runtimeConfig = window.__APP_CONFIG__;
@@ -95,6 +101,9 @@ if (typeof window !== 'undefined' && window.__APP_CONFIG__) {
   }
   if (runtimeConfig.git_sha) {
     config['git_sha'] = runtimeConfig.git_sha;
+  }
+  if (typeof runtimeConfig.allow_secret_key_load === 'boolean') {
+    config['allow_secret_key_load'] = runtimeConfig.allow_secret_key_load;
   }
 }
 


### PR DESCRIPTION
## Related issue

Fixes https://github.com/casper-ecosystem/casper-rust-wasm-sdk/issues/46

**Issue ask:** disable the Load Secret Key button in the demo so usage can be restricted to wallet signing.

## How this PR treats #46

- Adds `allow_secret_key_load` (default `true` for local/dev) in Angular `config`.
- Turns it **off** when `environment.production || environment.is_docker`, with optional `window.__APP_CONFIG__.allow_secret_key_load` override.
- Hides `<comp-secret-key>` and the PEM **Sign** button when the flag is false; keeps **Casper Wallet Sign**.
- Fixes `walletSign()` to call `wallet_sign_transaction` for `sign_transaction` (previously always deploy).

React/desktop demos are out of scope (no Load Secret Key UI).

## Test plan

- [ ] Local/dev Angular: Load Secret Key still visible and works
- [ ] Prod or docker env build: Load Secret Key and PEM Sign hidden; Wallet Sign still shown for sign_* actions
- [ ] `sign_transaction` + Wallet Sign uses transaction path (not deploy)
- [ ] `__APP_CONFIG__.allow_secret_key_load: true` can re-enable on a docker build if needed


Made with [Cursor](https://cursor.com)