### PR TITLE
fix(e2e): use ignoreDeprecations 5.0 under TypeScript 5.9

### DIFF
--- a/tests/e2e/tsconfig.json
+++ b/tests/e2e/tsconfig.json
@@ -7,7 +7,7 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "ignoreDeprecations": "6.0",
+    "ignoreDeprecations": "5.0",
     "typeRoots": ["./node_modules/@types"],
     "types": ["jest", "node"],
     "baseUrl": ".",


### PR DESCRIPTION
## Summary
- Align `tests/e2e/tsconfig.json` with Angular/#91: `ignoreDeprecations` is `"5.0"`, not `"6.0"`.
- `"6.0"` is invalid under TypeScript 5.9 (`TS5103`) and breaks `tsc -p tests/e2e/tsconfig.json`.

## Test plan
- [x] `npx tsc -p tests/e2e/tsconfig.json --noEmit` succeeds locally
- [ ] CI green on this PR


Made with [Cursor](https://cursor.com)