### PR TITLE
fix(ts): silence TS 6 option deprecations under Angular 21

### DIFF
--- a/examples/frontend/angular/libs/util/hihlight-webworker/src/lib/highlight.service.ts
+++ b/examples/frontend/angular/libs/util/hihlight-webworker/src/lib/highlight.service.ts
@@ -15,7 +15,7 @@ export class HighlightService {
   async highlightMessage<T>(message: T): Promise<string> {
     this.activateWorker();
     const hightlight = this.hightlightWebworker && await this.hightlightWebworker.postMessage<string, T>(message)
-      .catch((error) => {
+      .catch((error: unknown) => {
         console.error(error);
       });
     this.terminateWorker();

--- a/examples/frontend/angular/libs/util/services/result/tsconfig.lib.json
+++ b/examples/frontend/angular/libs/util/services/result/tsconfig.lib.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "ignoreDeprecations": "6.0",
     "outDir": "../../../../dist/out-tsc",
     "declaration": true,
     "declarationMap": true,

--- a/examples/frontend/angular/tsconfig.base.json
+++ b/examples/frontend/angular/tsconfig.base.json
@@ -13,6 +13,8 @@
     "lib": ["es2020", "dom"],
     "skipLibCheck": true,
     "skipDefaultLibCheck": true,
+    // Angular 21 requires typescript >=5.9 <6.0; silence TS 6 option deprecations until Angular 22 (file:../ pkg deps blocked there).
+    "ignoreDeprecations": "6.0",
     "baseUrl": ".",
     "paths": {
       "@components": ["libs/components/src/index.ts"],

--- a/examples/frontend/angular/tsconfig.base.json
+++ b/examples/frontend/angular/tsconfig.base.json
@@ -13,7 +13,6 @@
     "lib": ["es2020", "dom"],
     "skipLibCheck": true,
     "skipDefaultLibCheck": true,
-    "ignoreDeprecations": "6.0",
     "baseUrl": ".",
     "paths": {
       "@components": ["libs/components/src/index.ts"],

--- a/examples/frontend/angular/tsconfig.base.json
+++ b/examples/frontend/angular/tsconfig.base.json
@@ -13,6 +13,7 @@
     "lib": ["es2020", "dom"],
     "skipLibCheck": true,
     "skipDefaultLibCheck": true,
+    "ignoreDeprecations": "6.0",
     "baseUrl": ".",
     "paths": {
       "@components": ["libs/components/src/index.ts"],

--- a/examples/frontend/angular/tsconfig.editor.json
+++ b/examples/frontend/angular/tsconfig.editor.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.json",
   "include": ["src/**/*.ts"],
   "compilerOptions": {
+    "ignoreDeprecations": "6.0",
     "typeRoots": ["./node_modules/@types"],
     "types": ["jest", "node"]
   }

--- a/examples/frontend/angular/tsconfig.editor.json
+++ b/examples/frontend/angular/tsconfig.editor.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.json",
   "include": ["src/**/*.ts"],
   "compilerOptions": {
+    "typeRoots": ["./node_modules/@types"],
     "types": ["jest", "node"]
   }
 }

--- a/tests/e2e/package-lock.json
+++ b/tests/e2e/package-lock.json
@@ -15,6 +15,7 @@
       },
       "devDependencies": {
         "@types/jest": "^30.0.0",
+        "@types/node": "^25.9.5",
         "jest": "^30.4.2",
         "jest-puppeteer": "11.0.0",
         "ts-jest": "^29.4.12",
@@ -1426,13 +1427,13 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "25.0.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.10.tgz",
-      "integrity": "sha512-zWW5KPngR/yvakJgGOmZ5vTBemDoSqF3AcV/LrO5u5wTWyEAVVh+IT39G4gtyAkh3CtTZs8aX/yRM82OfzHJRg==",
+      "version": "25.9.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.5.tgz",
+      "integrity": "sha512-OScDchr2fwuUmWdf4kZ9h7PcJiYDVInhJizG/biAq3cAvqwYktuy/TYGGdZNMtNTFUP7rnb0NU4TUdm82kt4Rg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.16.0"
+        "undici-types": ">=7.24.0 <7.24.7"
       }
     },
     "node_modules/@types/stack-utils": {
@@ -5567,9 +5568,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
       "dev": true,
       "license": "MIT"
     },

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -11,15 +11,16 @@
   "type": "module",
   "devDependencies": {
     "@types/jest": "^30.0.0",
+    "@types/node": "^25.9.5",
     "jest": "^30.4.2",
     "jest-puppeteer": "11.0.0",
     "ts-jest": "^29.4.12",
     "ts-node": "=10.9.2"
   },
   "dependencies": {
-    "puppeteer": "^25.4.0",
     "casper-rust-wasm-sdk": "file:../../pkg-nodejs",
-    "dotenv": "^17.4.2"
+    "dotenv": "^17.4.2",
+    "puppeteer": "^25.4.0"
   },
   "overrides": {
     "jest-environment-node": "30.4.1"

--- a/tests/e2e/tsconfig.json
+++ b/tests/e2e/tsconfig.json
@@ -7,6 +7,7 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
+    "ignoreDeprecations": "6.0",
     "types": ["jest", "node", "puppeteer"],
     "baseUrl": "."
   },

--- a/tests/e2e/tsconfig.json
+++ b/tests/e2e/tsconfig.json
@@ -7,11 +7,11 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "ignoreDeprecations": "6.0",
-    "types": ["jest", "node", "puppeteer"],
-    "baseUrl": "."
-  },
-  "paths": {
-    "casper-rust-wasm-sdk": ["../../../pkg-nodejs"]
+    "typeRoots": ["./node_modules/@types"],
+    "types": ["jest", "node"],
+    "baseUrl": ".",
+    "paths": {
+      "casper-rust-wasm-sdk": ["../../../pkg-nodejs"]
+    }
   }
 }

--- a/tests/e2e/tsconfig.json
+++ b/tests/e2e/tsconfig.json
@@ -7,6 +7,7 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
+    "ignoreDeprecations": "6.0",
     "typeRoots": ["./node_modules/@types"],
     "types": ["jest", "node"],
     "baseUrl": ".",


### PR DESCRIPTION
## Summary
- Stay on **Angular 21 + TypeScript 5.9** (`@angular/compiler-cli` peer \`>=5.9 <6.0\`)
- Angular 22 is blocked for this example by \`file:../\` (and deeper) wasm package paths in \`package.json\`
- Add \`ignoreDeprecations: \"6.0\"\` in Angular \`tsconfig.base.json\` and e2e \`tsconfig.json\` so TS 6 tooling stops flagging legacy \`baseUrl\` / \`moduleResolution: node\`
- Keep e2e/editor \`typeRoots\` + \`@types/node\` fixes (no \`types: [\"puppeteer\"]\`)

## Test plan
- [ ] Deprecation diagnostics on Angular lib / editor / e2e tsconfigs clear after TS server reload
- [ ] \`npm install\` in angular + e2e if jest/node types still missing locally