### PR TITLE
fix(ts): drop deprecated node10 moduleResolution

### DIFF
--- a/examples/frontend/angular/tsconfig.base.json
+++ b/examples/frontend/angular/tsconfig.base.json
@@ -4,7 +4,7 @@
     "rootDir": ".",
     "sourceMap": true,
     "declaration": false,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "importHelpers": true,
@@ -13,9 +13,8 @@
     "lib": ["es2020", "dom"],
     "skipLibCheck": true,
     "skipDefaultLibCheck": true,
-    // Angular 21 requires typescript >=5.9 <6.0; silence 5.x option deprecations until Angular 22.
-    "ignoreDeprecations": "5.0",
     "baseUrl": ".",
+    "ignoreDeprecations": "5.0",
     "paths": {
       "@components": ["libs/components/src/index.ts"],
       "@util-binary": ["libs/util/services/binary/src/index.ts"],

--- a/tests/e2e/jest.config.ts
+++ b/tests/e2e/jest.config.ts
@@ -178,7 +178,8 @@ const config: Config = {
 
   // A map from regular expressions to paths to transformers
   transform: {
-    // Include .js so puppeteer ESM under node_modules is transformed.
+    // .js included so puppeteer ESM under node_modules can be transformed.
+    // pkg-nodejs is excluded via transformIgnorePatterns (not allowJs).
     '^.+\\.[tj]sx?$': ['ts-jest', { useESM: true }],
   },
 
@@ -201,9 +202,10 @@ const config: Config = {
   // watchman: true,
 
   extensionsToTreatAsEsm: ['.ts', '.tsx'],
-  // Transform puppeteer ESM; leave pkg-nodejs (CJS via file:) alone to avoid ts-jest allowJs noise.
+  // Transform puppeteer ESM; skip the local wasm pack so ts-jest never compiles its .js.
   transformIgnorePatterns: [
     '/node_modules/(?!puppeteer(?:-core)?|@puppeteer)/',
+    '[\\\\/]pkg-nodejs[\\\\/]',
   ],
 };
 

--- a/tests/e2e/tsconfig.json
+++ b/tests/e2e/tsconfig.json
@@ -3,16 +3,11 @@
     "target": "es2020",
     "module": "esnext",
     "strict": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "ignoreDeprecations": "5.0",
     "typeRoots": ["./node_modules/@types"],
-    "types": ["jest", "node"],
-    "baseUrl": ".",
-    "paths": {
-      "casper-rust-wasm-sdk": ["../../../pkg-nodejs"]
-    }
+    "types": ["jest", "node"]
   }
 }


### PR DESCRIPTION
## Summary
- Migrate `moduleResolution` from `node` (alias `node10`) to `bundler` in Angular `tsconfig.base` and e2e `tsconfig`.
- E2e: remove `baseUrl` / `paths` / `ignoreDeprecations` (SDK comes from `package.json` `file:../../pkg-nodejs`).
- Angular: keep `baseUrl` + `ignoreDeprecations: "5.0"` for `@util/*` path aliases (TS 5.9 still requires `baseUrl` for non-relative `paths`; `"6.0"` is invalid under 5.9 / Angular 21).
- E2e Jest: add `pkg-nodejs` to `transformIgnorePatterns` so ts-jest no longer compiles the pack `.js` (allowJs warning).

Repo fix for TS deprecation / Jest noise, not an editor settings workaround.

## Test plan
- [x] `tsc -p tests/e2e/tsconfig.json --noEmit`
- [x] `tsc -p examples/frontend/angular/tsconfig.app.json --noEmit`
- [x] `nx run casper:build --configuration=development`
- [x] `npx jest -t 'should have a title|SSE_client'` — no `ts-jest … allowJs` warning
- [ ] IDE: open `tests/e2e/jest.config.ts` — e2e `node10` / `baseUrl` warnings gone
- [ ] CI green

Note: Node `DEP0060` (`util._extend`) comes from a transitive dependency (often puppeteer / older libs), not this repo’s source. Track separately if it becomes noisy in CI.