### PR TITLE
feat: expose RuntimeArgs and set_session_args for session params (#43)

### DIFF
--- a/mcp/src/tools/params.rs
+++ b/mcp/src/tools/params.rs
@@ -1,5 +1,7 @@
 //! JSON → SDK *StrParams / TransactionBuilderParams parsers for MCP tools.
 
+#![allow(deprecated)]
+
 use casper_rust_wasm_sdk::helpers;
 use casper_rust_wasm_sdk::types::cl::bytes::Bytes;
 use casper_rust_wasm_sdk::types::deploy_params::deploy_str_params::DeployStrParams;
@@ -343,7 +345,7 @@ pub fn parse_session_str_params(json: &str) -> Result<SessionStrParams, String> 
         params.set_session_bytes(bytes_from_hex(&v)?);
     }
     if let Some(args) = opt_string_vec(&obj, "session_args_simple") {
-        params.set_session_args_simple_vec(args);
+        params.set_session_args_simple(args);
     }
     if let Some(v) = opt_str(&obj, "session_args_json") {
         params.set_session_args_json(&v);

--- a/mcp/src/tools/params.rs
+++ b/mcp/src/tools/params.rs
@@ -343,7 +343,7 @@ pub fn parse_session_str_params(json: &str) -> Result<SessionStrParams, String> 
         params.set_session_bytes(bytes_from_hex(&v)?);
     }
     if let Some(args) = opt_string_vec(&obj, "session_args_simple") {
-        params.set_session_args(args);
+        params.set_session_args_simple_vec(args);
     }
     if let Some(v) = opt_str(&obj, "session_args_json") {
         params.set_session_args_json(&v);

--- a/src/sdk/contract/call_entrypoint_deploy.rs
+++ b/src/sdk/contract/call_entrypoint_deploy.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 #[cfg(target_arch = "wasm32")]
 use crate::deploy::deploy::PutDeployResult;
 use crate::types::deploy_params::{
@@ -157,7 +159,7 @@ mod tests {
             .set_session_hash(&get_contract_hash().await.replace("entity-contract", "hash"));
         session_params.set_session_entry_point(ENTRYPOINT_MINT);
         let args_simple: Vec<String> = ARGS_SIMPLE.iter().map(|s| s.to_string()).collect();
-        session_params.set_session_args_simple_vec(args_simple);
+        session_params.set_session_args_simple(args_simple);
 
         // Act
         let result = sdk
@@ -204,7 +206,7 @@ mod tests {
         );
         session_params.set_session_entry_point(ENTRYPOINT_MINT);
         let args_simple: Vec<String> = ARGS_SIMPLE.iter().map(|s| s.to_string()).collect();
-        session_params.set_session_args_simple_vec(args_simple);
+        session_params.set_session_args_simple(args_simple);
 
         // Act
         let result = sdk
@@ -249,7 +251,7 @@ mod tests {
         );
         session_params.set_session_entry_point(ENTRYPOINT_MINT);
         let args_simple: Vec<String> = ARGS_SIMPLE.iter().map(|s| s.to_string()).collect();
-        session_params.set_session_args_simple_vec(args_simple);
+        session_params.set_session_args_simple(args_simple);
 
         // Act
         let result = sdk
@@ -295,7 +297,7 @@ mod tests {
         );
         session_params.set_session_entry_point(ENTRYPOINT_MINT);
         let args_simple: Vec<String> = ARGS_SIMPLE.iter().map(|s| s.to_string()).collect();
-        session_params.set_session_args_simple_vec(args_simple);
+        session_params.set_session_args_simple(args_simple);
 
         // Act
         let result = sdk

--- a/src/sdk/contract/call_entrypoint_deploy.rs
+++ b/src/sdk/contract/call_entrypoint_deploy.rs
@@ -157,7 +157,7 @@ mod tests {
             .set_session_hash(&get_contract_hash().await.replace("entity-contract", "hash"));
         session_params.set_session_entry_point(ENTRYPOINT_MINT);
         let args_simple: Vec<String> = ARGS_SIMPLE.iter().map(|s| s.to_string()).collect();
-        session_params.set_session_args(args_simple);
+        session_params.set_session_args_simple_vec(args_simple);
 
         // Act
         let result = sdk
@@ -204,7 +204,7 @@ mod tests {
         );
         session_params.set_session_entry_point(ENTRYPOINT_MINT);
         let args_simple: Vec<String> = ARGS_SIMPLE.iter().map(|s| s.to_string()).collect();
-        session_params.set_session_args(args_simple);
+        session_params.set_session_args_simple_vec(args_simple);
 
         // Act
         let result = sdk
@@ -249,7 +249,7 @@ mod tests {
         );
         session_params.set_session_entry_point(ENTRYPOINT_MINT);
         let args_simple: Vec<String> = ARGS_SIMPLE.iter().map(|s| s.to_string()).collect();
-        session_params.set_session_args(args_simple);
+        session_params.set_session_args_simple_vec(args_simple);
 
         // Act
         let result = sdk
@@ -295,7 +295,7 @@ mod tests {
         );
         session_params.set_session_entry_point(ENTRYPOINT_MINT);
         let args_simple: Vec<String> = ARGS_SIMPLE.iter().map(|s| s.to_string()).collect();
-        session_params.set_session_args(args_simple);
+        session_params.set_session_args_simple_vec(args_simple);
 
         // Act
         let result = sdk

--- a/src/sdk/contract/install_deploy.rs
+++ b/src/sdk/contract/install_deploy.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 #[cfg(target_arch = "wasm32")]
 use crate::deploy::deploy::PutDeployResult;
 use crate::types::deploy_params::{
@@ -157,7 +159,7 @@ mod tests {
         };
         session_params.set_session_bytes(module_bytes.into());
         let args_simple: Vec<String> = ARGS_SIMPLE.iter().map(|s| s.to_string()).collect();
-        session_params.set_session_args_simple_vec(args_simple);
+        session_params.set_session_args_simple(args_simple);
 
         // Act
         let result = sdk
@@ -206,7 +208,7 @@ mod tests {
         };
         session_params.set_session_bytes(module_bytes.into());
         let args_simple: Vec<String> = ARGS_SIMPLE.iter().map(|s| s.to_string()).collect();
-        session_params.set_session_args_simple_vec(args_simple);
+        session_params.set_session_args_simple(args_simple);
 
         // Act
         let result = sdk
@@ -253,7 +255,7 @@ mod tests {
         };
         session_params.set_session_bytes(module_bytes.into());
         let args_simple: Vec<String> = ARGS_SIMPLE.iter().map(|s| s.to_string()).collect();
-        session_params.set_session_args_simple_vec(args_simple);
+        session_params.set_session_args_simple(args_simple);
 
         // Act
         let result = sdk
@@ -301,7 +303,7 @@ mod tests {
         };
         session_params.set_session_bytes(module_bytes.into());
         let args_simple: Vec<String> = ARGS_SIMPLE.iter().map(|s| s.to_string()).collect();
-        session_params.set_session_args_simple_vec(args_simple);
+        session_params.set_session_args_simple(args_simple);
 
         // Act
         let result = sdk

--- a/src/sdk/contract/install_deploy.rs
+++ b/src/sdk/contract/install_deploy.rs
@@ -157,7 +157,7 @@ mod tests {
         };
         session_params.set_session_bytes(module_bytes.into());
         let args_simple: Vec<String> = ARGS_SIMPLE.iter().map(|s| s.to_string()).collect();
-        session_params.set_session_args(args_simple);
+        session_params.set_session_args_simple_vec(args_simple);
 
         // Act
         let result = sdk
@@ -206,7 +206,7 @@ mod tests {
         };
         session_params.set_session_bytes(module_bytes.into());
         let args_simple: Vec<String> = ARGS_SIMPLE.iter().map(|s| s.to_string()).collect();
-        session_params.set_session_args(args_simple);
+        session_params.set_session_args_simple_vec(args_simple);
 
         // Act
         let result = sdk
@@ -253,7 +253,7 @@ mod tests {
         };
         session_params.set_session_bytes(module_bytes.into());
         let args_simple: Vec<String> = ARGS_SIMPLE.iter().map(|s| s.to_string()).collect();
-        session_params.set_session_args(args_simple);
+        session_params.set_session_args_simple_vec(args_simple);
 
         // Act
         let result = sdk
@@ -301,7 +301,7 @@ mod tests {
         };
         session_params.set_session_bytes(module_bytes.into());
         let args_simple: Vec<String> = ARGS_SIMPLE.iter().map(|s| s.to_string()).collect();
-        session_params.set_session_args(args_simple);
+        session_params.set_session_args_simple_vec(args_simple);
 
         // Act
         let result = sdk

--- a/src/sdk/deploy/deploy.rs
+++ b/src/sdk/deploy/deploy.rs
@@ -179,7 +179,7 @@ mod tests {
             };
             new_session_params.set_session_bytes(module_bytes.into());
             let args_simple: Vec<String> = ARGS_SIMPLE.iter().map(|s| s.to_string()).collect();
-            new_session_params.set_session_args(args_simple);
+            new_session_params.set_session_args_simple_vec(args_simple);
             *session_params = Some(new_session_params);
         }
 

--- a/src/sdk/deploy/deploy.rs
+++ b/src/sdk/deploy/deploy.rs
@@ -179,7 +179,7 @@ mod tests {
             };
             new_session_params.set_session_bytes(module_bytes.into());
             let args_simple: Vec<String> = ARGS_SIMPLE.iter().map(|s| s.to_string()).collect();
-            new_session_params.set_session_args_simple_vec(args_simple);
+            new_session_params.set_session_args_simple(args_simple);
             *session_params = Some(new_session_params);
         }
 

--- a/src/sdk/deploy/mod.rs
+++ b/src/sdk/deploy/mod.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 #[allow(clippy::module_inception)]
 pub mod deploy;
 pub mod speculative_deploy;

--- a/src/sdk/deploy/speculative_deploy.rs
+++ b/src/sdk/deploy/speculative_deploy.rs
@@ -136,7 +136,7 @@ mod tests {
             };
             new_session_params.set_session_bytes(module_bytes.into());
             let args_simple: Vec<String> = ARGS_SIMPLE.iter().map(|s| s.to_string()).collect();
-            new_session_params.set_session_args(args_simple);
+            new_session_params.set_session_args_simple_vec(args_simple);
             *session_params = Some(new_session_params);
         }
 

--- a/src/sdk/deploy/speculative_deploy.rs
+++ b/src/sdk/deploy/speculative_deploy.rs
@@ -136,7 +136,7 @@ mod tests {
             };
             new_session_params.set_session_bytes(module_bytes.into());
             let args_simple: Vec<String> = ARGS_SIMPLE.iter().map(|s| s.to_string()).collect();
-            new_session_params.set_session_args_simple_vec(args_simple);
+            new_session_params.set_session_args_simple(args_simple);
             *session_params = Some(new_session_params);
         }
 

--- a/src/sdk/deploy_utils/mod.rs
+++ b/src/sdk/deploy_utils/mod.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 pub(crate) mod make_deploy;
 #[allow(deprecated)]
 pub(crate) use make_deploy::make_deploy;

--- a/src/types/cl/cl_value.rs
+++ b/src/types/cl/cl_value.rs
@@ -1,0 +1,194 @@
+use crate::types::sdk_error::SdkError;
+#[cfg(target_arch = "wasm32")]
+use crate::types::{cl::bytes::Bytes, key::Key, public_key::PublicKey, uref::URef};
+use casper_types::{
+    bytesrepr::{FromBytes, ToBytes},
+    CLTyped, CLValue as _CLValue,
+};
+#[cfg(target_arch = "wasm32")]
+use casper_types::{U128, U256, U512};
+#[cfg(target_arch = "wasm32")]
+use gloo_utils::format::JsValueSerdeExt;
+use wasm_bindgen::prelude::*;
+
+/// Wasm/native wrapper around [`casper_types::CLValue`].
+///
+/// Minimal surface for building [`crate::types::runtime_args::RuntimeArgs`] (#43).
+/// Full CLValue / StoredValue graph remains [#27](https://github.com/casper-ecosystem/casper-rust-wasm-sdk/issues/27).
+#[wasm_bindgen]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CLValue(_CLValue);
+
+impl CLValue {
+    pub fn from_t<T: CLTyped + ToBytes>(value: T) -> Result<Self, Box<SdkError>> {
+        _CLValue::from_t(value)
+            .map(CLValue)
+            .map_err(|err| Box::new(SdkError::from(err)))
+    }
+
+    pub fn inner(&self) -> &_CLValue {
+        &self.0
+    }
+}
+
+#[wasm_bindgen]
+impl CLValue {
+    #[cfg(target_arch = "wasm32")]
+    #[wasm_bindgen(js_name = "fromBool")]
+    pub fn from_bool_js(value: bool) -> Result<CLValue, JsError> {
+        Self::from_t(value).map_err(|err| JsError::new(&err.to_string()))
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    #[wasm_bindgen(js_name = "fromI32")]
+    pub fn from_i32_js(value: i32) -> Result<CLValue, JsError> {
+        Self::from_t(value).map_err(|err| JsError::new(&err.to_string()))
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    #[wasm_bindgen(js_name = "fromI64")]
+    pub fn from_i64_js(value: i64) -> Result<CLValue, JsError> {
+        Self::from_t(value).map_err(|err| JsError::new(&err.to_string()))
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    #[wasm_bindgen(js_name = "fromU8")]
+    pub fn from_u8_js(value: u8) -> Result<CLValue, JsError> {
+        Self::from_t(value).map_err(|err| JsError::new(&err.to_string()))
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    #[wasm_bindgen(js_name = "fromU32")]
+    pub fn from_u32_js(value: u32) -> Result<CLValue, JsError> {
+        Self::from_t(value).map_err(|err| JsError::new(&err.to_string()))
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    #[wasm_bindgen(js_name = "fromU64")]
+    pub fn from_u64_js(value: u64) -> Result<CLValue, JsError> {
+        Self::from_t(value).map_err(|err| JsError::new(&err.to_string()))
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    #[wasm_bindgen(js_name = "fromU128")]
+    pub fn from_u128_js(value: &str) -> Result<CLValue, JsError> {
+        let parsed = U128::from_dec_str(value)
+            .map_err(|err| JsError::new(&format!("Invalid U128: {err:?}")))?;
+        Self::from_t(parsed).map_err(|err| JsError::new(&err.to_string()))
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    #[wasm_bindgen(js_name = "fromU256")]
+    pub fn from_u256_js(value: &str) -> Result<CLValue, JsError> {
+        let parsed = U256::from_dec_str(value)
+            .map_err(|err| JsError::new(&format!("Invalid U256: {err:?}")))?;
+        Self::from_t(parsed).map_err(|err| JsError::new(&err.to_string()))
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    #[wasm_bindgen(js_name = "fromU512")]
+    pub fn from_u512_js(value: &str) -> Result<CLValue, JsError> {
+        let parsed = U512::from_dec_str(value)
+            .map_err(|err| JsError::new(&format!("Invalid U512: {err:?}")))?;
+        Self::from_t(parsed).map_err(|err| JsError::new(&err.to_string()))
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    #[wasm_bindgen(js_name = "fromString")]
+    pub fn from_string_js(value: &str) -> Result<CLValue, JsError> {
+        Self::from_t(value.to_string()).map_err(|err| JsError::new(&err.to_string()))
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    #[wasm_bindgen(js_name = "fromUnit")]
+    pub fn from_unit_js() -> Result<CLValue, JsError> {
+        Self::from_t(()).map_err(|err| JsError::new(&err.to_string()))
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    #[wasm_bindgen(js_name = "fromKey")]
+    pub fn from_key_js(key: &Key) -> Result<CLValue, JsError> {
+        Self::from_t(casper_types::Key::from(key.clone()))
+            .map_err(|err| JsError::new(&err.to_string()))
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    #[wasm_bindgen(js_name = "fromURef")]
+    pub fn from_uref_js(uref: &URef) -> Result<CLValue, JsError> {
+        Self::from_t(casper_types::URef::from(uref.clone()))
+            .map_err(|err| JsError::new(&err.to_string()))
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    #[wasm_bindgen(js_name = "fromPublicKey")]
+    pub fn from_public_key_js(public_key: &PublicKey) -> Result<CLValue, JsError> {
+        Self::from_t(casper_types::PublicKey::from(public_key.clone()))
+            .map_err(|err| JsError::new(&err.to_string()))
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    #[wasm_bindgen(js_name = "fromBytes")]
+    pub fn from_bytes_js(bytes: &Bytes) -> Result<CLValue, JsError> {
+        Self::from_t(casper_types::bytesrepr::Bytes::from(bytes.clone()))
+            .map_err(|err| JsError::new(&err.to_string()))
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    #[wasm_bindgen(js_name = "toJson")]
+    pub fn to_json(&self) -> JsValue {
+        JsValue::from_serde(&self.0).unwrap_or(JsValue::null())
+    }
+}
+
+impl From<CLValue> for _CLValue {
+    fn from(value: CLValue) -> Self {
+        value.0
+    }
+}
+
+impl From<_CLValue> for CLValue {
+    fn from(value: _CLValue) -> Self {
+        CLValue(value)
+    }
+}
+
+impl AsRef<_CLValue> for CLValue {
+    fn as_ref(&self) -> &_CLValue {
+        &self.0
+    }
+}
+
+impl ToBytes for CLValue {
+    fn to_bytes(&self) -> Result<Vec<u8>, casper_types::bytesrepr::Error> {
+        self.0.to_bytes()
+    }
+
+    fn serialized_length(&self) -> usize {
+        self.0.serialized_length()
+    }
+
+    fn write_bytes(&self, writer: &mut Vec<u8>) -> Result<(), casper_types::bytesrepr::Error> {
+        self.0.write_bytes(writer)
+    }
+}
+
+impl FromBytes for CLValue {
+    fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), casper_types::bytesrepr::Error> {
+        let (value, remainder) = _CLValue::from_bytes(bytes)?;
+        Ok((CLValue(value), remainder))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_t_round_trips_common_scalars() {
+        let value = CLValue::from_t("hello".to_string()).unwrap();
+        assert_eq!(value.inner().clone().into_t::<String>().unwrap(), "hello");
+
+        let flag = CLValue::from_t(true).unwrap();
+        assert!(flag.inner().clone().into_t::<bool>().unwrap());
+    }
+}

--- a/src/types/cl/mod.rs
+++ b/src/types/cl/mod.rs
@@ -1,1 +1,2 @@
 pub mod bytes;
+pub mod cl_value;

--- a/src/types/deploy.rs
+++ b/src/types/deploy.rs
@@ -1,6 +1,7 @@
 #[cfg(target_arch = "wasm32")]
 use crate::helpers::insert_js_value_arg;
 #[cfg(feature = "deploy")]
+#[allow(deprecated)]
 use crate::types::deploy_params::{
     deploy_str_params::DeployStrParams, payment_str_params::PaymentStrParams,
     session_str_params::SessionStrParams,

--- a/src/types/deploy_params/mod.rs
+++ b/src/types/deploy_params/mod.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 pub mod args_simple;
 pub mod deploy_str_params;
 pub mod dictionary_item_str_params;

--- a/src/types/deploy_params/session_str_params.rs
+++ b/src/types/deploy_params/session_str_params.rs
@@ -1,6 +1,8 @@
 use crate::{
     helpers::get_str_or_default,
-    types::{cl::bytes::Bytes, deploy_params::args_simple::ArgsSimple},
+    types::{
+        cl::bytes::Bytes, deploy_params::args_simple::ArgsSimple, runtime_args::RuntimeArgs,
+    },
 };
 use casper_client::cli::SessionStrParams as _SessionStrParams;
 use js_sys::Array;
@@ -160,7 +162,7 @@ impl SessionStrParams {
             .iter()
             .map(|value| value.as_string().unwrap_or_default())
             .collect();
-        self.set_session_args(args);
+        self.set_session_args_simple_vec(args);
     }
 
     // Getter and setter for session_args_json field
@@ -174,6 +176,14 @@ impl SessionStrParams {
         self.session_args_json
             .set(session_args_json.to_string())
             .unwrap();
+    }
+
+    /// Set session args from typed [`RuntimeArgs`] (fills `session_args_json`).
+    pub fn set_session_args(&self, args: &RuntimeArgs) {
+        let json = args
+            .to_session_args_json_string()
+            .expect("RuntimeArgs to session args JSON");
+        self.set_session_args_json(&json);
     }
 
     // Getter and setter for session_version field
@@ -215,7 +225,8 @@ impl SessionStrParams {
 }
 
 impl SessionStrParams {
-    pub fn set_session_args(&mut self, session_args_simple: Vec<String>) {
+    /// Sets session args from CLI-style simple strings (`name:Type='value'`).
+    pub fn set_session_args_simple_vec(&mut self, session_args_simple: Vec<String>) {
         let args_simple = ArgsSimple::from(session_args_simple);
         self.session_args_simple.set(args_simple).unwrap();
     }
@@ -339,5 +350,24 @@ mod tests {
         let result = session_str_params_to_casper_client(&session_params);
         let result_debug_output = format!("{result:?}");
         assert!(result_debug_output.contains("is_session_transfer: true"));
+    }
+
+    #[test]
+    fn test_set_session_args_from_runtime_args() {
+        use crate::types::cl::cl_value::CLValue;
+
+        let session_params = SessionStrParams::default();
+        let mut args = RuntimeArgs::new();
+        args.insert_cl_value("message", CLValue::from_t("hi".to_string()).unwrap());
+        session_params.set_session_args(&args);
+
+        let json = session_params.session_args_json().unwrap();
+        let parsed: Vec<serde_json::Value> = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.len(), 1);
+        assert_eq!(parsed[0]["name"], "message");
+
+        let client = session_str_params_to_casper_client(&session_params);
+        let debug = format!("{client:?}");
+        assert!(debug.contains("session_args_json"));
     }
 }

--- a/src/types/deploy_params/session_str_params.rs
+++ b/src/types/deploy_params/session_str_params.rs
@@ -1,8 +1,6 @@
 use crate::{
     helpers::get_str_or_default,
-    types::{
-        cl::bytes::Bytes, deploy_params::args_simple::ArgsSimple, runtime_args::RuntimeArgs,
-    },
+    types::{cl::bytes::Bytes, deploy_params::args_simple::ArgsSimple, runtime_args::RuntimeArgs},
 };
 use casper_client::cli::SessionStrParams as _SessionStrParams;
 use once_cell::sync::OnceCell;

--- a/src/types/deploy_params/session_str_params.rs
+++ b/src/types/deploy_params/session_str_params.rs
@@ -5,10 +5,17 @@ use crate::{
     },
 };
 use casper_client::cli::SessionStrParams as _SessionStrParams;
-use js_sys::Array;
 use once_cell::sync::OnceCell;
 use wasm_bindgen::prelude::*;
 
+/// Legacy deploy session params. Prefer [`crate::types::transaction_params::transaction_str_params::TransactionStrParams`].
+///
+/// Session args setters (same idea as transaction params):
+/// - [`Self::set_session_args_simple`] — CLI-style string bag
+/// - [`Self::set_session_args_json`] — JSON string
+/// - [`Self::set_session_args`] — typed [`RuntimeArgs`]
+#[deprecated(note = "prefer TransactionStrParams")]
+#[allow(deprecated)]
 #[wasm_bindgen]
 #[derive(Default, Debug, Clone)]
 pub struct SessionStrParams {
@@ -26,6 +33,7 @@ pub struct SessionStrParams {
 }
 
 #[wasm_bindgen]
+#[allow(deprecated)]
 impl SessionStrParams {
     #[wasm_bindgen(constructor)]
     #[allow(clippy::too_many_arguments)]
@@ -36,7 +44,7 @@ impl SessionStrParams {
         session_package_name: Option<String>,
         session_path: Option<String>,
         session_bytes: Option<Bytes>,
-        session_args_simple: Option<Array>,
+        session_args_simple: Option<Vec<String>>,
         session_args_json: Option<String>,
         session_version: Option<String>,
         session_entry_point: Option<String>,
@@ -156,13 +164,11 @@ impl SessionStrParams {
         self.session_args_simple.get().cloned()
     }
 
+    /// CLI-style simple args (`name:Type='value'`).
     #[wasm_bindgen(setter)]
-    pub fn set_session_args_simple(&mut self, session_args_simple: Array) {
-        let args: Vec<String> = session_args_simple
-            .iter()
-            .map(|value| value.as_string().unwrap_or_default())
-            .collect();
-        self.set_session_args_simple_vec(args);
+    pub fn set_session_args_simple(&mut self, session_args_simple: Vec<String>) {
+        let args_simple = ArgsSimple::from(session_args_simple);
+        self.session_args_simple.set(args_simple).unwrap();
     }
 
     // Getter and setter for session_args_json field
@@ -171,6 +177,7 @@ impl SessionStrParams {
         self.session_args_json.get().cloned()
     }
 
+    /// JSON session args string (human-typed or ByteArray bridge encoding).
     #[wasm_bindgen(setter)]
     pub fn set_session_args_json(&self, session_args_json: &str) {
         self.session_args_json
@@ -178,7 +185,7 @@ impl SessionStrParams {
             .unwrap();
     }
 
-    /// Set session args from typed [`RuntimeArgs`] (fills `session_args_json`).
+    /// Typed session args. Parameter type is [`RuntimeArgs`]; string setters stay separate.
     pub fn set_session_args(&self, args: &RuntimeArgs) {
         let json = args
             .to_session_args_json_string()
@@ -224,15 +231,8 @@ impl SessionStrParams {
     }
 }
 
-impl SessionStrParams {
-    /// Sets session args from CLI-style simple strings (`name:Type='value'`).
-    pub fn set_session_args_simple_vec(&mut self, session_args_simple: Vec<String>) {
-        let args_simple = ArgsSimple::from(session_args_simple);
-        self.session_args_simple.set(args_simple).unwrap();
-    }
-}
-
 // Convert SessionStrParams to casper_client::cli::SessionStrParam
+#[allow(deprecated)]
 pub fn session_str_params_to_casper_client(
     session_params: &SessionStrParams,
 ) -> _SessionStrParams<'_> {
@@ -305,6 +305,7 @@ pub fn session_str_params_to_casper_client(
 }
 
 #[cfg(test)]
+#[allow(deprecated)]
 mod tests {
     use super::*;
 

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -14,6 +14,7 @@ pub mod pricing_mode;
 pub mod public_key;
 #[cfg(feature = "binary-port")]
 pub mod record_id;
+pub mod runtime_args;
 pub mod sdk_error;
 pub mod transaction;
 pub mod transaction_params;

--- a/src/types/runtime_args.rs
+++ b/src/types/runtime_args.rs
@@ -1,0 +1,162 @@
+use crate::types::{cl::cl_value::CLValue, sdk_error::SdkError};
+use casper_types::{bytesrepr::ToBytes, CLValue as _CLValue, RuntimeArgs as _RuntimeArgs};
+#[cfg(target_arch = "wasm32")]
+use gloo_utils::format::JsValueSerdeExt;
+use serde_json::json;
+use wasm_bindgen::prelude::*;
+
+/// Wasm/native wrapper around [`casper_types::RuntimeArgs`].
+///
+/// Use with `TransactionStrParams::set_session_args` /
+/// `SessionStrParams::set_session_args` (#43). String / JSON setters remain.
+#[wasm_bindgen]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct RuntimeArgs(_RuntimeArgs);
+
+impl RuntimeArgs {
+    pub fn inner(&self) -> &_RuntimeArgs {
+        &self.0
+    }
+
+    pub fn inner_mut(&mut self) -> &mut _RuntimeArgs {
+        &mut self.0
+    }
+
+    /// Converts typed runtime args into the JSON array shape expected by
+    /// `casper_client` session/payment `*_args_json` (ByteArray encoding).
+    pub fn to_session_args_json_array(&self) -> Vec<serde_json::Value> {
+        runtime_args_to_json_array(&self.0)
+    }
+
+    pub fn to_session_args_json_string(&self) -> Result<String, Box<SdkError>> {
+        serde_json::to_string(&self.to_session_args_json_array())
+            .map_err(|err| Box::new(SdkError::from(err)))
+    }
+
+    pub fn insert_cl_value(&mut self, name: &str, value: CLValue) {
+        self.0.insert_cl_value(name, _CLValue::from(value));
+    }
+
+    pub fn insert_simple(&mut self, arg: &str) -> Result<(), Box<SdkError>> {
+        casper_client::cli::insert_arg(arg, &mut self.0).map_err(|err| {
+            Box::new(SdkError::CustomError {
+                context: "RuntimeArgs::insert_simple",
+                error: format!("{err:?}"),
+            })
+        })?;
+        Ok(())
+    }
+}
+
+/// Shared bridge used by transaction rebuild and StrParams setters.
+pub fn runtime_args_to_json_array(args: &_RuntimeArgs) -> Vec<serde_json::Value> {
+    args.named_args()
+        .map(|named_arg| {
+            let name = named_arg.name().to_string();
+            let cl_value = named_arg.cl_value();
+            let bytes = cl_value.to_bytes().unwrap_or_default();
+            let size = bytes.len();
+            json!({
+                "name": name,
+                "type": json!({ "ByteArray": size }),
+                "value": bytes,
+            })
+        })
+        .collect()
+}
+
+#[wasm_bindgen]
+impl RuntimeArgs {
+    #[wasm_bindgen(constructor)]
+    pub fn new() -> Self {
+        RuntimeArgs(_RuntimeArgs::new())
+    }
+
+    /// Insert a named [`CLValue`].
+    #[cfg(target_arch = "wasm32")]
+    pub fn insert(&mut self, name: &str, value: &CLValue) {
+        self.insert_cl_value(name, value.clone());
+    }
+
+    /// Insert a CLI-style simple arg (`name:Type='value'`).
+    #[cfg(target_arch = "wasm32")]
+    #[wasm_bindgen(js_name = "insertSimple")]
+    pub fn insert_simple_js(&mut self, arg: &str) -> Result<(), JsError> {
+        self.insert_simple(arg)
+            .map_err(|err| JsError::new(&err.to_string()))
+    }
+
+    /// Insert from a JS object `{name,type,value}` or a simple arg string.
+    #[cfg(target_arch = "wasm32")]
+    #[wasm_bindgen(js_name = "insertJsValue")]
+    pub fn insert_js_value(&mut self, js_value_arg: JsValue) -> Result<(), JsError> {
+        crate::helpers::insert_js_value_arg(&mut self.0, js_value_arg)
+            .map(|_| ())
+            .map_err(|err| JsError::new(&err.to_string()))
+    }
+
+    /// JSON array suitable for `set_session_args_json` / payment args JSON.
+    #[cfg(target_arch = "wasm32")]
+    #[wasm_bindgen(js_name = "toSessionArgsJson")]
+    pub fn to_session_args_json_js(&self) -> Result<String, JsError> {
+        self.to_session_args_json_string()
+            .map_err(|err| JsError::new(&err.to_string()))
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    #[wasm_bindgen(js_name = "toJson")]
+    pub fn to_json(&self) -> JsValue {
+        JsValue::from_serde(&self.to_session_args_json_array()).unwrap_or(JsValue::null())
+    }
+}
+
+impl From<RuntimeArgs> for _RuntimeArgs {
+    fn from(value: RuntimeArgs) -> Self {
+        value.0
+    }
+}
+
+impl From<_RuntimeArgs> for RuntimeArgs {
+    fn from(value: _RuntimeArgs) -> Self {
+        RuntimeArgs(value)
+    }
+}
+
+impl AsRef<_RuntimeArgs> for RuntimeArgs {
+    fn as_ref(&self) -> &_RuntimeArgs {
+        &self.0
+    }
+}
+
+impl AsMut<_RuntimeArgs> for RuntimeArgs {
+    fn as_mut(&mut self) -> &mut _RuntimeArgs {
+        &mut self.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn to_session_args_json_matches_bytearray_shape() {
+        let mut args = RuntimeArgs::new();
+        args.insert_cl_value("message", CLValue::from_t("hi".to_string()).unwrap());
+        args.insert_cl_value("flag", CLValue::from_t(true).unwrap());
+
+        let json = args.to_session_args_json_string().unwrap();
+        let parsed: Vec<serde_json::Value> = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.len(), 2);
+        assert_eq!(parsed[0]["name"], "message");
+        assert!(parsed[0]["type"].get("ByteArray").is_some());
+        assert!(parsed[0]["value"].is_array());
+        assert_eq!(parsed[1]["name"], "flag");
+    }
+
+    #[test]
+    fn insert_simple_parses_cli_string() {
+        let mut args = RuntimeArgs::new();
+        args.insert_simple("message:String='Hello Casper'").unwrap();
+        assert_eq!(args.inner().len(), 1);
+    }
+}

--- a/src/types/runtime_args.rs
+++ b/src/types/runtime_args.rs
@@ -7,8 +7,8 @@ use wasm_bindgen::prelude::*;
 
 /// Wasm/native wrapper around [`casper_types::RuntimeArgs`].
 ///
-/// Use with `TransactionStrParams::set_session_args` /
-/// `SessionStrParams::set_session_args` (#43). String / JSON setters remain.
+/// Pass to `set_session_args` on transaction (or legacy deploy) session params (#43).
+/// `set_session_args_simple` / `set_session_args_json` remain for string bags.
 #[wasm_bindgen]
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct RuntimeArgs(_RuntimeArgs);

--- a/src/types/transaction.rs
+++ b/src/types/transaction.rs
@@ -30,8 +30,8 @@ use crate::{make_transaction, make_transfer_transaction::make_transfer_transacti
 use casper_types::PricingMode as _PricingMode;
 #[cfg(feature = "transaction")]
 use casper_types::{
-    account::AccountHash as _AccountHash, bytesrepr::Bytes as _Bytes, bytesrepr::ToBytes,
-    PublicKey as _PublicKey, TransactionInvocationTarget, URef as _URef, U512,
+    account::AccountHash as _AccountHash, bytesrepr::Bytes as _Bytes, PublicKey as _PublicKey,
+    TransactionInvocationTarget, URef as _URef, U512,
 };
 use casper_types::{
     bytesrepr, Approval, ApprovalsHash, AsymmetricType, Deploy, GasLimited, InitiatorAddr,
@@ -696,37 +696,7 @@ impl Transaction {
 
     #[cfg(feature = "transaction")]
     fn args_to_json_array(&self, new_args: &RuntimeArgs) -> Vec<serde_json::Value> {
-        new_args
-            .named_args()
-            .map(|named_arg| {
-                let name = named_arg.name().to_string();
-                let cl_value = named_arg.cl_value();
-                // let cl_type = cl_value.cl_type().to_string();
-                // let capitalized_type = cl_type
-                //     .chars()
-                //     .next()
-                //     .map(|c| c.to_uppercase().collect::<String>() + &cl_type[1..])
-                //     .unwrap_or_default();
-
-                // let value_json: serde_json::Value =
-                //     serde_json::to_value(cl_value).unwrap_or(serde_json::Value::Null);
-
-                // let value = value_json
-                //     .get("parsed")
-                //     .cloned()
-                //     .unwrap_or(serde_json::Value::Null);
-
-                let bytes = cl_value.to_bytes().unwrap_or_default();
-                let size = bytes.len();
-
-                let json_value = json!({
-                    "name": name,
-                    "type": json!({ "ByteArray": size }),
-                    "value": bytes,
-                });
-                json_value
-            })
-            .collect()
+        crate::types::runtime_args::runtime_args_to_json_array(new_args)
     }
 
     #[cfg(feature = "transaction")]

--- a/src/types/transaction_params/transaction_str_params.rs
+++ b/src/types/transaction_params/transaction_str_params.rs
@@ -4,6 +4,7 @@ use crate::helpers::get_ttl_or_default;
 use crate::types::cl::bytes::Bytes;
 use crate::types::deploy_params::args_simple::ArgsSimple;
 use crate::types::pricing_mode::PricingMode;
+use crate::types::runtime_args::RuntimeArgs;
 use casper_client::cli::TransactionStrParams as _TransactionStrParams;
 use once_cell::sync::OnceCell;
 use wasm_bindgen::prelude::*;
@@ -246,6 +247,14 @@ impl TransactionStrParams {
         self.session_args_json
             .set(session_args_json.to_string())
             .unwrap();
+    }
+
+    /// Set session args from typed [`RuntimeArgs`] (fills `session_args_json`).
+    pub fn set_session_args(&self, args: &RuntimeArgs) {
+        let json = args
+            .to_session_args_json_string()
+            .expect("RuntimeArgs to session args JSON");
+        self.set_session_args_json(&json);
     }
 
     #[wasm_bindgen(getter)]
@@ -595,5 +604,25 @@ mod tests {
         assert_eq!(result.session_entry_point, None);
         assert_eq!(result.chunked_args, None);
         assert!(!result.min_bid_override);
+    }
+
+    #[test]
+    fn test_set_session_args_from_runtime_args() {
+        use crate::types::cl::cl_value::CLValue;
+
+        let transaction_params = TransactionStrParams::default();
+        let mut args = RuntimeArgs::new();
+        args.insert_cl_value("message", CLValue::from_t("hi".to_string()).unwrap());
+        args.insert_cl_value("count", CLValue::from_t(7u64).unwrap());
+        transaction_params.set_session_args(&args);
+
+        let json = transaction_params.session_args_json().unwrap();
+        let parsed: Vec<serde_json::Value> = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.len(), 2);
+        assert_eq!(parsed[0]["name"], "message");
+        assert!(parsed[0]["type"].get("ByteArray").is_some());
+
+        let client = transaction_str_params_to_casper_client(&transaction_params);
+        assert_eq!(client.session_args_json, json);
     }
 }

--- a/src/types/transaction_params/transaction_str_params.rs
+++ b/src/types/transaction_params/transaction_str_params.rs
@@ -249,7 +249,7 @@ impl TransactionStrParams {
             .unwrap();
     }
 
-    /// Set session args from typed [`RuntimeArgs`] (fills `session_args_json`).
+    /// Typed session args. Parameter type is [`RuntimeArgs`]; string setters stay separate.
     pub fn set_session_args(&self, args: &RuntimeArgs) {
         let json = args
             .to_session_args_json_string()

--- a/tests/integration/rust/src/lib.rs
+++ b/tests/integration/rust/src/lib.rs
@@ -1,2 +1,4 @@
+#![allow(deprecated)] // legacy Deploy / SessionStrParams coverage
+
 pub mod config;
 pub mod tests;

--- a/tests/integration/rust/src/tests/integration/contract/mod.rs
+++ b/tests/integration/rust/src/tests/integration/contract/mod.rs
@@ -49,7 +49,7 @@ pub mod test_module {
         };
         session_params.set_session_bytes(module_bytes.into());
         let args_simple: Vec<String> = ARGS_SIMPLE.iter().map(|s| s.to_string()).collect();
-        session_params.set_session_args(args_simple);
+        session_params.set_session_args_simple_vec(args_simple);
 
         let install = create_test_sdk(Some(config))
             .install_deploy(deploy_params, session_params, PAYMENT_AMOUNT, None)

--- a/tests/integration/rust/src/tests/integration/contract/mod.rs
+++ b/tests/integration/rust/src/tests/integration/contract/mod.rs
@@ -49,7 +49,7 @@ pub mod test_module {
         };
         session_params.set_session_bytes(module_bytes.into());
         let args_simple: Vec<String> = ARGS_SIMPLE.iter().map(|s| s.to_string()).collect();
-        session_params.set_session_args_simple_vec(args_simple);
+        session_params.set_session_args_simple(args_simple);
 
         let install = create_test_sdk(Some(config))
             .install_deploy(deploy_params, session_params, PAYMENT_AMOUNT, None)

--- a/tests/integration/rust/src/tests/integration/types/deploy.rs
+++ b/tests/integration/rust/src/tests/integration/types/deploy.rs
@@ -534,7 +534,7 @@ pub mod test_module_deploy {
             "foo:Bool='true'".to_string(),
             "bar:String='value'".to_string(),
         ]);
-        session_params.set_session_args_simple_vec(args.clone());
+        session_params.set_session_args_simple(args.clone());
         let payment_params = PaymentStrParams::default();
         payment_params.set_payment_amount(PAYMENT_AMOUNT);
         let deploy =

--- a/tests/integration/rust/src/tests/integration/types/deploy.rs
+++ b/tests/integration/rust/src/tests/integration/types/deploy.rs
@@ -534,7 +534,7 @@ pub mod test_module_deploy {
             "foo:Bool='true'".to_string(),
             "bar:String='value'".to_string(),
         ]);
-        session_params.set_session_args(args.clone());
+        session_params.set_session_args_simple_vec(args.clone());
         let payment_params = PaymentStrParams::default();
         payment_params.set_payment_amount(PAYMENT_AMOUNT);
         let deploy =

--- a/tests/integration/rust/src/tests/mod.rs
+++ b/tests/integration/rust/src/tests/mod.rs
@@ -1105,7 +1105,7 @@ MC4CAQAwBQYDK2VwBCIEII8ULlk1CJ12ZQ+bScjBt/IxMAZNggClWqK56D1/7CbI
         "token_meta_data:String='test_meta_data'".to_string(),
         format!("token_owner:Key='{TOKEN_OWNER}'").to_string(),
     ]);
-    session_params.set_session_args(args);
+    session_params.set_session_args_simple_vec(args);
 
     let payment_params = PaymentStrParams::default();
     payment_params.set_payment_amount(PAYMENT_AMOUNT);

--- a/tests/integration/rust/src/tests/mod.rs
+++ b/tests/integration/rust/src/tests/mod.rs
@@ -1105,7 +1105,7 @@ MC4CAQAwBQYDK2VwBCIEII8ULlk1CJ12ZQ+bScjBt/IxMAZNggClWqK56D1/7CbI
         "token_meta_data:String='test_meta_data'".to_string(),
         format!("token_owner:Key='{TOKEN_OWNER}'").to_string(),
     ]);
-    session_params.set_session_args_simple_vec(args);
+    session_params.set_session_args_simple(args);
 
     let payment_params = PaymentStrParams::default();
     payment_params.set_payment_amount(PAYMENT_AMOUNT);


### PR DESCRIPTION
## Summary
- Expose wasm/native `RuntimeArgs` (+ minimal `CLValue`) so session args can be typed, not only strings/JSON.
- Add `set_session_args(&RuntimeArgs)` on `TransactionStrParams` and legacy `SessionStrParams` — name is short; the parameter type is the discriminator. Keep `set_session_args_simple` / `set_session_args_json`.
- Align Session `set_session_args_simple` to `Vec<String>` (same as Transaction). Intentionally breaks the old Rust-only `SessionStrParams::set_session_args(Vec<String>)` (legacy Deploy); callers should use `set_session_args_simple` or typed `set_session_args`.
- Mark `SessionStrParams` `#[deprecated(note = "prefer TransactionStrParams")]`.

Closes #43.

## API surface (Rust + JS)

| Method | Takes |
| --- | --- |
| `set_session_args_simple` | string bag |
| `set_session_args_json` | JSON string |
| `set_session_args` | `RuntimeArgs` (**new**) |

## Test plan
- [x] `cargo test -p casper-rust-wasm-sdk --lib set_session_args_from_runtime`
- [x] `cargo check -p casper-rust-wasm-sdk --target wasm32-unknown-unknown`
- [x] `cargo check -p casper-rust-wasm-sdk-mcp`
- [ ] Spot-check JS: `new RuntimeArgs()` → `insert` → `transactionParams.set_session_args(args)`