### PR TITLE
feat: add JSON-RPC get_reward and MCP sdk_get_reward (#42)

### DIFF
--- a/mcp/TOOLS.md
+++ b/mcp/TOOLS.md
@@ -83,6 +83,7 @@ Env defaults: `CASPER_RPC_URL`, `CASPER_NODE_URL`, `CASPER_VERBOSITY`.
 | `get_entity`                                    | `sdk/rpcs/get_entity.rs`              | `sdk_get_entity`              | no     |
 | `get_era_info` (deprecated → `get_era_summary`) | `sdk/rpcs/get_era_info.rs`            | `sdk_get_era_info`            | no     |
 | `get_era_summary`                               | `sdk/rpcs/get_era_summary.rs`         | `sdk_get_era_summary`         | no     |
+| `get_reward`                                    | `sdk/rpcs/get_reward.rs`              | `sdk_get_reward`              | no     |
 | `get_node_status`                               | `sdk/rpcs/get_node_status.rs`         | `sdk_get_node_status`         | no     |
 | `get_peers`                                     | `sdk/rpcs/get_peers.rs`               | `sdk_get_peers`               | no     |
 | `get_state_root_hash`                           | `sdk/rpcs/get_state_root_hash.rs`     | `sdk_get_state_root_hash`     | no     |

--- a/mcp/src/server.rs
+++ b/mcp/src/server.rs
@@ -268,6 +268,20 @@ impl CasperSdkMcp {
     }
 
     #[tool(
+        description = "JSON-RPC info_get_reward (validator hex; optional delegator hex and era id)"
+    )]
+    async fn sdk_get_reward(
+        &self,
+        validator: String,
+        delegator: Option<String>,
+        maybe_era_id: Option<String>,
+        verbosity: Option<String>,
+        rpc_address: Option<String>,
+    ) -> ToolOutput {
+        tools::rpc::get_reward(validator, delegator, maybe_era_id, verbosity, rpc_address).await
+    }
+
+    #[tool(
         description = "JSON-RPC chain_get_era_info_by_switch_block (deprecated; prefer era_summary)"
     )]
     async fn sdk_get_era_info(

--- a/mcp/src/tools/rpc.rs
+++ b/mcp/src/tools/rpc.rs
@@ -34,6 +34,7 @@ pub fn tool_names() -> &'static [&'static str] {
         "sdk_get_era_summary",
         "sdk_get_node_status",
         "sdk_get_peers",
+        "sdk_get_reward",
         "sdk_get_state_root_hash",
         "sdk_get_transaction",
         "sdk_get_validator_changes",
@@ -157,6 +158,26 @@ pub async fn get_era_summary(
     rpc_ok!(
         sdk.get_era_summary(
             block_id(maybe_block_identifier),
+            verb(verbosity.as_deref()),
+            rpc_address
+        )
+        .await
+    )
+}
+
+pub async fn get_reward(
+    validator: String,
+    delegator: Option<String>,
+    maybe_era_id: Option<String>,
+    verbosity: Option<String>,
+    rpc_address: Option<String>,
+) -> ToolOutput {
+    let sdk = sdk_handle::sdk_snapshot();
+    rpc_ok!(
+        sdk.get_reward_as_string(
+            &validator,
+            delegator.as_deref(),
+            maybe_era_id.as_deref(),
             verb(verbosity.as_deref()),
             rpc_address
         )

--- a/src/sdk/rpcs/get_reward.rs
+++ b/src/sdk/rpcs/get_reward.rs
@@ -1,0 +1,285 @@
+#[cfg(target_arch = "wasm32")]
+use crate::types::identifier::block_identifier::BlockIdentifier;
+use crate::{
+    types::{public_key::PublicKey, sdk_error::SdkError, verbosity::Verbosity},
+    SDK,
+};
+use casper_client::{
+    cli::get_reward as get_reward_cli, get_reward as get_reward_lib,
+    rpcs::results::GetRewardResult as _GetRewardResult, rpcs::EraIdentifier, JsonRpcId,
+    SuccessResponse,
+};
+#[cfg(target_arch = "wasm32")]
+use casper_types::EraId;
+#[cfg(target_arch = "wasm32")]
+use gloo_utils::format::JsValueSerdeExt;
+use rand::Rng;
+#[cfg(target_arch = "wasm32")]
+use serde::{Deserialize, Serialize};
+#[cfg(target_arch = "wasm32")]
+use wasm_bindgen::prelude::*;
+
+/// Wrapper struct for the `GetRewardResult` from casper_client.
+#[cfg(target_arch = "wasm32")]
+#[derive(Debug, Deserialize, Serialize)]
+#[wasm_bindgen]
+pub struct GetRewardResult(_GetRewardResult);
+
+#[cfg(target_arch = "wasm32")]
+impl From<GetRewardResult> for _GetRewardResult {
+    fn from(result: GetRewardResult) -> Self {
+        result.0
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+impl From<_GetRewardResult> for GetRewardResult {
+    fn from(result: _GetRewardResult) -> Self {
+        GetRewardResult(result)
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+#[wasm_bindgen]
+impl GetRewardResult {
+    /// Gets the API version as a JsValue.
+    #[wasm_bindgen(getter)]
+    pub fn api_version(&self) -> JsValue {
+        JsValue::from_serde(&self.0.api_version).unwrap()
+    }
+
+    /// Gets the reward amount as a JsValue.
+    #[wasm_bindgen(getter)]
+    pub fn reward_amount(&self) -> JsValue {
+        JsValue::from_serde(&self.0.reward_amount).unwrap()
+    }
+
+    /// Gets the era id as a JsValue.
+    #[wasm_bindgen(getter)]
+    pub fn era_id(&self) -> JsValue {
+        JsValue::from_serde(&self.0.era_id).unwrap()
+    }
+
+    /// Gets the delegation rate.
+    #[wasm_bindgen(getter)]
+    pub fn delegation_rate(&self) -> u8 {
+        self.0.delegation_rate
+    }
+
+    /// Gets the switch block hash as a JsValue.
+    #[wasm_bindgen(getter)]
+    pub fn switch_block_hash(&self) -> JsValue {
+        JsValue::from_serde(&self.0.switch_block_hash).unwrap()
+    }
+
+    /// Converts the GetRewardResult to a JsValue.
+    #[wasm_bindgen(js_name = "toJson")]
+    pub fn to_json(&self) -> JsValue {
+        JsValue::from_serde(&self.0).unwrap_or(JsValue::null())
+    }
+}
+
+/// Options for the `get_reward` method.
+#[derive(Debug, Deserialize, Clone, Default, Serialize)]
+#[cfg(target_arch = "wasm32")]
+#[wasm_bindgen(js_name = "getRewardOptions", getter_with_clone)]
+pub struct GetRewardOptions {
+    pub validator_public_key: Option<PublicKey>,
+    pub validator_public_key_as_string: Option<String>,
+    pub delegator_public_key: Option<PublicKey>,
+    pub delegator_public_key_as_string: Option<String>,
+    pub maybe_era_id: Option<u64>,
+    pub maybe_era_id_as_string: Option<String>,
+    pub maybe_block_identifier: Option<BlockIdentifier>,
+    pub rpc_address: Option<String>,
+    pub verbosity: Option<Verbosity>,
+}
+
+#[cfg(target_arch = "wasm32")]
+#[wasm_bindgen]
+impl SDK {
+    /// Parses reward options from a JsValue.
+    pub fn get_reward_options(&self, options: JsValue) -> Result<GetRewardOptions, JsError> {
+        options
+            .into_serde::<GetRewardOptions>()
+            .map_err(|err| JsError::new(&format!("Error deserializing options: {err:?}")))
+    }
+
+    /// Retrieves validator/delegator reward via JSON-RPC `info_get_reward`.
+    #[wasm_bindgen(js_name = "get_reward")]
+    pub async fn get_reward_js_alias(
+        &self,
+        options: Option<GetRewardOptions>,
+    ) -> Result<GetRewardResult, JsError> {
+        let GetRewardOptions {
+            validator_public_key,
+            validator_public_key_as_string,
+            delegator_public_key,
+            delegator_public_key_as_string,
+            maybe_era_id,
+            maybe_era_id_as_string,
+            maybe_block_identifier,
+            verbosity,
+            rpc_address,
+        } = options.unwrap_or_default();
+
+        let validator = if let Some(pk) = validator_public_key {
+            pk
+        } else if let Some(hex) = validator_public_key_as_string {
+            PublicKey::new(&hex).map_err(|err| JsError::new(&format!("{err:?}")))?
+        } else {
+            return Err(JsError::new(
+                "validator_public_key or validator_public_key_as_string is required",
+            ));
+        };
+
+        let delegator = if let Some(pk) = delegator_public_key {
+            Some(pk)
+        } else if let Some(hex) = delegator_public_key_as_string {
+            Some(PublicKey::new(&hex).map_err(|err| JsError::new(&format!("{err:?}")))?)
+        } else {
+            None
+        };
+
+        let maybe_era_identifier = if let Some(era_id) = maybe_era_id {
+            Some(EraIdentifier::Era(EraId::new(era_id)))
+        } else if let Some(era_str) = maybe_era_id_as_string {
+            if era_str.is_empty() {
+                None
+            } else {
+                let era_id: u64 = era_str
+                    .parse()
+                    .map_err(|err| JsError::new(&format!("Invalid era id: {err:?}")))?;
+                Some(EraIdentifier::Era(EraId::new(era_id)))
+            }
+        } else {
+            maybe_block_identifier.map(|block| EraIdentifier::Block(block.into()))
+        };
+
+        let result = self
+            .get_reward(
+                validator,
+                delegator,
+                maybe_era_identifier,
+                verbosity,
+                rpc_address,
+            )
+            .await;
+        match result {
+            Ok(data) => Ok(data.result.into()),
+            Err(err) => {
+                let err = &format!("Error occurred with {err:?}");
+                Err(JsError::new(err))
+            }
+        }
+    }
+
+    /// JavaScript alias for `get_reward`.
+    #[wasm_bindgen(js_name = "info_get_reward")]
+    #[deprecated(note = "This function is an alias. Please use `get_reward` instead.")]
+    #[allow(deprecated)]
+    pub async fn info_get_reward(
+        &self,
+        options: Option<GetRewardOptions>,
+    ) -> Result<GetRewardResult, JsError> {
+        self.get_reward_js_alias(options).await
+    }
+}
+
+impl SDK {
+    /// Retrieves reward information (`info_get_reward`).
+    ///
+    /// # Arguments
+    ///
+    /// * `validator` - Validator public key.
+    /// * `maybe_delegator` - Optional delegator public key (validator reward when `None`).
+    /// * `maybe_era_identifier` - Optional era or block identifier (`None` = last finalized era).
+    /// * `verbosity` - Optional verbosity.
+    /// * `rpc_address` - Optional RPC URL.
+    pub async fn get_reward(
+        &self,
+        validator: PublicKey,
+        maybe_delegator: Option<PublicKey>,
+        maybe_era_identifier: Option<EraIdentifier>,
+        verbosity: Option<Verbosity>,
+        rpc_address: Option<String>,
+    ) -> Result<SuccessResponse<_GetRewardResult>, SdkError> {
+        let random_id = rand::rng().random::<u64>().to_string();
+        get_reward_lib(
+            JsonRpcId::from(random_id),
+            &self.get_rpc_address(rpc_address),
+            self.get_verbosity(verbosity).into(),
+            maybe_era_identifier,
+            validator.into(),
+            maybe_delegator.map(Into::into),
+        )
+        .await
+        .map_err(SdkError::from)
+    }
+
+    /// CLI-string convenience wrapper around `info_get_reward`.
+    pub async fn get_reward_as_string(
+        &self,
+        validator: &str,
+        maybe_delegator: Option<&str>,
+        maybe_era_id: Option<&str>,
+        verbosity: Option<Verbosity>,
+        rpc_address: Option<String>,
+    ) -> Result<SuccessResponse<_GetRewardResult>, SdkError> {
+        let random_id = rand::rng().random::<u64>().to_string();
+        get_reward_cli(
+            &random_id,
+            &self.get_rpc_address(rpc_address),
+            self.get_verbosity(verbosity).into(),
+            maybe_era_id.unwrap_or(""),
+            validator,
+            maybe_delegator.unwrap_or(""),
+        )
+        .await
+        .map_err(SdkError::from)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_get_reward_with_none_rpc_address() {
+        let sdk = SDK::new(None, None, None);
+        let error_message = "failed to parse node address as valid URL";
+        let result = sdk
+            .get_reward_as_string(
+                "01aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                None,
+                None,
+                None,
+                None,
+            )
+            .await;
+        assert!(result.is_err());
+        let err_string = result.err().unwrap().to_string();
+        assert!(
+            err_string.contains(error_message)
+                || err_string.contains("Failed")
+                || err_string.contains("parse")
+                || err_string.contains("PublicKey")
+                || err_string.contains("Validator")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_get_reward_with_error() {
+        let sdk = SDK::new(Some("http://localhost".to_string()), None, None);
+        let result = sdk
+            .get_reward_as_string(
+                "01aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                None,
+                None,
+                None,
+                None,
+            )
+            .await;
+        assert!(result.is_err());
+    }
+}

--- a/src/sdk/rpcs/mod.rs
+++ b/src/sdk/rpcs/mod.rs
@@ -11,6 +11,7 @@ pub mod get_era_info;
 pub mod get_era_summary;
 pub mod get_node_status;
 pub mod get_peers;
+pub mod get_reward;
 pub mod get_state_root_hash;
 pub mod get_transaction;
 pub mod get_validator_changes;


### PR DESCRIPTION
## Related issue

Fixes https://github.com/casper-ecosystem/casper-rust-wasm-sdk/issues/42

**Issue ask:** add `get_reward` (empty body; enhancement).

## How this PR treats #42

Binary-port already had `get_binary_*_reward_*`. That is **not** a substitute for JSON-RPC `info_get_reward`.

This PR wraps `casper_client::get_reward` / `cli::get_reward`:

- New [`src/sdk/rpcs/get_reward.rs`](src/sdk/rpcs/get_reward.rs): native `SDK::get_reward` + `get_reward_as_string`, wasm `get_reward` / deprecated alias `info_get_reward`
- MCP `sdk_get_reward` + [`mcp/TOOLS.md`](mcp/TOOLS.md)
- Keeps binary-port reward APIs unchanged

### Live smoke (local NCTL `:dev`)

Against `http://127.0.0.1:11101`, SDK call reaches `info_get_reward` (fresh net returned “No rewards found” for node-1 — expected until eras accrue).

## Test plan

- [ ] `cargo check -p casper-rust-wasm-sdk --lib` and `--target wasm32-unknown-unknown`
- [ ] `cargo check -p casper-rust-wasm-sdk-mcp`
- [ ] `cargo test -p casper-rust-wasm-sdk --lib rpcs::get_reward`
- [ ] Against NCTL: `sdk_get_reward` / `get_reward` with a validator public key


Made with [Cursor](https://cursor.com)