### PR TITLE
fix(angular): restore valid ignoreDeprecations for TS 5.9

### DIFF
--- a/examples/frontend/angular/libs/util/services/result/tsconfig.lib.json
+++ b/examples/frontend/angular/libs/util/services/result/tsconfig.lib.json
@@ -1,7 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "ignoreDeprecations": "6.0",
+    "ignoreDeprecations": "5.0",
     "outDir": "../../../../dist/out-tsc",
     "declaration": true,
     "declarationMap": true,

--- a/examples/frontend/angular/tsconfig.base.json
+++ b/examples/frontend/angular/tsconfig.base.json
@@ -13,8 +13,8 @@
     "lib": ["es2020", "dom"],
     "skipLibCheck": true,
     "skipDefaultLibCheck": true,
-    // Angular 21 requires typescript >=5.9 <6.0; silence TS 6 option deprecations until Angular 22 (file:../ pkg deps blocked there).
-    "ignoreDeprecations": "6.0",
+    // Angular 21 requires typescript >=5.9 <6.0; silence 5.x option deprecations until Angular 22.
+    "ignoreDeprecations": "5.0",
     "baseUrl": ".",
     "paths": {
       "@components": ["libs/components/src/index.ts"],

--- a/examples/frontend/angular/tsconfig.editor.json
+++ b/examples/frontend/angular/tsconfig.editor.json
@@ -2,7 +2,7 @@
   "extends": "./tsconfig.json",
   "include": ["src/**/*.ts"],
   "compilerOptions": {
-    "ignoreDeprecations": "6.0",
+    "ignoreDeprecations": "5.0",
     "typeRoots": ["./node_modules/@types"],
     "types": ["jest", "node"]
   }


### PR DESCRIPTION
## Summary
- move the Angular TypeScript deprecation gate back to a valid TS 5.9 value
- update `ignoreDeprecations` from `6.0` to `5.0` in workspace/editor/lib tsconfig files
- restore successful compile flow by removing the TS5103 config error

## Test plan
- [x] `npm run build` in `examples/frontend/angular`
- [ ] optional: run `npm run serve` locally

Made with [Cursor](https://cursor.com)