### PR TITLE
Pin Binaryen 130 for wasm-pack packs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ target/
 *.pem
 
 .env
+
+# Local Binaryen pin (make ensure-binaryen)
+.tools/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,10 +96,6 @@ opt-level = "s"
 strip = true
 panic = "abort"
 
-# Needs Binaryen/wasm-opt that accepts rustc's bulk-memory ops (--all-features).
-[package.metadata.wasm-pack.profile.release]
-wasm-opt = ["-O", "--all-features"]
-
 [dev-dependencies]
 sdk_tests = { path = "tests/integration/rust" }
 tokio = { version = "1", features = ["full"] }

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,46 @@ WASM_FEATURES_FULL =
 WASM_FEATURES_READ_ONLY = --no-default-features
 WASM_FEATURES_TRANSACTION = --no-default-features --features transaction,helpers,watcher
 
-.PHONY: all web nodejs clean build doc web-full web-read-only web-transaction nodejs-full nodejs-read-only
+# Pin Binaryen so wasm-pack does not fall back to its vendored 117 download.
+BINARYEN_VERSION := 130
+BINARYEN_DIR := $(CURDIR)/.tools/binaryen-version_$(BINARYEN_VERSION)
+BINARYEN_BIN := $(BINARYEN_DIR)/bin
+BINARYEN_PATH_FILE := $(CURDIR)/.tools/wasm-opt-bin
+
+.PHONY: all web nodejs clean build doc web-full web-read-only web-transaction nodejs-full nodejs-read-only ensure-binaryen
+
+ensure-binaryen:
+	@set -euo pipefail; \
+	mkdir -p "$(CURDIR)/.tools"; \
+	is_pin() { "$$1" --version 2>/dev/null | grep -qE 'version[_ ]$(BINARYEN_VERSION)([^0-9]|$$)'; }; \
+	if command -v wasm-opt >/dev/null 2>&1 && is_pin wasm-opt; then \
+		dirname "$$(command -v wasm-opt)" > "$(BINARYEN_PATH_FILE)"; \
+		echo "ensure-binaryen: $$(wasm-opt --version) (PATH)"; \
+		exit 0; \
+	fi; \
+	if [ -x "$(BINARYEN_BIN)/wasm-opt" ] && is_pin "$(BINARYEN_BIN)/wasm-opt"; then \
+		echo "$(BINARYEN_BIN)" > "$(BINARYEN_PATH_FILE)"; \
+		echo "ensure-binaryen: $$($(BINARYEN_BIN)/wasm-opt --version) ($(BINARYEN_BIN))"; \
+		exit 0; \
+	fi; \
+	case "$$(uname -m)" in \
+		x86_64|amd64) arch=x86_64 ;; \
+		aarch64|arm64) arch=aarch64 ;; \
+		*) echo "ensure-binaryen: unsupported arch $$(uname -m)" >&2; exit 1 ;; \
+	esac; \
+	case "$$(uname -s)" in \
+		Linux) plat=linux ;; \
+		Darwin) plat=macos ;; \
+		*) echo "ensure-binaryen: unsupported OS $$(uname -s)" >&2; exit 1 ;; \
+	esac; \
+	url="https://github.com/WebAssembly/binaryen/releases/download/version_$(BINARYEN_VERSION)/binaryen-version_$(BINARYEN_VERSION)-$${arch}-$${plat}.tar.gz"; \
+	echo "ensure-binaryen: downloading $$url"; \
+	rm -rf "$(BINARYEN_DIR)"; \
+	curl -fsSL "$$url" | tar -xz -C "$(CURDIR)/.tools"; \
+	test -x "$(BINARYEN_BIN)/wasm-opt"; \
+	is_pin "$(BINARYEN_BIN)/wasm-opt" || { echo "ensure-binaryen: expected version $(BINARYEN_VERSION)" >&2; exit 1; }; \
+	echo "$(BINARYEN_BIN)" > "$(BINARYEN_PATH_FILE)"; \
+	echo "ensure-binaryen: $$($(BINARYEN_BIN)/wasm-opt --version)"
 
 pack: web nodejs
 
@@ -19,20 +58,20 @@ web: web-full
 
 nodejs: nodejs-full
 
-web-full:
-	wasm-pack build --target web --release --out-dir $(WEB_OUT_DIR) $(CURRENT_DIR) $(WASM_FEATURES_FULL)
+web-full: ensure-binaryen
+	PATH="$$(cat "$(BINARYEN_PATH_FILE)"):$$PATH" wasm-pack build --target web --release --out-dir $(WEB_OUT_DIR) $(CURRENT_DIR) $(WASM_FEATURES_FULL)
 
-web-read-only:
-	wasm-pack build --target web --release --out-dir $(WEB_OUT_DIR) $(CURRENT_DIR) $(WASM_FEATURES_READ_ONLY)
+web-read-only: ensure-binaryen
+	PATH="$$(cat "$(BINARYEN_PATH_FILE)"):$$PATH" wasm-pack build --target web --release --out-dir $(WEB_OUT_DIR) $(CURRENT_DIR) $(WASM_FEATURES_READ_ONLY)
 
-web-transaction:
-	wasm-pack build --target web --release --out-dir $(WEB_OUT_DIR) $(CURRENT_DIR) $(WASM_FEATURES_TRANSACTION)
+web-transaction: ensure-binaryen
+	PATH="$$(cat "$(BINARYEN_PATH_FILE)"):$$PATH" wasm-pack build --target web --release --out-dir $(WEB_OUT_DIR) $(CURRENT_DIR) $(WASM_FEATURES_TRANSACTION)
 
-nodejs-full:
-	wasm-pack build --target nodejs --release --out-dir $(NODEJS_OUT_DIR) $(CURRENT_DIR) $(WASM_FEATURES_FULL)
+nodejs-full: ensure-binaryen
+	PATH="$$(cat "$(BINARYEN_PATH_FILE)"):$$PATH" wasm-pack build --target nodejs --release --out-dir $(NODEJS_OUT_DIR) $(CURRENT_DIR) $(WASM_FEATURES_FULL)
 
-nodejs-read-only:
-	wasm-pack build --target nodejs --release --out-dir $(NODEJS_OUT_DIR) $(CURRENT_DIR) $(WASM_FEATURES_READ_ONLY)
+nodejs-read-only: ensure-binaryen
+	PATH="$$(cat "$(BINARYEN_PATH_FILE)"):$$PATH" wasm-pack build --target nodejs --release --out-dir $(NODEJS_OUT_DIR) $(CURRENT_DIR) $(WASM_FEATURES_READ_ONLY)
 
 clean:
 	rm -rf $(WEB_OUT_DIR) $(NODEJS_OUT_DIR)

--- a/docs/README.md
+++ b/docs/README.md
@@ -92,6 +92,8 @@ $ make prepare
 $ make pack
 ```
 
+`make pack` ensures Binaryen **version_130** on `PATH` (host or `.tools/`) so `wasm-pack` does not fall back to its vendored Binaryen 117. Do not use `apt install binaryen` (often 120).
+
 This will create a `pkg` and `pkg-nodejs` containing the Typescript interfaces. You can find more details about building the SDK for Javascript with `wasm-pack` in the [wasm-pack documention](https://rustwasm.github.io/docs/wasm-pack/commands/build.html).
 
 ### Cargo features


### PR DESCRIPTION
## Summary
- `make ensure-binaryen` pins Binaryen **version_130** on PATH (or `.tools/`) before every `wasm-pack` pack so CI does not fall back to wasm-pack’s vendored Binaryen 117.
- Removes `[package.metadata.wasm-pack.profile.release]` `--all-features` workaround; default `-O` is enough with Binaryen 130.
- Documents the pin in `docs/README.md`.

## Test plan
- [ ] `make ensure-binaryen` reports version 130
- [ ] `make pack` (or `web-full`) finds wasm-opt 130 and completes
- [ ] Confirm pack log does not pull Binaryen 117 from `~/.cache/.wasm-pack`


Made with [Cursor](https://cursor.com)