### PR TITLE
chore(angular): approve npm install scripts for toolchain deps

### DIFF
--- a/examples/frontend/angular/package.json
+++ b/examples/frontend/angular/package.json
@@ -68,5 +68,14 @@
     "ts-jest": "^29.4.12",
     "ts-node": "~10.9.2",
     "typescript": "~5.9.3"
+  },
+  "allowScripts": {
+    "@parcel/watcher": true,
+    "@swc/core": true,
+    "esbuild": true,
+    "lmdb": true,
+    "msgpackr-extract": true,
+    "nx": true,
+    "unrs-resolver": true
   }
 }


### PR DESCRIPTION
## Summary
- Add `allowScripts` to `examples/frontend/angular/package.json` for the packages npm 11 flags (`nx`, `esbuild`, `@swc/core`, etc.).
- Stops the post-`npm update` / install `allow-scripts` warning spam; scripts already run today (advisory allowlist).

## Test plan
- [ ] In `examples/frontend/angular`, `npm update` (or `npm install`) no longer prints the 7-package `allow-scripts` warning block.


Made with [Cursor](https://cursor.com)