### PR TITLE
fix(mcp): keep publishing slim casper-rust-wasm-sdk-mcp Hub image

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -32,10 +32,12 @@ jobs:
             --build-arg APP_VERSION="$APP_VERSION" \
             --build-arg GIT_SHA="${{ github.sha }}"
 
-          # MCP binary is embedded in casper-webclient (ENABLE_MCP / entrypoint mcp).
-          # Do not build or push the deprecated slim casper-rust-wasm-sdk-mcp Hub image.
+          # Slim MCP for Cursor/agents (stdio / HTTP :5790).
+          docker build -f mcp/Dockerfile -t casper-rust-wasm-sdk-mcp:latest .
+
           # Tags: :latest, :dev, and :$APP_VERSION (from package.json, e.g. 2.2.2). No :stable.
-          for image in casper-webclient cors-anywhere ws-proxy; do
+          # webclient also embeds the MCP binary (ENABLE_MCP / entrypoint mcp).
+          for image in casper-webclient cors-anywhere ws-proxy casper-rust-wasm-sdk-mcp; do
             docker tag "${image}:latest" "${{ secrets.DOCKER_USERNAME_ITC }}/${image}:latest"
             docker tag "${image}:latest" "${{ secrets.DOCKER_USERNAME_ITC }}/${image}:dev"
             docker tag "${image}:latest" "${{ secrets.DOCKER_USERNAME_ITC }}/${image}:${APP_VERSION}"
@@ -44,7 +46,7 @@ jobs:
       - name: Push Docker images to Docker Hub
         run: |
           APP_VERSION=$(jq -r .version examples/frontend/angular/package.json)
-          for image in casper-webclient cors-anywhere ws-proxy; do
+          for image in casper-webclient cors-anywhere ws-proxy casper-rust-wasm-sdk-mcp; do
             docker push "${{ secrets.DOCKER_USERNAME_ITC }}/${image}:latest"
             docker push "${{ secrets.DOCKER_USERNAME_ITC }}/${image}:dev"
             docker push "${{ secrets.DOCKER_USERNAME_ITC }}/${image}:${APP_VERSION}"

--- a/Makefile
+++ b/Makefile
@@ -162,17 +162,17 @@ docker-deploy-prod:
 
 .PHONY: docker-build docker-start docker-stop docker-start-prod docker-stop-prod
 
-# --- MCP (mcp/ crate; runtime via casper-webclient image) ---
-# Hub: interchouette/casper-webclient:{dev,latest,$APP_VERSION}. Slim casper-rust-wasm-sdk-mcp Hub image is deprecated.
+# --- MCP (mcp/ crate) ---
+# Cursor/agents: interchouette/casper-rust-wasm-sdk-mcp:{dev,latest,$APP_VERSION} (stdio / HTTP :5790)
+# SPA demo:      interchouette/casper-webclient embeds the same binary (ENABLE_MCP, /mcp on :8080)
 
-WEBCLIENT_HUB_IMAGE ?= interchouette/casper-webclient
-CASPER_SDK_MCP_IMAGE ?= $(WEBCLIENT_HUB_IMAGE):dev
+CASPER_SDK_MCP_IMAGE ?= interchouette/casper-rust-wasm-sdk-mcp:dev
 COMPOSE_MCP ?= docker/docker-compose.mcp.yml
 
 mcp-build:
 	cargo build -p casper-rust-wasm-sdk-mcp --release
 
-# Local HTTP via webclient (SPA :8080 + /mcp). MCP stays on container loopback.
+# Local HTTP via slim MCP image (:5790).
 mcp-http:
 	-docker pull $(CASPER_SDK_MCP_IMAGE)
 	CASPER_SDK_MCP_IMAGE=$(CASPER_SDK_MCP_IMAGE) \
@@ -180,8 +180,8 @@ mcp-http:
 
 mcp-http-stop:
 	-docker compose -f $(COMPOSE_MCP) down --remove-orphans
-	-docker stop casper-webclient-mcp 2>/dev/null
-	-docker rm casper-webclient-mcp 2>/dev/null
+	-docker stop casper-rust-wasm-sdk-mcp 2>/dev/null
+	-docker rm casper-rust-wasm-sdk-mcp 2>/dev/null
 
 run-mcp:
 	cargo run -p casper-rust-wasm-sdk-mcp --quiet --

--- a/docker/docker-compose.mcp.yml
+++ b/docker/docker-compose.mcp.yml
@@ -1,19 +1,18 @@
-# MCP via unified webclient image (SPA :8080 + /mcp proxy).
-# Publishes host :8080 only; MCP listens on container loopback :5790.
+# Slim MCP for Cursor/agents (HTTP :5790).
 # Use: make mcp-http / make mcp-http-stop
-# Hosted: https://casper-webclient.interchouette.net/mcp
+# Hosted SPA + /mcp: https://casper-webclient.interchouette.net/mcp (casper-webclient image)
 services:
   sdk-mcp:
-    image: ${CASPER_SDK_MCP_IMAGE:-interchouette/casper-webclient:dev}
-    container_name: casper-webclient-mcp
+    image: ${CASPER_SDK_MCP_IMAGE:-interchouette/casper-rust-wasm-sdk-mcp:dev}
+    container_name: casper-rust-wasm-sdk-mcp
     ports:
-      - "8080:8080"
+      - "5790:5790"
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
-      ENABLE_MCP: "1"
+      CASPER_SDK_MCP_ADDR: "0.0.0.0:5790"
       CASPER_RPC_URL: ${CASPER_RPC_URL:-http://host.docker.internal:11101}
       CASPER_NODE_URL: ${CASPER_NODE_URL:-host.docker.internal:28101}
       RUST_LOG: ${RUST_LOG:-warn}
-    command: ["web"]
+    command: ["--http", "--listen", "0.0.0.0:5790"]
     restart: unless-stopped

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,17 +23,18 @@ Demo / development only — same warning as above.
 
 ## MCP
 
-The workspace package [`mcp/`](../mcp/) (`casper-rust-wasm-sdk-mcp`) exposes the native Rust SDK as [MCP](https://modelcontextprotocol.io/) tools for Cursor and other agents. The binary ships inside **`interchouette/casper-webclient`** (`:dev` / `:latest` / `:$APP_VERSION`).
+The workspace package [`mcp/`](../mcp/) (`casper-rust-wasm-sdk-mcp`) exposes the native Rust SDK as [MCP](https://modelcontextprotocol.io/) tools for Cursor and other agents.
 
-- **Hosted:** https://casper-webclient.interchouette.net/mcp (`ENABLE_MCP=1`, `/mcp` proxy on the SPA)
-- **Local Docker:** `make mcp-http` → http://127.0.0.1:8080/mcp
+- **Cursor/agents (slim Hub):** `interchouette/casper-rust-wasm-sdk-mcp` (`:dev` / `:latest` / `:$APP_VERSION`)
+- **Hosted SPA:** https://casper-webclient.interchouette.net/mcp (`casper-webclient` embeds the same binary, `ENABLE_MCP=1`)
+- **Local Docker:** `make mcp-http` → http://127.0.0.1:5790/mcp
 - **Host HTTP:** `make run-mcp-http` → http://127.0.0.1:5790/mcp
-- **stdio:** `interchouette/casper-webclient:dev` with `--entrypoint casper-rust-wasm-sdk-mcp` (see [`mcp/mcp.json.example`](../mcp/mcp.json.example))
+- **stdio:** `interchouette/casper-rust-wasm-sdk-mcp:dev` (see [`mcp/mcp.json.example`](../mcp/mcp.json.example))
 
 ```bash
 make run-mcp      # stdio (host cargo)
 make run-mcp-http # HTTP on 127.0.0.1:5790
-make mcp-http     # webclient → http://127.0.0.1:8080/mcp
+make mcp-http     # slim image → http://127.0.0.1:5790/mcp
 make mcp-test
 make mcp-test-live  # against a live local node
 ```

--- a/mcp/Dockerfile
+++ b/mcp/Dockerfile
@@ -1,5 +1,6 @@
-# DEPRECATED for Hub / Cursor. Prefer interchouette/casper-webclient:{dev,latest,$APP_VERSION}
-# which embeds the same binary (see docker/Dockerfile.cicd). Kept for local experiments only.
+# Hub / Cursor runtime: interchouette/casper-rust-wasm-sdk-mcp:{dev,latest,$APP_VERSION}
+# Slim MCP that drives the SDK (stdio or HTTP :5790).
+# Webclient embeds the same binary (docker/Dockerfile.cicd); that image is the SPA + /mcp demo.
 #   docker build -f mcp/Dockerfile -t casper-rust-wasm-sdk-mcp:local .
 
 ARG RUST_IMAGE=rust:slim-bookworm
@@ -42,5 +43,5 @@ ENV CASPER_SDK_MCP_ADDR=0.0.0.0:5790 \
 
 EXPOSE 5790
 
+# Default stdio for Cursor; pass --http --listen for Docker HTTP (see docker-compose.mcp.yml).
 ENTRYPOINT ["casper-rust-wasm-sdk-mcp"]
-CMD ["--http", "--listen", "0.0.0.0:5790"]

--- a/mcp/PATTERNS.md
+++ b/mcp/PATTERNS.md
@@ -111,11 +111,11 @@ assert!(include_str!("server.rs").contains(&needle));
 | --- | --- |
 | `mcp-build` | release build of mcp package |
 | `run-mcp` | stdio (host cargo) |
-| `mcp-http` | webclient Docker → `http://127.0.0.1:8080/mcp` |
+| `mcp-http` | slim Docker → `http://127.0.0.1:5790/mcp` |
 | `run-mcp-http` | host cargo HTTP on `127.0.0.1:5790` |
 | `mcp-test` | `cargo test -p casper-rust-wasm-sdk-mcp` |
 
-Runtime image: `interchouette/casper-webclient:{dev,latest,$APP_VERSION}`. See [mcp.json.example](mcp.json.example).
+Cursor/agents image: `interchouette/casper-rust-wasm-sdk-mcp:{dev,latest,$APP_VERSION}`. SPA embeds the same binary: `interchouette/casper-webclient`. See [mcp.json.example](mcp.json.example).
 
 ---
 
@@ -126,5 +126,6 @@ Runtime image: `interchouette/casper-webclient:{dev,latest,$APP_VERSION}`. See [
 | Separate `mcp/` crate, mcpkit | keep mcpkit off the wasm root crate |
 | Path-dep on SDK lib | in-process tools, not an HTTP proxy of the SDK |
 | clap `--http` / `--listen` | stdio or Streamable HTTP from one binary |
-| MCP embedded in webclient image | SPA `:8080` + loopback MCP `:5790` + `/mcp` proxy |
+| Slim Hub image for agents | Cursor pulls MCP without SPA/Node layers |
+| MCP also embedded in webclient | SPA `:8080` + loopback MCP `:5790` + `/mcp` proxy |
 | stderr warn logging | quiet default for MCP clients |

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -2,22 +2,27 @@
 
 Rust **mcpkit** crate (`casper-rust-wasm-sdk-mcp`) exposing the native SDK API as MCP tools (in-process path dependency — not an HTTP proxy of the SDK).
 
-**Runtime image:** the binary ships inside **`interchouette/casper-webclient`** (`:dev`, `:latest`, and the app version tag such as `:2.2.2`). The slim Hub image `casper-rust-wasm-sdk-mcp` is deprecated.
+**Two Hub images:**
+
+| Image | Role |
+| ----- | ---- |
+| **`interchouette/casper-rust-wasm-sdk-mcp`** | Slim MCP for Cursor/agents (stdio / HTTP `:5790`) |
+| **`interchouette/casper-webclient`** | SPA demo; embeds the same binary (`ENABLE_MCP=1`, `/mcp` on `:8080`) |
 
 Inventory: [TOOLS.md](TOOLS.md). Patterns: [PATTERNS.md](PATTERNS.md). MCP client sample: [mcp.json.example](mcp.json.example).
 
 ## Transports
 
-| Mode               | How                                                     | URL / notes                                      |
-| ------------------ | ------------------------------------------------------- | ------------------------------------------------ |
-| **Hosted**         | Render webclient                                        | `https://casper-webclient.interchouette.net/mcp` |
-| **HTTP (Docker)**  | `make mcp-http` → webclient SPA                         | `http://127.0.0.1:8080/mcp` (`ENABLE_MCP=1`)     |
-| **stdio (Docker)** | `docker run -i … --entrypoint casper-rust-wasm-sdk-mcp` | `interchouette/casper-webclient:dev`             |
-| **stdio (host)**   | `make run-mcp`                                          | cargo; for local debug                           |
-| **HTTP (host)**    | `make run-mcp-http`                                     | cargo on `127.0.0.1:5790`                        |
+| Mode               | How                                                      | URL / notes                                      |
+| ------------------ | -------------------------------------------------------- | ------------------------------------------------ |
+| **Hosted**         | Render webclient                                         | `https://casper-webclient.interchouette.net/mcp` |
+| **HTTP (Docker)**  | `make mcp-http` → slim MCP image                         | `http://127.0.0.1:5790/mcp`                      |
+| **stdio (Docker)** | `docker run -i … interchouette/casper-rust-wasm-sdk-mcp` | `:dev` / `:latest` / `:$APP_VERSION`             |
+| **stdio (host)**   | `make run-mcp`                                           | cargo; for local debug                           |
+| **HTTP (host)**    | `make run-mcp-http`                                      | cargo on `127.0.0.1:5790`                        |
 
 ```bash
-make mcp-http           # webclient → http://127.0.0.1:8080/mcp
+make mcp-http           # slim image → http://127.0.0.1:5790/mcp
 make mcp-http-stop
 make run-mcp            # stdio (host cargo)
 make run-mcp-http       # HTTP host on 127.0.0.1:5790
@@ -27,15 +32,15 @@ make mcp-test-live      # ignored tests vs live local node (CASPER_RPC_URL)
 
 ## Env
 
-| Variable              | Role                                    | Default                                                       |
-| --------------------- | --------------------------------------- | ------------------------------------------------------------- |
-| `ENABLE_MCP`          | Start MCP inside webclient (`web` mode) | `1`                                                           |
-| `MCP_HTTP`            | Use HTTP transport (binary)             | off (stdio) / on (web loopback)                               |
-| `CASPER_SDK_MCP_ADDR` | HTTP bind                               | `0.0.0.0:5790` (host) / `127.0.0.1:5790` (webclient loopback) |
-| `CASPER_RPC_URL`      | JSON-RPC                                | `http://127.0.0.1:11101`                                      |
-| `CASPER_NODE_URL`     | Binary port                             | `127.0.0.1:28101`                                             |
-| `CASPER_VERBOSITY`    | `low` / `medium` / `high`               | `low`                                                         |
-| `RUST_LOG`            | tracing filter (stderr, no ANSI)        | `warn`                                                        |
+| Variable              | Role                                    | Default                                                     |
+| --------------------- | --------------------------------------- | ----------------------------------------------------------- |
+| `ENABLE_MCP`          | Start MCP inside webclient (`web` mode) | `1`                                                         |
+| `MCP_HTTP`            | Use HTTP transport (binary)             | off (stdio) / on (Docker HTTP / web loopback)               |
+| `CASPER_SDK_MCP_ADDR` | HTTP bind                               | `0.0.0.0:5790` (slim / host) / `127.0.0.1:5790` (webclient) |
+| `CASPER_RPC_URL`      | JSON-RPC                                | `http://127.0.0.1:11101`                                    |
+| `CASPER_NODE_URL`     | Binary port                             | `127.0.0.1:28101`                                           |
+| `CASPER_VERBOSITY`    | `low` / `medium` / `high`               | `low`                                                       |
+| `RUST_LOG`            | tracing filter (stderr, no ANSI)        | `warn`                                                      |
 
 Docker containers reach the host node via `host.docker.internal`.
 
@@ -68,11 +73,11 @@ Complex inputs use JSON strings — see [TOOLS.md](TOOLS.md) and `tools/params.r
 
 ## MCP client config
 
-Hub tags for `interchouette/casper-webclient`: **`dev`**, **`latest`**, and the app version (e.g. **`2.2.2`**).
+Hub tags for `interchouette/casper-rust-wasm-sdk-mcp` and `interchouette/casper-webclient`: **`dev`**, **`latest`**, and the app version (e.g. **`2.2.2`**).
 
-| Server name (example)       | Transport | Backing                                                                        |
-| --------------------------- | --------- | ------------------------------------------------------------------------------ |
-| `casper-rust-wasm-sdk`      | stdio     | `interchouette/casper-webclient:dev` (`--entrypoint casper-rust-wasm-sdk-mcp`) |
-| `casper-rust-wasm-sdk-http` | HTTP      | `http://127.0.0.1:8080/mcp` (webclient) or `http://127.0.0.1:5790/mcp` (host)  |
+| Server name (example)       | Transport | Backing                                                       |
+| --------------------------- | --------- | ------------------------------------------------------------- |
+| `casper-rust-wasm-sdk`      | stdio     | `interchouette/casper-rust-wasm-sdk-mcp:dev`                  |
+| `casper-rust-wasm-sdk-http` | HTTP      | `http://127.0.0.1:5790/mcp` (slim) or hosted webclient `/mcp` |
 
 Full sample: [mcp.json.example](mcp.json.example).

--- a/mcp/mcp.json.example
+++ b/mcp/mcp.json.example
@@ -13,14 +13,17 @@
         "-e",
         "CASPER_NODE_URL=host.docker.internal:28101",
         "-e",
+        "MCP_HTTP=false",
+        "-e",
         "RUST_LOG=warn",
-        "--entrypoint",
-        "casper-rust-wasm-sdk-mcp",
-        "interchouette/casper-webclient:dev"
+        "interchouette/casper-rust-wasm-sdk-mcp:dev"
       ]
     },
     "casper-rust-wasm-sdk-http": {
-      "url": "http://127.0.0.1:8080/mcp"
+      "url": "http://127.0.0.1:5790/mcp"
+    },
+    "casper-rust-wasm-sdk-hosted": {
+      "url": "https://casper-webclient.interchouette.net/mcp"
     },
     "casper-rust-wasm-sdk-stdio-cargo": {
       "command": "cargo",


### PR DESCRIPTION
## Summary
- Resume Hub build/push of `interchouette/casper-rust-wasm-sdk-mcp` (`:latest` / `:dev` / `:$APP_VERSION`) alongside webclient
- Point `make mcp-http` and compose at the slim image on `:5790` (stdio by default in the Dockerfile)
- Document two roles: slim MCP drives the SDK for agents; `casper-webclient` embeds the same binary for SPA + `/mcp`

## Test plan
- [ ] CI `docker-build-push` builds and pushes `casper-rust-wasm-sdk-mcp` tags
- [ ] `make mcp-http` serves `http://127.0.0.1:5790/mcp`
- [ ] Agent stdio still uses `interchouette/casper-rust-wasm-sdk-mcp:dev`
- [ ] Hosted `https://casper-webclient.interchouette.net/mcp` unchanged (webclient embed)