### PR TITLE
ci: freeze Hub :latest to release; add overnight dev-preview

### DIFF
--- a/.github/workflows/dev-preview-release.yml
+++ b/.github/workflows/dev-preview-release.yml
@@ -1,0 +1,66 @@
+# Overwrite one GitHub Pre-release after green overnight tests (not Latest).
+# Fixed tag: dev-preview (does not match crates v*.*.*; does not collide with branch dev).
+name: Dev preview release
+
+on:
+  workflow_run:
+    workflows: ["nightly-scheduled-test"]
+    types: [completed]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  overwrite-prerelease:
+    name: Overwrite GitHub Pre-release dev-preview
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Resolve SHA
+        id: sha
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_run" ]; then
+            echo "sha=${{ github.event.workflow_run.head_sha }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "sha=${{ github.sha }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout tested commit
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ steps.sha.outputs.sha }}
+          fetch-depth: 0
+
+      - name: Move tag and overwrite Pre-release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: dev-preview
+          SHA: ${{ steps.sha.outputs.sha }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          SHORT=$(git rev-parse --short "$SHA")
+          NOTES="Nightly-green tip of \`dev\` @ \`${SHORT}\` (\`${SHA}\`).
+
+          Overwritten on each successful [nightly-scheduled-test](https://github.com/${{ github.repository }}/actions/workflows/nightly-scheduled-test.yml). Not Latest — that remains the node-aligned semver release (e.g. v2.2.2).
+          "
+
+          # Drop prior Pre-release entry (keep tag for now); then repoint tag and recreate.
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            gh release delete "$TAG" --yes || true
+          fi
+          git tag -f "$TAG" "$SHA"
+          git push -f origin "refs/tags/$TAG"
+
+          # Recreate so publish-docs (release: created) rebuilds desktop assets.
+          gh release create "$TAG" \
+            --prerelease \
+            --title "dev preview" \
+            --notes "$NOTES" \
+            --target "$SHA"

--- a/.github/workflows/docker-build-push-release.yml
+++ b/.github/workflows/docker-build-push-release.yml
@@ -1,0 +1,98 @@
+# Frozen Hub semver + :latest (same digest). Tip of dev is CI/CD Image dev (:dev only).
+name: CI/CD Image release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Hub tag without leading v (e.g. 2.2.2). Empty uses Angular package.json version.
+        required: false
+        type: string
+      ref:
+        description: Git ref to build (tag, branch, or SHA). Empty uses the workflow ref / default branch checkout.
+        required: false
+        type: string
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  build-push-release:
+    name: Build and Push Docker Image release
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      - name: Resolve release version
+        id: ver
+        run: |
+          if [ "${{ github.event_name }}" = "push" ]; then
+            VERSION="${GITHUB_REF_NAME#v}"
+          elif [ -n "${{ inputs.version }}" ]; then
+            VERSION="${{ inputs.version }}"
+            VERSION="${VERSION#v}"
+          else
+            VERSION=$(jq -r .version examples/frontend/angular/package.json)
+          fi
+          if [ -z "$VERSION" ] || [ "$VERSION" = "null" ]; then
+            echo "Could not resolve release version" >&2
+            exit 1
+          fi
+          PKG=$(jq -r .version examples/frontend/angular/package.json)
+          if [ "$VERSION" != "$PKG" ]; then
+            echo "Refusing Hub tag $VERSION: Angular package.json is $PKG" >&2
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Resolved Hub release tag: $VERSION"
+
+      - name: Set up Make
+        run: sudo apt-get install -y make
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build Docker images for release
+        run: |
+          APP_VERSION="${{ steps.ver.outputs.version }}"
+          GIT_SHA=$(git rev-parse HEAD)
+          docker compose -f docker/docker-compose.cicd.yml build \
+            --build-arg APP_VERSION="$APP_VERSION" \
+            --build-arg GIT_SHA="$GIT_SHA"
+
+          docker build -f mcp/Dockerfile -t casper-rust-wasm-sdk-mcp:latest .
+
+          # Stable: :$APP_VERSION and :latest (same digest). Do not move :dev.
+          for image in casper-webclient cors-anywhere ws-proxy casper-rust-wasm-sdk-mcp; do
+            docker tag "${image}:latest" "${{ secrets.DOCKER_USERNAME_ITC }}/${image}:${APP_VERSION}"
+            docker tag "${image}:latest" "${{ secrets.DOCKER_USERNAME_ITC }}/${image}:latest"
+          done
+
+      - name: Push Docker images to Docker Hub
+        run: |
+          APP_VERSION="${{ steps.ver.outputs.version }}"
+          for image in casper-webclient cors-anywhere ws-proxy casper-rust-wasm-sdk-mcp; do
+            docker push "${{ secrets.DOCKER_USERNAME_ITC }}/${image}:${APP_VERSION}"
+            docker push "${{ secrets.DOCKER_USERNAME_ITC }}/${image}:latest"
+          done
+
+      # Hosted demo pulls :latest (stable). Tip of :dev is not redeployed here.
+      - name: Trigger Render redeploy
+        env:
+          RENDER_DEPLOY_HOOK: ${{ secrets.RENDER_DEPLOY_HOOK }}
+        run: |
+          if [ -z "${RENDER_DEPLOY_HOOK}" ]; then
+            echo "RENDER_DEPLOY_HOOK secret not set; skipping Render redeploy"
+            exit 0
+          fi
+          echo "Triggering Render deploy hook…"
+          curl -fsS -X GET "${RENDER_DEPLOY_HOOK}"
+          echo
+          echo "Render deploy requested"

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -7,7 +7,7 @@ on:
       - dev
 
 jobs:
-  nightly-build-push-2-0:
+  build-push-dev:
     name: Build and Push Docker Image dev
     runs-on: ubuntu-latest
 
@@ -35,34 +35,14 @@ jobs:
           # Slim MCP for Cursor/agents (stdio / HTTP :5790).
           docker build -f mcp/Dockerfile -t casper-rust-wasm-sdk-mcp:latest .
 
-          # Tags: :latest, :dev, and :$APP_VERSION (from package.json, e.g. 2.2.2). No :stable.
-          # webclient also embeds the MCP binary (ENABLE_MCP / entrypoint mcp).
+          # Tip only: :dev. Semver (:$APP_VERSION) and :latest are owned by
+          # docker-build-push-release.yml (stable = last release).
           for image in casper-webclient cors-anywhere ws-proxy casper-rust-wasm-sdk-mcp; do
-            docker tag "${image}:latest" "${{ secrets.DOCKER_USERNAME_ITC }}/${image}:latest"
             docker tag "${image}:latest" "${{ secrets.DOCKER_USERNAME_ITC }}/${image}:dev"
-            docker tag "${image}:latest" "${{ secrets.DOCKER_USERNAME_ITC }}/${image}:${APP_VERSION}"
           done
 
       - name: Push Docker images to Docker Hub
         run: |
-          APP_VERSION=$(jq -r .version examples/frontend/angular/package.json)
           for image in casper-webclient cors-anywhere ws-proxy casper-rust-wasm-sdk-mcp; do
-            docker push "${{ secrets.DOCKER_USERNAME_ITC }}/${image}:latest"
             docker push "${{ secrets.DOCKER_USERNAME_ITC }}/${image}:dev"
-            docker push "${{ secrets.DOCKER_USERNAME_ITC }}/${image}:${APP_VERSION}"
           done
-
-      # Render does not watch Hub for new digests — call the service Deploy Hook
-      # after a successful push so it pulls interchouette/casper-webclient:latest.
-      - name: Trigger Render redeploy
-        env:
-          RENDER_DEPLOY_HOOK: ${{ secrets.RENDER_DEPLOY_HOOK }}
-        run: |
-          if [ -z "${RENDER_DEPLOY_HOOK}" ]; then
-            echo "RENDER_DEPLOY_HOOK secret not set; skipping Render redeploy"
-            exit 0
-          fi
-          echo "Triggering Render deploy hook…"
-          curl -fsS -X GET "${RENDER_DEPLOY_HOOK}"
-          echo
-          echo "Render deploy requested"

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -2,6 +2,7 @@ name: Publish docs
 
 on:
   release:
+    # created: semver cuts and each overwrite of Pre-release tag (delete+recreate).
     types: [created]
 
 permissions:
@@ -9,6 +10,8 @@ permissions:
 
 jobs:
   build-and-deploy:
+    # Stable docs only — do not overwrite GitHub Pages from overnight Pre-releases.
+    if: ${{ !github.event.release.prerelease }}
     strategy:
       matrix:
         os: [ubuntu-latest]
@@ -40,7 +43,7 @@ jobs:
           folder: docs # The folder the action should deploy.
 
   desktop-assets:
-    # Electron demos belong on product releases, not MCP sidecar tags.
+    # Electron demos on product releases and the overwritten dev-preview Pre-release.
     if: ${{ !contains(github.event.release.tag_name, 'mcp') }}
     runs-on: ubuntu-latest
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,11 +25,12 @@ Demo / development only — same warning as above.
 
 The workspace package [`mcp/`](../mcp/) (`casper-rust-wasm-sdk-mcp`) exposes the native Rust SDK as [MCP](https://modelcontextprotocol.io/) tools for Cursor and other agents.
 
-- **Cursor/agents (slim Hub):** `interchouette/casper-rust-wasm-sdk-mcp` (`:dev` / `:latest` / `:$APP_VERSION`)
+- **Cursor/agents (slim Hub):** `interchouette/casper-rust-wasm-sdk-mcp` — `:dev` (tip) / `:latest` = `:2.2.2` (stable)
 - **Hosted SPA:** https://casper-webclient.interchouette.net/mcp (`casper-webclient` embeds the same binary, `ENABLE_MCP=1`)
 - **Local Docker:** `make mcp-http` → http://127.0.0.1:5790/mcp
 - **Host HTTP:** `make run-mcp-http` → http://127.0.0.1:5790/mcp
 - **stdio:** `interchouette/casper-rust-wasm-sdk-mcp:dev` (see [`mcp/mcp.json.example`](../mcp/mcp.json.example))
+- **GitHub Releases:** Latest = node-aligned semver (`v2.2.2`); tip desktop cut = Pre-release [`dev-preview`](https://github.com/casper-ecosystem/casper-rust-wasm-sdk/releases) (overwritten after green nightly)
 
 ```bash
 make run-mcp      # stdio (host cargo)

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -17,7 +17,7 @@ Inventory: [TOOLS.md](TOOLS.md). Patterns: [PATTERNS.md](PATTERNS.md). MCP clien
 | ------------------ | -------------------------------------------------------- | ------------------------------------------------ |
 | **Hosted**         | Render webclient                                         | `https://casper-webclient.interchouette.net/mcp` |
 | **HTTP (Docker)**  | `make mcp-http` → slim MCP image                         | `http://127.0.0.1:5790/mcp`                      |
-| **stdio (Docker)** | `docker run -i … interchouette/casper-rust-wasm-sdk-mcp` | `:dev` / `:latest` / `:$APP_VERSION`             |
+| **stdio (Docker)** | `docker run -i … interchouette/casper-rust-wasm-sdk-mcp` | `:dev` (tip) / `:latest` = `:2.2.2` (stable) |
 | **stdio (host)**   | `make run-mcp`                                           | cargo; for local debug                           |
 | **HTTP (host)**    | `make run-mcp-http`                                      | cargo on `127.0.0.1:5790`                        |
 
@@ -73,7 +73,7 @@ Complex inputs use JSON strings — see [TOOLS.md](TOOLS.md) and `tools/params.r
 
 ## MCP client config
 
-Hub tags for `interchouette/casper-rust-wasm-sdk-mcp` and `interchouette/casper-webclient`: **`dev`**, **`latest`**, and the app version (e.g. **`2.2.2`**).
+Hub tags for `interchouette/casper-rust-wasm-sdk-mcp` and `interchouette/casper-webclient`: **`dev`** (tip), **`latest`** = current stable semver (e.g. **`2.2.2`**). GitHub Pre-release **`dev-preview`** carries overnight tip desktop assets (not Latest).
 
 | Server name (example)       | Transport | Backing                                                       |
 | --------------------------- | --------- | ------------------------------------------------------------- |


### PR DESCRIPTION
## Summary
- Tip of `dev` (CI/CD Image **dev**) pushes Hub **`:dev` only**; it no longer moves `:latest` or `:$APP_VERSION`.
- New **CI/CD Image release** workflow pushes **`:$APP_VERSION` and `:latest`** (same digest) on `v*.*.*` tags / dispatch (Render redeploy stays on this path).
- New **Dev preview release** workflow overwrites GitHub Pre-release tag **`dev-preview`** after green `nightly-scheduled-test` (desktop assets via `publish-docs` on `release: created`; Pages deploy skipped for prereleases).

## Test plan
- [ ] Merge, then confirm a tip push to `dev` updates Hub `:dev` only (`:latest` / `:2.2.2` unchanged).
- [ ] Dispatch **CI/CD Image release** with `ref=v2.2.2` / `version=2.2.2` (one-time re-cut) and verify `:2.2.2` and `:latest` share one digest from that tag.
- [ ] Dispatch **Dev preview release** (or wait for green nightly) and verify Pre-release `dev-preview` is overwritten, still not Latest, and desktop assets refresh.
- [ ] Confirm `v2.2.2` remains GitHub Latest and Pages are not overwritten by the Pre-release path.


Made with [Cursor](https://cursor.com)