### PR TITLE
chore: houseclean TODOs, AE keys, Bytesrepr, V1/V2 runtime, CES Bytes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2607,8 +2607,6 @@ dependencies = [
  "casper-rust-wasm-sdk",
  "chrono",
  "dotenvy",
- "lazy_static",
- "once_cell",
  "serde_json",
  "tokio",
 ]

--- a/docs/README.md
+++ b/docs/README.md
@@ -1092,7 +1092,7 @@ client.subscribe("TransactionProcessed", (raw) => {
 
 #### Rust — CESParser
 
-Load contract metadata (including `__events_schema`) via `query_global_state`, then parse transforms from an execution-result JSON string. Pass a `hash-…` or bare hex contract hash; if you only have an account named key of the form `entity-contract-…`, remap it to `hash-…` before create (same pattern as dictionary helpers when addressable entities are disabled).
+Load contract metadata (including `__events_schema`) via `query_global_state`, then parse transforms from an execution-result JSON string. Pass a `hash-…`, bare hex, or `entity-contract-…` named key: `CESParser::create` remaps via `helpers::contract_hash_key_for_global_state` when addressable entities are disabled and global state expects `hash-…` → `StoredValue::Contract`.
 
 ```rust
 use casper_rust_wasm_sdk::SSE::CESParser;
@@ -2509,99 +2509,81 @@ Download pre-built desktop demos from the **[GitHub Releases](https://github.com
 
 ## Rust API
 
-- [Modules and Structs](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/api-rust/casper_rust_wasm_sdk/)
+Published rustdoc: [crate root](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/api-rust/casper_rust_wasm_sdk/) · [all items](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/api-rust/casper_rust_wasm_sdk/all.html)
 
-- [Full item list](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/api-rust/casper_rust_wasm_sdk/all.html)
+Cargo features (see `Cargo.toml`): `transaction`, `deploy`, `contract`, `binary-port`, `watcher`, `SSE` (includes `watcher` + `SSEClient` / `CESParser`), `helpers`. Default bundle is `full` (not the same as enabling `SSE`).
 
-### SDK
+### SDK and RPC
 
-- [SDK Struct and methods](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/api-rust/casper_rust_wasm_sdk/struct.SDK.html)
+- [SDK](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/api-rust/casper_rust_wasm_sdk/struct.SDK.html) — construct with RPC URL / verbosity; all `get_*` / `put_*` / builders hang here
+- [RPC module](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/api-rust/casper_rust_wasm_sdk/rpcs/index.html)
 
-### RPC
+### Transactions (Casper 2.x)
 
-- [RPC List](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/api-rust/casper_rust_wasm_sdk/rpcs/index.html)
+- [TransactionStrParams](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/api-rust/casper_rust_wasm_sdk/types/transaction_params/transaction_str_params/index.html) — chain name, signing, TTL, payment, session args
+- [TransactionBuilderParams](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/api-rust/casper_rust_wasm_sdk/types/transaction_params/transaction_builder_params/index.html) — session / entity / package / transfer targets; **runtime** `VmCasperV1` or `VmCasperV2` (session/entity/package default to V2; set V1 for classic wasm such as CEP-78)
+- [Transaction](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/api-rust/casper_rust_wasm_sdk/types/transaction/struct.Transaction.html) — sign / put / rebuild; session args are either **named** (`session_args`) or **Bytesrepr** (`session_args_bytes`, `is_bytesrepr` / `is_named`)
 
-### Transaction Params
+### Deploys (legacy 1.x path)
 
-- [TransactionStrParams](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/api-rust/casper_rust_wasm_sdk/types/transaction_params/transaction_str_params/index.html)
-- [TransactionBuilderParams](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/api-rust/casper_rust_wasm_sdk/types/transaction_params/transaction_builder_params/index.html)
+- [Deploy params](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/api-rust/casper_rust_wasm_sdk/types/deploy_params/index.html) — `DeployStrParams`, `SessionStrParams`, `PaymentStrParams`, dictionary params
+- [Deploy](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/api-rust/casper_rust_wasm_sdk/types/deploy/struct.Deploy.html)
 
-### Transaction
+### Contracts (feature `contract`)
 
-- [Transaction Type](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/api-rust/casper_rust_wasm_sdk/types/transaction/struct.Transaction.html)
+High-level install / entrypoint / dictionary / key query helpers on `SDK` (see rustdoc methods and the [Install / Mint examples](#more-examples) above). When addressable entities are **off**, named keys may still look like `entity-contract-…` while `query_global_state` expects `hash-…` — use [`contract_hash_key_for_global_state`](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/api-rust/casper_rust_wasm_sdk/helpers/fn.contract_hash_key_for_global_state.html) (or pass `entity-contract-…` into `CESParser::create`, which remaps). Background for node core: [#96](https://github.com/casper-ecosystem/casper-rust-wasm-sdk/issues/96).
 
-### Deploy Params (Legacy)
+### Watcher and SSE
 
-- [Params and Args simple](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/api-rust/casper_rust_wasm_sdk/types/deploy_params/index.html)
+- [watcher](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/api-rust/casper_rust_wasm_sdk/watcher/index.html) — wait / watch for a transaction (or legacy deploy) to finalize (`Subscription`, `EventParseResult`)
+- Feature **`SSE`**: [`SSEClient`](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/api-rust/casper_rust_wasm_sdk/SSE/index.html) for the node event stream (`BlockAdded`, `TransactionProcessed`, …) and [`CESParser`](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/api-rust/casper_rust_wasm_sdk/SSE/index.html) for Casper Event Standard transforms (`events_mode: 2`). Examples: [SSEClient / CESParser](#rust--sseclient)
 
-### Deploy (Legacy)
+### Types and helpers
 
-- [Deploy Type and static builder](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/api-rust/casper_rust_wasm_sdk/types/deploy/struct.Deploy.html)
+- [types](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/api-rust/casper_rust_wasm_sdk/types/index.html) — keys, hashes, CL values, verbosity, …
+- [helpers](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/api-rust/casper_rust_wasm_sdk/helpers/index.html) — hashing, TTL/timestamp parse, dictionary item key, motes, **AE-off contract key remap**, …
 
-### Transaction Watcher
+### Binary Port (feature `binary-port`)
 
-- [Watcher](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/api-rust/casper_rust_wasm_sdk/watcher/index.html)
-- [Subscription](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/api-rust/casper_rust_wasm_sdk/watcher/struct.Subscription.html)
-- [EventParseResult](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/api-rust/casper_rust_wasm_sdk/watcher/struct.EventParseResult.html)
+- [binary_port](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/api-rust/casper_rust_wasm_sdk/binary_port/index.html) — native binary-port reads (block headers, global state, rewards, speculative exec, …) when talking to a node that exposes the port
 
-### Types
+### MCP (agents)
 
-- [Current exposed types](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/api-rust/casper_rust_wasm_sdk/types/index.html)
-
-### Helpers functions
-
-- [Rust helpers](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/api-rust/casper_rust_wasm_sdk/helpers/index.html)
-
-### Binary Port
-
-- [Binary methods](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/api-rust/casper_rust_wasm_sdk/binary_port/index.html)
+Not part of the Rust crate root: sibling package [`mcp/`](../mcp/) wraps the same SDK as MCP tools. See [MCP](#mcp) above and [`mcp/TOOLS.md`](../mcp/TOOLS.md).
 
 ## Typescript API
 
-- [Full item list](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/api-wasm/index.html)
+Published typedoc: [index](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/api-wasm/index.html)
 
-### SDK
+Same surface as Rust, via the Wasm pack (`pkg` / `pkg-nodejs`). Notable entry points:
 
-- [SDK Class and methods](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/api-wasm/classes/SDK.html)
+### SDK and RPC
 
-### Transaction Params
+- [SDK](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/api-wasm/classes/SDK.html)
 
-- [Transaction Params](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/api-wasm/classes/TransactionStrParams.html)
-- [Transaction Builder Params](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/api-wasm/classes/TransactionBuilderParams.html)
-- [Dictionary Item Params](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/api-wasm/classes/DictionaryItemStrParams.html)
+### Transactions
 
-### Transaction
+- [TransactionStrParams](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/api-wasm/classes/TransactionStrParams.html)
+- [TransactionBuilderParams](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/api-wasm/classes/TransactionBuilderParams.html) — `setRuntimeV1` / `setRuntimeV2`
+- [Transaction](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/api-wasm/classes/Transaction.html) — named vs Bytesrepr session args (`session_args` / `session_args_bytes` / `is_bytesrepr`)
 
-- [Transaction Type](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/api-wasm/classes/Transaction.html)
+### Deploys (legacy)
 
-### Deploy Params (Legacy)
+- [DeployStrParams](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/api-wasm/classes/DeployStrParams.html), [SessionStrParams](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/api-wasm/classes/SessionStrParams.html), [PaymentStrParams](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/api-wasm/classes/PaymentStrParams.html), [DictionaryItemStrParams](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/api-wasm/classes/DictionaryItemStrParams.html)
+- [Deploy](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/api-wasm/classes/Deploy.html)
 
-- [Deploy Params](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/api-wasm/classes/DeployStrParams.html)
-- [Session Params](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/api-wasm/classes/SessionStrParams.html)
-- [Payment Params](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/api-wasm/classes/PaymentStrParams.html)
-- [Dictionary Item Params](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/api-wasm/classes/DictionaryItemStrParams.html)
+### Watcher and SSE / CES
 
-### Deploy (Legacy)
+- [Watcher](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/api-wasm/classes/Watcher.html), [Subscription](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/api-wasm/classes/Subscription.html), [EventParseResult](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/api-wasm/classes/EventParseResult.html)
+- `SDK.SSE_client` / `SDK.CES_parser` (Wasm build with `SSE`) — see [TypeScript SSE / CES examples](#typescript--sseclient)
 
-- [Deploy Type and static builder](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/api-wasm/classes/Deploy.html)
+### Types and helpers
 
-### Transaction Watcher
-
-- [Watcher](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/api-wasm/classes/Watcher.html)
-- [Subscription](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/api-wasm/classes/Subscription.html)
-- [EventParseResult](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/api-wasm/classes/EventParseResult.html)
-
-### Types
-
-- [Current exposed types](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/api-wasm/modules.html)
-
-### Helpers functions
-
-- [TS helpers](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/api-wasm/modules.html#Functions)
+- [modules](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/api-wasm/modules.html) — types + free functions (`contractHashKeyForGlobalState`, `makeDictionaryItemKey`, …)
 
 ### Binary Port
 
-- [Binary methods](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/api-wasm/classes/SDK.html#Methods)
+- Methods on [SDK](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/api-wasm/classes/SDK.html#Methods) (binary-port feature)
 
 ## Casper Wallet
 
@@ -2676,7 +2658,13 @@ SECRET_KEY_NCTL_PATH=/casper/casper-nctl-2-docker/assets/users/user-1/
 
 ## Todo
 
-- Expose more CL Types and Casper Client result Types
-- EventStream for other events than transaction processed
+Open tracking (not a full roadmap):
+
+- [#9](https://github.com/casper-ecosystem/casper-rust-wasm-sdk/issues/9) — Python / PyO3 bindings
+- [#27](https://github.com/casper-ecosystem/casper-rust-wasm-sdk/issues/27) — more typed `StoredValue` / entrypoint / named-keys surface (code largely landed; issue open until accepted)
+- [#36](https://github.com/casper-ecosystem/casper-rust-wasm-sdk/issues/36) — first crates.io publish
+- [#96](https://github.com/casper-ecosystem/casper-rust-wasm-sdk/issues/96) — explainer for node core: AE-off `entity-contract-…` vs `hash-…` on `query_global_state` (SDK remaps; permanent fix is upstream)
+
+Mac desktop Electron build is still TODO (Windows / Linux demos ship on releases).
 
 ⚠ **Reminder**: Do not use private keys or perform real transactions on the testnet/mainnet unless you are fully aware of the security risks.

--- a/examples/frontend/angular/libs/components/src/lib/header/header.component.ts
+++ b/examples/frontend/angular/libs/components/src/lib/header/header.component.ts
@@ -184,7 +184,6 @@ export class HeaderComponent implements AfterViewInit {
     const customNetwork = this.networks.find(
       (network) => network.name === 'custom',
     );
-    // Todo check
     if (customNetwork) {
       customNetwork.rpc_address = this.rpc_address;
       //  customNetwork.node_address = this.node_address;

--- a/examples/frontend/angular/libs/components/src/lib/public-key/public-key.component.ts
+++ b/examples/frontend/angular/libs/components/src/lib/public-key/public-key.component.ts
@@ -109,9 +109,6 @@ export class PublicKeyComponent implements AfterViewInit, OnDestroy {
       if (!get_entity.entity_result) {
         return;
       }
-      // TODO Fix this camelcase syntax with helpers
-      // const account_hash = get_account?.account?.account_hash;
-      // const main_purse = get_account?.account?.main_purse;
       account_hash =
         get_entity?.entity_result?.AddressableEntity?.entity.entity_kind
           .Account;

--- a/examples/frontend/angular/libs/util/services/client/src/lib/client.service.ts
+++ b/examples/frontend/angular/libs/util/services/client/src/lib/client.service.ts
@@ -46,7 +46,6 @@ export class ClientService {
   private deploy_json!: string;
   private transaction_json!: string;
   private select_dict_identifier!: string;
-  // TODO Verbosity from config
   private verbosity = Verbosity.High;
 
   constructor(
@@ -944,10 +943,6 @@ export class ClientService {
       err && this.errorService.setError(err.toString());
       return;
     }
-
-    // TODO
-    // deploy_to_sign = deploy_to_sign.addArg("test:bool='false"); // Deploy was modified has no approvals anymore
-    // deploy_to_sign = deploy_to_sign.addArg({ "name": "name_of_my_key", "type": "U256", "value": 1 });
 
     let signed_deploy;
     try {

--- a/mcp/src/tools/params.rs
+++ b/mcp/src/tools/params.rs
@@ -187,7 +187,7 @@ fn parse_transfer_target(obj: &Value) -> Result<TransferTarget, String> {
 pub fn parse_transaction_builder_params(json: &str) -> Result<TransactionBuilderParams, String> {
     let obj: Value = serde_json::from_str(json).map_err(|e| format!("builder_params JSON: {e}"))?;
     let kind = req_str(&obj, "kind")?;
-    match kind.to_lowercase().as_str() {
+    let mut params = match kind.to_lowercase().as_str() {
         "session" => {
             let bytes = match opt_str(&obj, "transaction_bytes_hex") {
                 Some(h) => Some(bytes_from_hex(&h)?),
@@ -304,7 +304,30 @@ pub fn parse_transaction_builder_params(json: &str) -> Result<TransactionBuilder
         other => Err(format!(
             "unknown builder kind `{other}` (Session|Transfer|InvocableEntity|…)"
         )),
+    }?;
+    apply_builder_runtime(&mut params, &obj)?;
+    Ok(params)
+}
+
+fn apply_builder_runtime(params: &mut TransactionBuilderParams, obj: &Value) -> Result<(), String> {
+    let seed = match opt_str(obj, "seed_hex") {
+        Some(h) => Some(Vec::<u8>::from(bytes_from_hex(&h)?)),
+        None => None,
+    };
+    if let Some(runtime) = opt_str(obj, "runtime") {
+        match runtime.to_lowercase().as_str() {
+            "v1" | "vmcasperv1" | "vm_casper_v1" => params.set_runtime_v1(),
+            "v2" | "vmcasperv2" | "vm_casper_v2" => {
+                let transferred_value = opt_u64(obj, "transferred_value").unwrap_or(0);
+                params.set_runtime_v2(transferred_value, seed);
+            }
+            other => return Err(format!("unknown runtime `{other}` (v1|v2)")),
+        }
+    } else if opt_u64(obj, "transferred_value").is_some() || seed.is_some() {
+        let transferred_value = opt_u64(obj, "transferred_value").unwrap_or(0);
+        params.set_runtime_v2(transferred_value, seed);
     }
+    Ok(())
 }
 
 /// Parse `DeployStrParams` from JSON.

--- a/src/helpers/mod.rs
+++ b/src/helpers/mod.rs
@@ -167,6 +167,43 @@ pub fn get_base64_key_from_key_hash(formatted_hash: &str) -> Result<String, Box<
     Ok(general_purpose::STANDARD.encode(key)) // base64.encode
 }
 
+/// Prefix used when addressable entities are enabled for contract-shaped named keys.
+pub const ENTITY_CONTRACT_PREFIX: &str = "entity-contract-";
+/// Prefix expected by `query_global_state` for classic `StoredValue::Contract` keys.
+pub const HASH_PREFIX: &str = "hash-";
+
+/// Maps a contract-shaped formatted key to the `hash-…` form used when AE is off.
+///
+/// With addressable entities disabled, account named keys often still store
+/// `entity-contract-<hex>`, but `query_global_state` and contract-info identifiers
+/// resolve `hash-<hex>` to `StoredValue::Contract`. Pass the named-key string
+/// through this helper before those queries.
+///
+/// - `entity-contract-<hex>` → `hash-<hex>`
+/// - already `hash-…` → unchanged
+/// - bare hex (no prefix) → `hash-<hex>`
+/// - any other prefix → unchanged
+pub fn contract_hash_key_for_global_state(formatted: &str) -> String {
+    if let Some(hex) = formatted.strip_prefix(ENTITY_CONTRACT_PREFIX) {
+        format!("{HASH_PREFIX}{hex}")
+    } else if formatted.starts_with(HASH_PREFIX) {
+        formatted.to_string()
+    } else if formatted.contains('-') {
+        // account-hash-, uref-, package-, addressable-entity-, …
+        formatted.to_string()
+    } else {
+        format!("{HASH_PREFIX}{formatted}")
+    }
+}
+
+/// Strips `hash-` or `entity-contract-` for hex-only comparisons.
+pub fn strip_contract_key_prefix(formatted: &str) -> &str {
+    formatted
+        .strip_prefix(HASH_PREFIX)
+        .or_else(|| formatted.strip_prefix(ENTITY_CONTRACT_PREFIX))
+        .unwrap_or(formatted)
+}
+
 /// Gets the time to live (TTL) value or returns the default value if not provided.
 ///
 /// # Arguments
@@ -496,6 +533,32 @@ pub(crate) fn insert_arg(args: &mut RuntimeArgs, new_arg: String) -> &RuntimeArg
 mod tests {
     use super::*;
     use casper_types::U256;
+
+    #[test]
+    fn test_contract_hash_key_for_global_state() {
+        let hex = "5be5b0ef09a7016e11292848d77f539e55791cb07a7012fbc336b1f92a4fe743";
+        assert_eq!(
+            contract_hash_key_for_global_state(&format!("entity-contract-{hex}")),
+            format!("hash-{hex}")
+        );
+        assert_eq!(
+            contract_hash_key_for_global_state(&format!("hash-{hex}")),
+            format!("hash-{hex}")
+        );
+        assert_eq!(
+            contract_hash_key_for_global_state(hex),
+            format!("hash-{hex}")
+        );
+        assert_eq!(
+            contract_hash_key_for_global_state(&format!("uref-{hex}-007")),
+            format!("uref-{hex}-007")
+        );
+        assert_eq!(
+            strip_contract_key_prefix(&format!("entity-contract-{hex}")),
+            hex
+        );
+        assert_eq!(strip_contract_key_prefix(&format!("hash-{hex}")), hex);
+    }
 
     #[test]
     fn test_cl_value_to_json() {

--- a/src/js/interns.rs
+++ b/src/js/interns.rs
@@ -1,6 +1,6 @@
 use crate::helpers::{
-    get_base64_key_from_account_hash, get_base64_key_from_key_hash, get_blake2b_hash,
-    get_current_timestamp, hex_to_uint8_vec,
+    contract_hash_key_for_global_state, get_base64_key_from_account_hash,
+    get_base64_key_from_key_hash, get_blake2b_hash, get_current_timestamp, hex_to_uint8_vec,
     make_dictionary_item_key as make_dictionary_item_key_helper, public_key_from_secret_key,
     secret_key_generate, secret_key_secp256k1_generate,
 };
@@ -234,6 +234,12 @@ pub fn get_base64_key_from_key_hash_js_alias(formatted_key_hash: &str) -> Result
         let error_text = format!("Error serializing package hash: {err:?}");
         JsError::new(&error_text)
     })
+}
+
+/// Maps `entity-contract-…` (or bare hex) to `hash-…` for AE-off global-state / contract-info queries.
+#[wasm_bindgen(js_name = "contractHashKeyForGlobalState")]
+pub fn contract_hash_key_for_global_state_js_alias(formatted: &str) -> String {
+    contract_hash_key_for_global_state(formatted)
 }
 
 /// Gets the current timestamp.

--- a/src/sdk/binary_port/mod.rs
+++ b/src/sdk/binary_port/mod.rs
@@ -856,7 +856,6 @@ mod tests {
             .get_binary_consensus_validator_changes(Some(node_address))
             .await;
         let changes = result.unwrap();
-        // Todo check empty
         assert!(changes.into_inner().is_empty());
     }
 
@@ -891,7 +890,6 @@ mod tests {
 
         let result = sdk.get_binary_next_upgrade(Some(node_address)).await;
         let upgrade = result.unwrap();
-        // TODO check
         assert!(upgrade.is_none());
     }
 
@@ -935,7 +933,6 @@ mod tests {
     async fn test_get_binary_validator_reward_by_era_success() {
         let sdk = SDK::new(None, None, None);
         let (_, _, _, node_address, _) = get_network_constants();
-        // TODO Get validator key
         let secret_key = get_user_secret_key(None).unwrap();
         let secret_key_from_pem = secret_key_from_pem(&secret_key).unwrap();
         let validator_key = PublicKey::from(&secret_key_from_pem);
@@ -945,7 +942,6 @@ mod tests {
             .get_binary_validator_reward_by_era(Some(node_address), validator_key, era)
             .await;
 
-        // TODO
         let reward = result.unwrap();
         assert!(reward.is_none());
     }
@@ -954,7 +950,6 @@ mod tests {
     async fn test_get_binary_validator_reward_by_block_height_success() {
         let sdk = SDK::new(None, None, None);
         let (_, _, _, node_address, _) = get_network_constants();
-        // TODO Get validator key
         let secret_key = get_user_secret_key(None).unwrap();
         let secret_key_from_pem = secret_key_from_pem(&secret_key).unwrap();
         let validator_key = PublicKey::from(&secret_key_from_pem);
@@ -968,7 +963,6 @@ mod tests {
             )
             .await;
 
-        // TODO
         let reward = result.unwrap();
         assert!(reward.is_none());
     }
@@ -977,7 +971,6 @@ mod tests {
     async fn test_get_binary_validator_reward_by_block_hash_success() {
         let sdk = SDK::new(None, None, None);
         let (_, _, _, node_address, _) = get_network_constants();
-        // TODO Get validator key
         let secret_key = get_user_secret_key(None).unwrap();
         let secret_key_from_pem = secret_key_from_pem(&secret_key).unwrap();
         let validator_key = PublicKey::from(&secret_key_from_pem);
@@ -1002,7 +995,6 @@ mod tests {
             )
             .await;
 
-        // TODO
         let reward = result.unwrap();
         assert!(reward.is_none());
     }
@@ -1011,12 +1003,10 @@ mod tests {
     async fn test_get_binary_delegator_reward_by_era_success() {
         let sdk = SDK::new(None, None, None);
         let (_, _, _, node_address, _) = get_network_constants();
-        // TODO Get delegator key
         let secret_key = get_user_secret_key(None).unwrap();
         let validator_secret_key_from_pem = secret_key_from_pem(&secret_key).unwrap();
         let validator_key = PublicKey::from(&validator_secret_key_from_pem);
 
-        // TODO Get Delegator key
         let secret_key = get_user_secret_key(Some("user-2")).unwrap();
         let delegator_secret_key_from_pem = secret_key_from_pem(&secret_key).unwrap();
         let delegator_key = PublicKey::from(&delegator_secret_key_from_pem);
@@ -1032,7 +1022,6 @@ mod tests {
             )
             .await;
 
-        // TODO
         let reward = result.unwrap();
         assert!(reward.is_none());
     }
@@ -1041,12 +1030,10 @@ mod tests {
     async fn test_get_binary_delegator_reward_by_block_height_success() {
         let sdk = SDK::new(None, None, None);
         let (_, _, _, node_address, _) = get_network_constants();
-        // TODO Get delegator key
         let secret_key = get_user_secret_key(None).unwrap();
         let validator_secret_key_from_pem = secret_key_from_pem(&secret_key).unwrap();
         let validator_key = PublicKey::from(&validator_secret_key_from_pem);
 
-        // TODO Get Delegator key
         let secret_key = get_user_secret_key(Some("user-2")).unwrap();
         let delegator_secret_key_from_pem = secret_key_from_pem(&secret_key).unwrap();
         let delegator_key = PublicKey::from(&delegator_secret_key_from_pem);
@@ -1061,7 +1048,6 @@ mod tests {
             )
             .await;
 
-        // TODO
         let reward = result.unwrap();
         assert!(reward.is_none());
     }
@@ -1070,12 +1056,10 @@ mod tests {
     async fn test_get_binary_delegator_reward_by_block_hash_success() {
         let sdk = SDK::new(None, None, None);
         let (_, _, _, node_address, _) = get_network_constants();
-        // TODO Get delegator key
         let secret_key = get_user_secret_key(None).unwrap();
         let validator_secret_key_from_pem = secret_key_from_pem(&secret_key).unwrap();
         let validator_key = PublicKey::from(&validator_secret_key_from_pem);
 
-        // TODO Get Delegator key
         let secret_key = get_user_secret_key(Some("user-2")).unwrap();
         let delegator_secret_key_from_pem = secret_key_from_pem(&secret_key).unwrap();
         let delegator_key = PublicKey::from(&delegator_secret_key_from_pem);
@@ -1101,7 +1085,6 @@ mod tests {
             )
             .await;
 
-        // TODO
         let reward = result.unwrap();
         assert!(reward.is_none());
     }
@@ -1117,9 +1100,8 @@ mod tests {
             .get_binary_read_record(Some(node_address), record_id, key)
             .await;
 
-        // TODO
-        let reward = result.unwrap();
-        assert!(reward.is_empty());
+        let record = result.unwrap();
+        assert!(record.is_empty());
     }
 
     #[tokio::test]
@@ -1297,7 +1279,6 @@ mod tests {
             )
             .await;
 
-        // TODO check transaction V1 in speculative exec
         assert!(result.is_ok());
     }
 

--- a/src/sdk/contract/call_entrypoint.rs
+++ b/src/sdk/contract/call_entrypoint.rs
@@ -58,7 +58,10 @@ impl SDK {
 /// A set of functions for working with smart contract entry points.
 /// Alias of sdk.transaction
 impl SDK {
-    /// Calls a smart contract entry point with the specified parameters and returns the result.
+    /// Calls a smart contract entry point and returns the put result.
+    ///
+    /// Pins `VmCasperV1` (CEP-78 and other current stored fixtures). For VM2
+    /// contracts, use `transaction` with `set_runtime_v2` on builder params.
     ///
     /// # Arguments
     ///
@@ -75,11 +78,12 @@ impl SDK {
     /// Returns a `SdkError` if there is an error during the call.
     pub async fn call_entrypoint(
         &self,
-        builder_params: TransactionBuilderParams,
+        mut builder_params: TransactionBuilderParams,
         transaction_params: TransactionStrParams,
         rpc_address: Option<String>,
     ) -> Result<SuccessResponse<_PutTransactionResult>, SdkError> {
-        //log("call_entrypoint!");;
+        // Classic stored contracts (CEP-78, …) are VmCasperV1 wasm.
+        builder_params.set_runtime_v1();
         self.transaction(builder_params, transaction_params, None, rpc_address)
             .await
     }

--- a/src/sdk/contract/call_entrypoint_deploy.rs
+++ b/src/sdk/contract/call_entrypoint_deploy.rs
@@ -155,8 +155,9 @@ mod tests {
         payment_params.set_payment_amount(PAYMENT_AMOUNT);
 
         let mut session_params = SessionStrParams::default();
-        session_params
-            .set_session_hash(&get_contract_hash().await.replace("entity-contract", "hash"));
+        session_params.set_session_hash(&crate::helpers::contract_hash_key_for_global_state(
+            &get_contract_hash().await,
+        ));
         session_params.set_session_entry_point(ENTRYPOINT_MINT);
         let args_simple: Vec<String> = ARGS_SIMPLE.iter().map(|s| s.to_string()).collect();
         session_params.set_session_args_simple(args_simple);

--- a/src/sdk/contract/install.rs
+++ b/src/sdk/contract/install.rs
@@ -59,7 +59,10 @@ impl SDK {
 /// A set of functions for installing smart contracts on the blockchain.
 /// Alias of sdk.transaction
 impl SDK {
-    /// Installs a smart contract with the specified parameters and returns the result.
+    /// Installs classic session wasm (`is_install_upgrade`) and returns the put result.
+    ///
+    /// Pins `VmCasperV1` (CEP-78, HELLO, and other current session fixtures). For VM2
+    /// contracts, use `TransactionBuilderParams` with `set_runtime_v2` instead.
     ///
     /// # Arguments
     ///
@@ -82,8 +85,10 @@ impl SDK {
     ) -> Result<SuccessResponse<_PutTransactionResult>, SdkError> {
         //log("install!");
         let is_install_upgrade = Some(true);
-        let builder_params =
+        let mut builder_params =
             TransactionBuilderParams::new_session(Some(transaction_bytes), is_install_upgrade);
+        // Classic session installs (CEP-78, HELLO, …) are VmCasperV1 wasm.
+        builder_params.set_runtime_v1();
         self.transaction(builder_params, transaction_params, None, rpc_address)
             .await
     }

--- a/src/sdk/contract/mod.rs
+++ b/src/sdk/contract/mod.rs
@@ -107,7 +107,7 @@ async fn get_dictionary_item_input(entity_addr: &str) -> DictionaryItemInput {
     } else {
         DictionaryItemInput::Identifier(
             DictionaryItemIdentifier::new_from_contract_info(
-                &entity_addr.replace("entity-contract", "hash"),
+                &crate::helpers::contract_hash_key_for_global_state(entity_addr),
                 DICTIONARY_NAME,
                 DICTIONARY_ITEM_KEY,
             )
@@ -127,7 +127,7 @@ async fn get_dictionary_item_params_input(key: &str) -> DictionaryItemInput {
         params.set_entity_named_key(key, DICTIONARY_NAME, DICTIONARY_ITEM_KEY);
     } else {
         params.set_contract_named_key(
-            &key.replace("entity-contract", "hash"),
+            &crate::helpers::contract_hash_key_for_global_state(key),
             DICTIONARY_NAME,
             DICTIONARY_ITEM_KEY,
         );

--- a/src/sdk/contract/query_contract_dict.rs
+++ b/src/sdk/contract/query_contract_dict.rs
@@ -232,8 +232,7 @@ mod tests {
         let verbosity = Some(Verbosity::High);
         let (rpc_address, _, _, _, _) = get_network_constants();
 
-        let error_message =
-            "Failed to parse dictionary item address as a key: unknown prefix for key";
+        let error_message = "no dictionary item params set";
 
         let state_root_hash = "";
         let params = DictionaryItemStrParams::new();

--- a/src/sdk/contract/query_contract_key.rs
+++ b/src/sdk/contract/query_contract_key.rs
@@ -187,7 +187,8 @@ impl SDK {
             }
             Err(_) => {
                 // Entities not enabled
-                let key_as_string = key_as_string.replace("entity-contract", "hash");
+                let key_as_string =
+                    crate::helpers::contract_hash_key_for_global_state(&key_as_string);
                 let key = KeyIdentifierInput::String(key_as_string);
                 self.query_global_state(QueryGlobalStateParams {
                     key,

--- a/src/sdk/rpcs/get_dictionary_item.rs
+++ b/src/sdk/rpcs/get_dictionary_item.rs
@@ -410,8 +410,7 @@ mod tests {
         let verbosity = Some(Verbosity::High);
         let (rpc_address, _, _, _, _) = get_network_constants();
 
-        let error_message =
-            "Failed to parse dictionary item address as a key: unknown prefix for key";
+        let error_message = "no dictionary item params set";
 
         let state_root_hash = "";
         let params = DictionaryItemStrParams::new();

--- a/src/sdk/rpcs/get_dictionary_item.rs
+++ b/src/sdk/rpcs/get_dictionary_item.rs
@@ -255,15 +255,20 @@ impl SDK {
         };
         let random_id = rand::rng().random::<u64>().to_string();
         match dictionary_item_input {
-            DictionaryItemInput::Params(dictionary_item_params) => get_dictionary_item_cli(
-                &random_id,
-                &self.get_rpc_address(rpc_address),
-                self.get_verbosity(verbosity).into(),
-                &state_root_hash.to_string(),
-                dictionary_item_str_params_to_casper_client(&dictionary_item_params),
-            )
-            .await
-            .map_err(SdkError::from),
+            DictionaryItemInput::Params(dictionary_item_params) => {
+                let dictionary_item_params =
+                    dictionary_item_str_params_to_casper_client(&dictionary_item_params)
+                        .map_err(|err| *err)?;
+                get_dictionary_item_cli(
+                    &random_id,
+                    &self.get_rpc_address(rpc_address),
+                    self.get_verbosity(verbosity).into(),
+                    &state_root_hash.to_string(),
+                    dictionary_item_params,
+                )
+                .await
+                .map_err(SdkError::from)
+            }
             DictionaryItemInput::Identifier(dictionary_item_identifier) => get_dictionary_item_lib(
                 JsonRpcId::from(random_id),
                 &self.get_rpc_address(rpc_address),

--- a/src/sdk/sse/ces/parser.rs
+++ b/src/sdk/sse/ces/parser.rs
@@ -106,14 +106,8 @@ impl CESParser {
         rpc_address: Option<String>,
     ) -> Result<ContractMetadata, String> {
         // NCTL/account named keys often use entity-contract-…; query_global_state
-        // expects hash-… (same remap as dictionary helpers).
-        let key = if contract_hash.starts_with("entity-contract-") {
-            contract_hash.replacen("entity-contract-", "hash-", 1)
-        } else if contract_hash.starts_with("hash-") {
-            contract_hash.to_string()
-        } else {
-            format!("hash-{contract_hash}")
-        };
+        // expects hash-… (see helpers::contract_hash_key_for_global_state).
+        let key = crate::helpers::contract_hash_key_for_global_state(contract_hash);
 
         let contract_json =
             query_stored_value_json(sdk, &key, &[], state_root_hash, rpc_address.clone()).await?;
@@ -129,10 +123,7 @@ impl CESParser {
             .ok_or_else(|| format!("no CLValue bytes for schema uref {events_schema_uref}"))?;
         let schemas = parse_schemas_from_bytes(&schema_bytes)?;
 
-        let hash_hex = contract_hash
-            .trim_start_matches("hash-")
-            .trim_start_matches("entity-contract-")
-            .to_string();
+        let hash_hex = crate::helpers::strip_contract_key_prefix(contract_hash).to_string();
 
         Ok(ContractMetadata {
             schemas,
@@ -619,5 +610,36 @@ mod tests {
         }"#;
         let events = parser.parse_execution_result_json(json).unwrap();
         assert!(events.is_empty());
+    }
+
+    /// Regression: `into_t::<Vec<u8>>` / `Vec::<u8>::from_bytes` hits
+    /// `debug_assert` in casper_types (`ensure_efficient_serialization`); use `Bytes`.
+    #[test]
+    fn dictionary_list_u8_decodes_via_bytes() {
+        let payload = b"event_Mint\x01\x02\x03".to_vec();
+        let cl = CLValue::from_t(Bytes::from(payload.clone())).unwrap();
+        let uref_addr = [0xab_u8; 32];
+        let dict_key = "42".to_string();
+
+        let mut wire = cl.to_bytes().unwrap();
+        wire.extend((uref_addr.len() as u32).to_bytes().unwrap());
+        wire.extend_from_slice(&uref_addr);
+        wire.extend(dict_key.to_bytes().unwrap());
+
+        let dict = new_dictionary_from_bytes(&wire).expect("Bytes path must not panic/fail");
+        assert_eq!(dict.value, payload);
+        assert_eq!(dict.key, dict_key);
+        assert!(dict.uref.starts_with("uref-"));
+    }
+
+    #[test]
+    fn list_u8_field_decodes_via_bytes() {
+        let raw = Bytes::from(vec![9_u8, 8, 7]);
+        let encoded = raw.to_bytes().unwrap();
+        let (cl, rest) =
+            decode_clvalue_by_type(CLType::List(Box::new(CLType::U8)), &encoded).unwrap();
+        assert!(rest.is_empty());
+        let roundtrip: Bytes = cl.into_t().unwrap();
+        assert_eq!(roundtrip.as_ref(), raw.as_ref());
     }
 }

--- a/src/sdk/sse/client.rs
+++ b/src/sdk/sse/client.rs
@@ -10,6 +10,23 @@ use wasm_bindgen::prelude::*;
 #[cfg(target_arch = "wasm32")]
 use gloo_utils::format::JsValueSerdeExt;
 
+/// HTTP client for native SSE. Disables idle keep-alive so a dropped tokio
+/// runtime cannot leave pooled connections (hyperium/hyper#2136).
+#[cfg(not(target_arch = "wasm32"))]
+fn sse_http_client() -> Result<reqwest::Client, String> {
+    reqwest::Client::builder()
+        .pool_max_idle_per_host(0)
+        .build()
+        .map_err(|e| format!("SSE HTTP client build failed: {e}"))
+}
+
+#[cfg(target_arch = "wasm32")]
+fn sse_http_client() -> Result<reqwest::Client, String> {
+    reqwest::Client::builder()
+        .build()
+        .map_err(|e| format!("SSE HTTP client build failed: {e}"))
+}
+
 /// Native event handler.
 #[cfg(not(target_arch = "wasm32"))]
 pub type SSEHandlerFn = Arc<Mutex<dyn Fn(RawEvent) + Send + Sync>>;
@@ -183,7 +200,7 @@ impl SSEClient {
         }
 
         let url = url_with_start_from(&self.events_url, start_from);
-        let client = reqwest::Client::new();
+        let client = sse_http_client()?;
         let response = client
             .get(&url)
             .send()
@@ -274,7 +291,7 @@ impl SSEClient {
         use chrono::{Duration, Utc};
 
         let url = url_with_start_from(&self.events_url, start_from);
-        let client = reqwest::Client::new();
+        let client = sse_http_client()?;
         let response = client
             .get(&url)
             .send()

--- a/src/sdk/sse/watcher/mod.rs
+++ b/src/sdk/sse/watcher/mod.rs
@@ -23,6 +23,23 @@ use wasm_bindgen_futures::future_to_promise;
 
 const DEFAULT_TIMEOUT_MS: u64 = 60000;
 
+/// HTTP client for native SSE. Disables idle keep-alive so a dropped tokio
+/// runtime cannot leave pooled connections (hyperium/hyper#2136).
+#[cfg(not(target_arch = "wasm32"))]
+fn sse_http_client() -> Result<reqwest::Client, String> {
+    reqwest::Client::builder()
+        .pool_max_idle_per_host(0)
+        .build()
+        .map_err(|e| format!("SSE HTTP client build failed: {e}"))
+}
+
+#[cfg(target_arch = "wasm32")]
+fn sse_http_client() -> Result<reqwest::Client, String> {
+    reqwest::Client::builder()
+        .build()
+        .map_err(|e| format!("SSE HTTP client build failed: {e}"))
+}
+
 impl SDK {
     /// Creates a new Watcher instance to watch deploys.
     /// Legacy alias
@@ -380,7 +397,16 @@ impl Watcher {
             *active = true;
         }
 
-        let client = reqwest::Client::new();
+        let client = match sse_http_client() {
+            Ok(client) => client,
+            Err(err) => {
+                let event_parse_result = EventParseResult {
+                    err: Some(err),
+                    body: None,
+                };
+                return Some(vec![event_parse_result]);
+            }
+        };
         // Replay from event id 0 so a TransactionProcessed already emitted
         // before connect is still visible (parity with SSEClient).
         let url = url_with_start_from(&self.events_url, Some(0));

--- a/src/sdk/sse/watcher/mod.rs
+++ b/src/sdk/sse/watcher/mod.rs
@@ -385,8 +385,7 @@ impl Watcher {
         // before connect is still visible (parity with SSEClient).
         let url = url_with_start_from(&self.events_url, Some(0));
 
-        // TODO fix this warning
-        // https://github.com/rust-lang/rust-clippy/issues/11034
+        // Clippy false positive until rust-lang/rust-clippy#11034 is fixed.
         #[allow(clippy::arc_with_non_send_sync)]
         let watcher = Arc::new(Mutex::new(self.clone()));
 

--- a/src/sdk/transaction/speculative_transaction.rs
+++ b/src/sdk/transaction/speculative_transaction.rs
@@ -127,10 +127,12 @@ mod tests {
 
             let is_install_upgrade = Some(true);
 
-            let new_builder_params = TransactionBuilderParams::new_session(
+            let mut new_builder_params = TransactionBuilderParams::new_session(
                 Some(transaction_bytes.into()),
                 is_install_upgrade,
             );
+            // HELLO fixture is classic VmCasperV1 wasm.
+            new_builder_params.set_runtime_v1();
             *builder_params = Some(new_builder_params);
         }
 

--- a/src/sdk/transaction/transaction.rs
+++ b/src/sdk/transaction/transaction.rs
@@ -176,10 +176,12 @@ mod tests {
 
             let is_install_upgrade = Some(true);
 
-            let new_builder_params = TransactionBuilderParams::new_session(
+            let mut new_builder_params = TransactionBuilderParams::new_session(
                 Some(transaction_bytes.into()),
                 is_install_upgrade,
             );
+            // HELLO fixture is classic VmCasperV1 wasm.
+            new_builder_params.set_runtime_v1();
             *builder_params = Some(new_builder_params);
         }
 

--- a/src/types/deploy_params/dictionary_item_str_params.rs
+++ b/src/types/deploy_params/dictionary_item_str_params.rs
@@ -1,4 +1,4 @@
-use crate::{debug::error, helpers::get_str_or_default, types::sdk_error::SdkError};
+use crate::{helpers::get_str_or_default, types::sdk_error::SdkError};
 use casper_client::cli::DictionaryItemStrParams as _DictionaryItemStrParams;
 use casper_types::URef;
 #[cfg(target_arch = "wasm32")]
@@ -241,48 +241,49 @@ impl DictionaryItemStrParams {
 
 pub fn dictionary_item_str_params_to_casper_client(
     dictionary_item_params: &DictionaryItemStrParams,
-) -> _DictionaryItemStrParams<'_> {
+) -> Result<_DictionaryItemStrParams<'_>, Box<SdkError>> {
     if let Some(account_named_key) = &dictionary_item_params.account_named_key {
         let account_hash = get_str_or_default(account_named_key.key.get());
         let dictionary_name = get_str_or_default(account_named_key.dictionary_name.get());
         let dictionary_item_key = get_str_or_default(account_named_key.dictionary_item_key.get());
-        _DictionaryItemStrParams::AccountNamedKey {
+        Ok(_DictionaryItemStrParams::AccountNamedKey {
             account_hash,
             dictionary_name,
             dictionary_item_key,
-        }
+        })
     } else if let Some(contract_named_key) = &dictionary_item_params.contract_named_key {
         let hash_addr = get_str_or_default(contract_named_key.key.get());
         let dictionary_name = get_str_or_default(contract_named_key.dictionary_name.get());
         let dictionary_item_key = get_str_or_default(contract_named_key.dictionary_item_key.get());
-        _DictionaryItemStrParams::ContractNamedKey {
+        Ok(_DictionaryItemStrParams::ContractNamedKey {
             hash_addr,
             dictionary_name,
             dictionary_item_key,
-        }
+        })
     } else if let Some(entity_named_key) = &dictionary_item_params.entity_named_key {
         let entity_addr = get_str_or_default(entity_named_key.key.get());
         let dictionary_name = get_str_or_default(entity_named_key.dictionary_name.get());
         let dictionary_item_key = get_str_or_default(entity_named_key.dictionary_item_key.get());
-        _DictionaryItemStrParams::EntityNamedKey {
+        Ok(_DictionaryItemStrParams::EntityNamedKey {
             entity_addr,
             dictionary_name,
             dictionary_item_key,
-        }
+        })
     } else if let Some(uref_variant) = &dictionary_item_params.uref {
         let seed_uref = get_str_or_default(uref_variant.seed_uref.get());
         let dictionary_item_key = get_str_or_default(uref_variant.dictionary_item_key.get());
-        _DictionaryItemStrParams::URef {
+        Ok(_DictionaryItemStrParams::URef {
             seed_uref,
             dictionary_item_key,
-        }
+        })
     } else if let Some(dictionary_variant) = &dictionary_item_params.dictionary {
         let value = get_str_or_default(dictionary_variant.value.get());
-        _DictionaryItemStrParams::Dictionary(value)
+        Ok(_DictionaryItemStrParams::Dictionary(value))
     } else {
-        // TODO Fix return type
-        error("Error converting dictionary_item_params");
-        _DictionaryItemStrParams::Dictionary("")
+        Err(Box::new(SdkError::InvalidArgument {
+            context: "dictionary_item_str_params_to_casper_client",
+            error: "no dictionary item params set".to_string(),
+        }))
     }
 }
 
@@ -323,7 +324,7 @@ mod tests {
             account_hash,
             dictionary_name,
             dictionary_item_key,
-        } = dictionary_item_str_params_to_casper_client(&dictionary_item_params)
+        } = dictionary_item_str_params_to_casper_client(&dictionary_item_params).unwrap()
         {
             assert_eq!(account_hash, "account_key");
             assert_eq!(dictionary_name, "test_dict");
@@ -363,7 +364,7 @@ mod tests {
             hash_addr,
             dictionary_name,
             dictionary_item_key,
-        } = dictionary_item_str_params_to_casper_client(&dictionary_item_params)
+        } = dictionary_item_str_params_to_casper_client(&dictionary_item_params).unwrap()
         {
             assert_eq!(hash_addr, "contract_key");
             assert_eq!(dictionary_name, "test_contract_dict");
@@ -400,7 +401,7 @@ mod tests {
             entity_addr,
             dictionary_name,
             dictionary_item_key,
-        } = dictionary_item_str_params_to_casper_client(&dictionary_item_params)
+        } = dictionary_item_str_params_to_casper_client(&dictionary_item_params).unwrap()
         {
             assert_eq!(entity_addr, "entity_key");
             assert_eq!(dictionary_name, "test_entity_dict");
@@ -431,7 +432,7 @@ mod tests {
         if let _DictionaryItemStrParams::URef {
             seed_uref,
             dictionary_item_key,
-        } = dictionary_item_str_params_to_casper_client(&dictionary_item_params)
+        } = dictionary_item_str_params_to_casper_client(&dictionary_item_params).unwrap()
         {
             assert_eq!(seed_uref, "seed_uref");
             assert_eq!(dictionary_item_key, "uref_item_key");
@@ -457,7 +458,7 @@ mod tests {
         };
 
         if let _DictionaryItemStrParams::Dictionary(value) =
-            dictionary_item_str_params_to_casper_client(&dictionary_item_params)
+            dictionary_item_str_params_to_casper_client(&dictionary_item_params).unwrap()
         {
             assert_eq!(value, "dictionary_value");
         } else {
@@ -473,12 +474,6 @@ mod tests {
             entity_named_key: None,
         };
 
-        if let _DictionaryItemStrParams::Dictionary(value) =
-            dictionary_item_str_params_to_casper_client(&invalid_params)
-        {
-            assert_eq!(value, "");
-        } else {
-            panic!("Unexpected enum variant");
-        }
+        assert!(dictionary_item_str_params_to_casper_client(&invalid_params).is_err());
     }
 }

--- a/src/types/deploy_params/payment_str_params.rs
+++ b/src/types/deploy_params/payment_str_params.rs
@@ -296,7 +296,5 @@ mod tests {
         let result = payment_str_params_to_casper_client(&payment_params);
         let result_debug_output = format!("{result:?}");
         assert!(result_debug_output.contains("payment_path: \"path_value\""));
-
-        // TODO Find alternative as no setter in client
     }
 }

--- a/src/types/key.rs
+++ b/src/types/key.rs
@@ -54,10 +54,8 @@ impl Key {
     }
 
     #[wasm_bindgen(js_name = "fromTransfer")]
-    pub fn from_transfer(key: Vec<u8>) -> TransferAddr {
-        // TODO Fix with TransferAddr as _TransferAddr, and [u8; 32]
-        // Key(_Key::Transfer(key.into()))
-        TransferAddr::from(key)
+    pub fn from_transfer(key: Vec<u8>) -> Self {
+        Self(_Key::Transfer(TransferAddr::from(key).into()))
     }
 
     #[wasm_bindgen(js_name = "fromEraInfo")]

--- a/src/types/transaction.rs
+++ b/src/types/transaction.rs
@@ -5,9 +5,9 @@ use crate::helpers::secret_key_from_pem;
 use crate::helpers::{
     get_current_timestamp, get_ttl_or_default, insert_arg, parse_timestamp, parse_ttl,
 };
+use crate::types::{cl::bytes::Bytes, hash::account_hash::AccountHash, sdk_error::SdkError};
 #[cfg(feature = "transaction")]
 use crate::types::{
-    cl::bytes::Bytes,
     hash::{addressable_entity_hash::AddressableEntityHash, package_hash::PackageHash},
     public_key::PublicKey,
     transaction_params::{
@@ -16,7 +16,6 @@ use crate::types::{
     },
     uref::URef,
 };
-use crate::types::{hash::account_hash::AccountHash, sdk_error::SdkError};
 use crate::{
     debug::{error, log},
     types::{digest::Digest, hash::transaction_hash::TransactionHash, pricing_mode::PricingMode},
@@ -432,13 +431,39 @@ impl Transaction {
     #[cfg(target_arch = "wasm32")]
     #[wasm_bindgen(js_name = "session_args")]
     pub fn session_args_js_alias(&self) -> JsValue {
-        match JsValue::from_serde(&self.session_args()) {
-            Ok(json) => json,
+        match self.session_args() {
+            Ok(args) => match JsValue::from_serde(&args) {
+                Ok(json) => json,
+                Err(err) => {
+                    error(&format!("Error serializing session_args to JSON: {err:?}"));
+                    JsValue::null()
+                }
+            },
             Err(err) => {
-                error(&format!("Error serializing session_args to JSON: {err:?}"));
+                error(&format!("Error retrieving session_args: {err:?}"));
                 JsValue::null()
             }
         }
+    }
+
+    /// Bytesrepr session args, or an error when args are named.
+    #[cfg(target_arch = "wasm32")]
+    #[wasm_bindgen(js_name = "session_args_bytes")]
+    pub fn session_args_bytes_js_alias(&self) -> Result<Bytes, JsError> {
+        self.session_args_bytes()
+            .map_err(|err| JsError::new(&format!("{err:?}")))
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    #[wasm_bindgen(getter, js_name = "is_bytesrepr")]
+    pub fn is_bytesrepr_js_alias(&self) -> bool {
+        self.is_bytesrepr()
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    #[wasm_bindgen(getter, js_name = "is_named")]
+    pub fn is_named_js_alias(&self) -> bool {
+        self.is_named()
     }
 
     #[wasm_bindgen(js_name = "addSignature")]
@@ -535,9 +560,11 @@ impl Transaction {
         match &self.0 {
             _Transaction::Deploy(_deploy) => {
                 unimplemented!("receipt not implemented in deploy!")
-            } // TODO
-            // _Transaction::V1(transaction_v1) => transaction_v1.pricing_mode().receipt().into(),
-            _Transaction::V1(_transaction_v1) => Digest::new("0").unwrap(),
+            }
+            _Transaction::V1(transaction_v1) => match transaction_v1.pricing_mode() {
+                _PricingMode::Prepaid { receipt } => (*receipt).into(),
+                _ => Digest::default(),
+            },
         }
     }
 
@@ -564,7 +591,9 @@ impl Transaction {
         js_value_arg: JsValue,
         secret_key: Option<String>,
     ) -> Result<Transaction, JsError> {
-        let mut args = self.session_args().clone();
+        let mut args = self
+            .session_args()
+            .map_err(|err| JsError::new(&format!("Error adding argument: {err}")))?;
         let new_args = match insert_js_value_arg(&mut args, js_value_arg) {
             Ok(new_args) => new_args,
             Err(err) => return Err(JsError::new(&format!("Error adding argument: {err}"))),
@@ -574,24 +603,52 @@ impl Transaction {
 }
 
 impl Transaction {
-    pub fn session_args(&self) -> RuntimeArgs {
+    fn transaction_args(&self) -> Result<TransactionArgs, Box<SdkError>> {
         match &self.0 {
-            _Transaction::Deploy(deploy) => deploy.session().args().clone(),
-            _Transaction::V1(transaction_v1) => {
-                let args = transaction_v1
-                    .deserialize_field::<TransactionArgs>(ARGS_MAP_KEY)
-                    .map_err(|err| SdkError::FieldDeserialization {
-                        index: TARGET_MAP_KEY,
+            _Transaction::Deploy(deploy) => {
+                Ok(TransactionArgs::Named(deploy.session().args().clone()))
+            }
+            _Transaction::V1(transaction_v1) => transaction_v1
+                .deserialize_field::<TransactionArgs>(ARGS_MAP_KEY)
+                .map_err(|err| {
+                    Box::new(SdkError::FieldDeserialization {
+                        index: ARGS_MAP_KEY,
                         error: format!("{err:?}"),
                     })
-                    .unwrap();
+                }),
+        }
+    }
 
-                match args {
-                    TransactionArgs::Named(runtime_args) => runtime_args,
-                    TransactionArgs::Bytesrepr(_) => unimplemented!(), // TODO Return TransactionArgs for new Bytesrepr
-                }
+    /// Named session args. Errors when args are Bytesrepr (`UnexpectedTransactionArgsVariant`).
+    pub fn session_args(&self) -> Result<RuntimeArgs, Box<SdkError>> {
+        match self.transaction_args()? {
+            TransactionArgs::Named(runtime_args) => Ok(runtime_args),
+            TransactionArgs::Bytesrepr(_) => {
+                Err(Box::new(SdkError::UnexpectedTransactionArgsVariant))
             }
         }
+    }
+
+    /// Bytesrepr session args. Errors when args are Named (`UnexpectedTransactionArgsVariant`).
+    pub fn session_args_bytes(&self) -> Result<Bytes, Box<SdkError>> {
+        match self.transaction_args()? {
+            TransactionArgs::Bytesrepr(bytes) => Ok(bytes.into()),
+            TransactionArgs::Named(_) => Err(Box::new(SdkError::UnexpectedTransactionArgsVariant)),
+        }
+    }
+
+    /// True when V1 args are Bytesrepr (Deploy is always named).
+    pub fn is_bytesrepr(&self) -> bool {
+        self.transaction_args()
+            .map(|args| args.is_bytesrepr())
+            .unwrap_or(false)
+    }
+
+    /// True when args are Named (Deploy is always named).
+    pub fn is_named(&self) -> bool {
+        self.transaction_args()
+            .map(|args| args.is_named())
+            .unwrap_or(true)
     }
 
     pub fn target(&self) -> Result<TransactionTarget, Box<SdkError>> {
@@ -607,10 +664,14 @@ impl Transaction {
     }
 
     #[cfg(feature = "transaction")]
-    pub fn add_arg(&mut self, new_value_arg: String, secret_key: Option<String>) -> Transaction {
-        let mut session_args = self.session_args().clone();
+    pub fn add_arg(
+        &mut self,
+        new_value_arg: String,
+        secret_key: Option<String>,
+    ) -> Result<Transaction, Box<SdkError>> {
+        let mut session_args = self.session_args()?;
         let new_args = insert_arg(&mut session_args, new_value_arg);
-        self.add_arg_common(new_args, secret_key)
+        Ok(self.add_arg_common(new_args, secret_key))
     }
 
     #[cfg(feature = "transaction")]
@@ -750,15 +811,26 @@ impl Transaction {
         let ttl = ttl.unwrap_or_else(|| self.0.ttl());
         let timestamp = timestamp.unwrap_or_else(|| self.0.timestamp());
         let initiator_addr = initiator_addr.unwrap_or_else(|| self.0.initiator_addr().clone());
-        let runtime_args = session_args.unwrap_or_else(|| self.session_args());
 
         builder = builder
             .with_chain_name(chain_name)
             .with_ttl(ttl)
             .with_timestamp(timestamp)
             .with_pricing_mode(self.pricing_mode_typed())
-            .with_initiator_addr(initiator_addr)
-            .with_runtime_args(runtime_args);
+            .with_initiator_addr(initiator_addr);
+
+        builder = match session_args {
+            Some(named) => builder.with_runtime_args(named),
+            None => match self.transaction_args().unwrap_or_else(|err| {
+                error(&format!(
+                    "Error reading transaction args for rebuild: {err:?}"
+                ));
+                TransactionArgs::Named(RuntimeArgs::new())
+            }) {
+                TransactionArgs::Named(named) => builder.with_runtime_args(named),
+                TransactionArgs::Bytesrepr(bytes) => builder.with_chunked_args(bytes),
+            },
+        };
 
         let secret_key_owned: Option<SecretKey> = secret_key.as_ref().map(|pem| {
             secret_key_from_pem(pem)
@@ -813,7 +885,9 @@ impl Transaction {
         let builder = match target {
             TransactionTarget::Native => match entry_point {
                 TransactionEntryPoint::Transfer => {
-                    let args = self.session_args();
+                    let args = self
+                        .session_args()
+                        .expect("transfer rebuild requires named session args");
 
                     let target_arg = args.get("target").expect("Expected 'target' argument");
 
@@ -1018,14 +1092,21 @@ mod tests {
 
         let builder_params = TransactionBuilderParams::default();
         let mut transaction = Transaction::new_session(builder_params, transaction_params).unwrap();
-        let transaction = transaction.add_arg("foo:bool='false".to_string(), None);
+        let transaction = transaction
+            .add_arg("foo:bool='false".to_string(), None)
+            .unwrap();
 
-        assert_eq!(transaction.session_args().len(), 1);
+        assert_eq!(transaction.session_args().unwrap().len(), 1);
         // Direct RuntimeArgs path (bool false), not JSON→CLI rematerialization.
         let expected_inner_bytes = vec![0];
 
         assert_eq!(
-            *transaction.session_args().get("foo").unwrap().inner_bytes(),
+            *transaction
+                .session_args()
+                .unwrap()
+                .get("foo")
+                .unwrap()
+                .inner_bytes(),
             expected_inner_bytes
         );
     }
@@ -1043,13 +1124,18 @@ mod tests {
 
         let builder_params = TransactionBuilderParams::default();
         let mut transaction = Transaction::new_session(builder_params, transaction_params).unwrap();
-        let transaction = transaction.add_arg("foo:bool='false".to_string(), None);
-
-        let expected_inner_bytes = vec![0];
+        let transaction = transaction
+            .add_arg("foo:bool='false".to_string(), None)
+            .unwrap();
 
         assert_eq!(
-            *transaction.session_args().get("foo").unwrap().inner_bytes(),
-            expected_inner_bytes
+            *transaction
+                .session_args()
+                .unwrap()
+                .get("foo")
+                .unwrap()
+                .inner_bytes(),
+            vec![0]
         );
     }
 
@@ -1065,16 +1151,53 @@ mod tests {
 
         let builder_params = TransactionBuilderParams::default();
         let mut transaction = Transaction::new_session(builder_params, transaction_params).unwrap();
-        let transaction = transaction.add_arg("foo:bool='true".to_string(), None);
+        let transaction = transaction
+            .add_arg("foo:bool='true".to_string(), None)
+            .unwrap();
         let rebuilt = transaction.with_ttl("1h", None);
 
         assert_eq!(rebuilt.ttl(), "1h");
         assert_eq!(rebuilt.chain_name(), chain_name);
-        assert_eq!(rebuilt.session_args().len(), 1);
+        assert_eq!(rebuilt.session_args().unwrap().len(), 1);
         assert_eq!(
-            *rebuilt.session_args().get("foo").unwrap().inner_bytes(),
+            *rebuilt
+                .session_args()
+                .unwrap()
+                .get("foo")
+                .unwrap()
+                .inner_bytes(),
             vec![1]
         );
+    }
+
+    #[test]
+    fn test_session_args_bytesrepr_accessors() {
+        let (_, _, _, _, chain_name) = get_network_constants();
+        let secret_key = get_user_secret_key(None).unwrap();
+
+        let transaction_params = TransactionStrParams::default();
+        transaction_params.set_secret_key(&secret_key);
+        transaction_params.set_chain_name(&chain_name);
+        transaction_params.set_payment_amount(PAYMENT_AMOUNT);
+        transaction_params.set_chunked_args(Bytes::from(vec![1, 2, 3, 4]));
+
+        let builder_params = TransactionBuilderParams::default();
+        let transaction = Transaction::new_session(builder_params, transaction_params).unwrap();
+
+        assert!(transaction.is_bytesrepr());
+        assert!(!transaction.is_named());
+        assert!(matches!(
+            *transaction.session_args().unwrap_err(),
+            SdkError::UnexpectedTransactionArgsVariant
+        ));
+        assert_eq!(
+            transaction.session_args_bytes().unwrap().as_ref(),
+            &[1, 2, 3, 4]
+        );
+        assert!(transaction
+            .clone()
+            .add_arg("foo:bool='false".to_string(), None)
+            .is_err());
     }
 
     #[test]

--- a/src/types/transaction_params/transaction_builder_params.rs
+++ b/src/types/transaction_params/transaction_builder_params.rs
@@ -78,6 +78,8 @@ pub struct TransactionBuilderParams {
     maximum_delegation_amount: Option<Option<u64>>,
     reserved_slots: Option<Option<u32>>,
     major_protocol_version: Option<ProtocolVersionMajor>,
+    /// Session/entity/package runtime. `None` means default VmCasperV2.
+    runtime: Option<TransactionRuntimeParams>,
 }
 
 #[wasm_bindgen]
@@ -127,6 +129,7 @@ impl TransactionBuilderParams {
             maximum_delegation_amount: None,
             reserved_slots: None,
             major_protocol_version: None,
+            runtime: None,
         }
     }
 
@@ -161,6 +164,7 @@ impl TransactionBuilderParams {
             maximum_delegation_amount: None,
             reserved_slots: None,
             major_protocol_version: None,
+            runtime: None,
         }
     }
 
@@ -192,6 +196,7 @@ impl TransactionBuilderParams {
             maximum_delegation_amount: None,
             reserved_slots: None,
             major_protocol_version: None,
+            runtime: None,
         }
     }
 
@@ -223,6 +228,7 @@ impl TransactionBuilderParams {
             maximum_delegation_amount: None,
             reserved_slots: None,
             major_protocol_version: None,
+            runtime: None,
         }
     }
 
@@ -267,6 +273,7 @@ impl TransactionBuilderParams {
             maximum_delegation_amount: None,
             reserved_slots: None,
             major_protocol_version,
+            runtime: None,
         }
     }
 
@@ -310,6 +317,7 @@ impl TransactionBuilderParams {
             maximum_delegation_amount: None,
             reserved_slots: None,
             major_protocol_version,
+            runtime: None,
         }
     }
 
@@ -346,6 +354,7 @@ impl TransactionBuilderParams {
             maximum_delegation_amount: Some(maximum_delegation_amount),
             reserved_slots: Some(reserved_slots),
             major_protocol_version: None,
+            runtime: None,
         }
     }
 
@@ -379,6 +388,7 @@ impl TransactionBuilderParams {
             maximum_delegation_amount: None,
             reserved_slots: None,
             major_protocol_version: None,
+            runtime: None,
         }
     }
 
@@ -413,6 +423,7 @@ impl TransactionBuilderParams {
             reserved_slots: None,
 
             major_protocol_version: None,
+            runtime: None,
         }
     }
 
@@ -447,6 +458,7 @@ impl TransactionBuilderParams {
             maximum_delegation_amount: None,
             reserved_slots: None,
             major_protocol_version: None,
+            runtime: None,
         }
     }
 
@@ -476,6 +488,7 @@ impl TransactionBuilderParams {
             maximum_delegation_amount: None,
             reserved_slots: None,
             major_protocol_version: None,
+            runtime: None,
         }
     }
 
@@ -669,12 +682,97 @@ impl TransactionBuilderParams {
     pub fn set_is_install_upgrade(&mut self, is_install_upgrade: bool) {
         self.is_install_upgrade = Some(is_install_upgrade);
     }
+
+    /// True when runtime resolves to VmCasperV1.
+    #[wasm_bindgen(getter, js_name = "isRuntimeV1")]
+    pub fn is_runtime_v1(&self) -> bool {
+        matches!(
+            self.resolved_runtime(),
+            TransactionRuntimeParams::VmCasperV1
+        )
+    }
+
+    /// True when runtime resolves to VmCasperV2 (the default).
+    #[wasm_bindgen(getter, js_name = "isRuntimeV2")]
+    pub fn is_runtime_v2(&self) -> bool {
+        matches!(
+            self.resolved_runtime(),
+            TransactionRuntimeParams::VmCasperV2 { .. }
+        )
+    }
+
+    /// V2 `transferred_value`, or 0 for V1.
+    #[wasm_bindgen(getter, js_name = "runtimeTransferredValue")]
+    pub fn runtime_transferred_value(&self) -> u64 {
+        match self.resolved_runtime() {
+            TransactionRuntimeParams::VmCasperV2 {
+                transferred_value, ..
+            } => transferred_value,
+            TransactionRuntimeParams::VmCasperV1 => 0,
+        }
+    }
+
+    /// V2 installer seed bytes, if set.
+    #[wasm_bindgen(getter, js_name = "runtimeSeed")]
+    pub fn runtime_seed(&self) -> Option<Vec<u8>> {
+        match self.resolved_runtime() {
+            TransactionRuntimeParams::VmCasperV2 {
+                seed: Some(seed), ..
+            } => Some(seed.to_vec()),
+            _ => None,
+        }
+    }
+
+    /// Force VmCasperV1 (legacy).
+    #[wasm_bindgen(js_name = "setRuntimeV1")]
+    pub fn set_runtime_v1(&mut self) {
+        self.runtime = Some(TransactionRuntimeParams::VmCasperV1);
+    }
+
+    /// Set VmCasperV2. `seed` must be absent or exactly 32 bytes (invalid length is ignored).
+    #[wasm_bindgen(js_name = "setRuntimeV2")]
+    pub fn set_runtime_v2(&mut self, transferred_value: u64, seed: Option<Vec<u8>>) {
+        self.runtime = Some(runtime_v2(transferred_value, seed));
+    }
+}
+
+impl TransactionBuilderParams {
+    fn resolved_runtime(&self) -> TransactionRuntimeParams {
+        self.runtime.clone().unwrap_or_else(default_runtime_v2)
+    }
+}
+
+fn default_runtime_v2() -> TransactionRuntimeParams {
+    TransactionRuntimeParams::VmCasperV2 {
+        transferred_value: 0,
+        seed: None,
+    }
+}
+
+fn runtime_v2(transferred_value: u64, seed: Option<Vec<u8>>) -> TransactionRuntimeParams {
+    let seed = match seed {
+        Some(bytes) if bytes.len() == 32 => {
+            let mut arr = [0u8; 32];
+            arr.copy_from_slice(&bytes);
+            Some(arr)
+        }
+        Some(_) => {
+            error("set_runtime_v2: seed must be 32 bytes; ignoring seed");
+            None
+        }
+        None => None,
+    };
+    TransactionRuntimeParams::VmCasperV2 {
+        transferred_value,
+        seed,
+    }
 }
 
 // Convert TransactionBuilderParams to casper_client::cli::TransactionBuilderParams
 pub fn transaction_builder_params_to_casper_client(
     transaction_params: &TransactionBuilderParams,
 ) -> _TransactionBuilderParams<'_> {
+    let runtime = transaction_params.resolved_runtime();
     match transaction_params.kind {
         TransactionKind::Session => _TransactionBuilderParams::Session {
             is_install_upgrade: transaction_params.is_install_upgrade.unwrap_or_default(),
@@ -683,7 +781,7 @@ pub fn transaction_builder_params_to_casper_client(
                 .clone()
                 .unwrap_or_default()
                 .into(),
-            runtime: TransactionRuntimeParams::VmCasperV1, // TODo FIX Runtime
+            runtime,
         },
         TransactionKind::Transfer => _TransactionBuilderParams::Transfer {
             maybe_source: transaction_params.maybe_source.clone().map(Into::into),
@@ -711,7 +809,7 @@ pub fn transaction_builder_params_to_casper_client(
                 .entry_point
                 .as_deref()
                 .unwrap_or_default(),
-            runtime: TransactionRuntimeParams::VmCasperV1, // TODO FIX Runtime
+            runtime,
         },
         TransactionKind::InvocableEntityAlias => _TransactionBuilderParams::InvocableEntityAlias {
             entity_alias: transaction_params
@@ -722,7 +820,7 @@ pub fn transaction_builder_params_to_casper_client(
                 .entry_point
                 .as_deref()
                 .unwrap_or_default(),
-            runtime: TransactionRuntimeParams::VmCasperV1, // TODO FIX Runtime
+            runtime,
         },
         TransactionKind::Package => _TransactionBuilderParams::PackageWithMajorVersion {
             package_hash: transaction_params.package_hash.unwrap().into(),
@@ -731,7 +829,7 @@ pub fn transaction_builder_params_to_casper_client(
                 .entry_point
                 .as_deref()
                 .unwrap_or_default(),
-            runtime: TransactionRuntimeParams::VmCasperV1, // TODO FIX Runtime
+            runtime,
             major_protocol_version: transaction_params.major_protocol_version,
         },
         TransactionKind::PackageAlias => _TransactionBuilderParams::PackageAliasWithMajorVersion {
@@ -744,7 +842,7 @@ pub fn transaction_builder_params_to_casper_client(
                 .entry_point
                 .as_deref()
                 .unwrap_or_default(),
-            runtime: TransactionRuntimeParams::VmCasperV1, // TODO FIX Runtime
+            runtime,
             major_protocol_version: transaction_params.major_protocol_version,
         },
         TransactionKind::AddBid => _TransactionBuilderParams::AddBid {
@@ -796,4 +894,53 @@ fn convert_amount(amount: &str) -> Option<U512> {
             error(&format!("Error converting amount: {err:?}"));
         })
         .ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_runtime_is_v2_for_session_and_entity() {
+        let session = TransactionBuilderParams::new_session(None, None);
+        assert!(session.is_runtime_v2());
+        assert!(!session.is_runtime_v1());
+        assert_eq!(session.runtime_transferred_value(), 0);
+
+        let client = transaction_builder_params_to_casper_client(&session);
+        match client {
+            _TransactionBuilderParams::Session { runtime, .. } => {
+                assert!(matches!(
+                    runtime,
+                    TransactionRuntimeParams::VmCasperV2 {
+                        transferred_value: 0,
+                        seed: None
+                    }
+                ));
+            }
+            _ => panic!("expected Session"),
+        }
+
+        let mut entity = TransactionBuilderParams::new_invocable_entity_alias("cep78", "mint");
+        assert!(entity.is_runtime_v2());
+        entity.set_runtime_v1();
+        assert!(entity.is_runtime_v1());
+        let client = transaction_builder_params_to_casper_client(&entity);
+        match client {
+            _TransactionBuilderParams::InvocableEntityAlias { runtime, .. } => {
+                assert!(matches!(runtime, TransactionRuntimeParams::VmCasperV1));
+            }
+            _ => panic!("expected InvocableEntityAlias"),
+        }
+    }
+
+    #[test]
+    fn set_runtime_v2_with_seed() {
+        let mut params = TransactionBuilderParams::default();
+        let seed = vec![7u8; 32];
+        params.set_runtime_v2(42, Some(seed.clone()));
+        assert!(params.is_runtime_v2());
+        assert_eq!(params.runtime_transferred_value(), 42);
+        assert_eq!(params.runtime_seed(), Some(seed));
+    }
 }

--- a/src/types/transaction_params/transaction_builder_params.rs
+++ b/src/types/transaction_params/transaction_builder_params.rs
@@ -78,7 +78,8 @@ pub struct TransactionBuilderParams {
     maximum_delegation_amount: Option<Option<u64>>,
     reserved_slots: Option<Option<u32>>,
     major_protocol_version: Option<ProtocolVersionMajor>,
-    /// Session/entity/package runtime. `None` means default VmCasperV2.
+    /// Session/entity/package runtime. `None` uses kind default: Session → V2,
+    /// stored invocation (entity/package) → V1.
     runtime: Option<TransactionRuntimeParams>,
 }
 
@@ -692,7 +693,7 @@ impl TransactionBuilderParams {
         )
     }
 
-    /// True when runtime resolves to VmCasperV2 (the default).
+    /// True when runtime resolves to VmCasperV2.
     #[wasm_bindgen(getter, js_name = "isRuntimeV2")]
     pub fn is_runtime_v2(&self) -> bool {
         matches!(
@@ -738,7 +739,23 @@ impl TransactionBuilderParams {
 
 impl TransactionBuilderParams {
     fn resolved_runtime(&self) -> TransactionRuntimeParams {
-        self.runtime.clone().unwrap_or_else(default_runtime_v2)
+        self.runtime
+            .clone()
+            .unwrap_or_else(|| default_runtime_for_kind(self.kind))
+    }
+}
+
+/// Session defaults to V2 (VM2-oriented installs). Stored entity/package calls
+/// default to V1 (classic CEP-78 and current on-chain fixtures).
+fn default_runtime_for_kind(kind: TransactionKind) -> TransactionRuntimeParams {
+    match kind {
+        TransactionKind::Session => default_runtime_v2(),
+        TransactionKind::InvocableEntity
+        | TransactionKind::InvocableEntityAlias
+        | TransactionKind::Package
+        | TransactionKind::PackageAlias => TransactionRuntimeParams::VmCasperV1,
+        // Transfer / auction kinds do not carry a session runtime field.
+        _ => default_runtime_v2(),
     }
 }
 
@@ -901,7 +918,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn default_runtime_is_v2_for_session_and_entity() {
+    fn default_runtime_is_v2_for_session_v1_for_entity() {
         let session = TransactionBuilderParams::new_session(None, None);
         assert!(session.is_runtime_v2());
         assert!(!session.is_runtime_v1());
@@ -921,10 +938,9 @@ mod tests {
             _ => panic!("expected Session"),
         }
 
-        let mut entity = TransactionBuilderParams::new_invocable_entity_alias("cep78", "mint");
-        assert!(entity.is_runtime_v2());
-        entity.set_runtime_v1();
+        let entity = TransactionBuilderParams::new_invocable_entity_alias("cep78", "mint");
         assert!(entity.is_runtime_v1());
+        assert!(!entity.is_runtime_v2());
         let client = transaction_builder_params_to_casper_client(&entity);
         match client {
             _TransactionBuilderParams::InvocableEntityAlias { runtime, .. } => {
@@ -932,6 +948,10 @@ mod tests {
             }
             _ => panic!("expected InvocableEntityAlias"),
         }
+
+        let mut entity_v2 = entity;
+        entity_v2.set_runtime_v2(0, None);
+        assert!(entity_v2.is_runtime_v2());
     }
 
     #[test]

--- a/src/types/transaction_params/transaction_str_params.rs
+++ b/src/types/transaction_params/transaction_str_params.rs
@@ -553,8 +553,10 @@ mod tests {
         assert_eq!(result.standard_payment, "true");
         assert_eq!(result.transferred_value, "0");
         assert_eq!(result.session_entry_point, Some("session_entry_point"));
-        // TODO FIX
-        //assert_eq!(result.chunked_args, Some());
+        assert_eq!(
+            result.chunked_args,
+            Some(Bytes::from("json".to_bytes().unwrap()).to_vec())
+        );
         assert_eq!(result.min_bid_override, true);
     }
 

--- a/tests/e2e/puppeteer/tests.spec.ts
+++ b/tests/e2e/puppeteer/tests.spec.ts
@@ -24,6 +24,7 @@ import {
   TransactionStrParams,
   TransactionBuilderParams,
   AddressableEntityHash,
+  contractHashKeyForGlobalState,
 } from 'casper-rust-wasm-sdk';
 
 describe('Angular App Tests', () => {
@@ -849,10 +850,9 @@ describe('Angular App Tests', () => {
       test.contract_cep78_entity =
         named_keys.find((key) => key.name === config.contract_cep78_key)?.key ||
         '';
-      // Hack 2.0
-      test.contract_cep78_hash = test.contract_cep78_entity.replace(
-        'entity-contract',
-        'hash'
+      // AE-off: named keys may be entity-contract-…; session/global-state use hash-…
+      test.contract_cep78_hash = contractHashKeyForGlobalState(
+        test.contract_cep78_entity
       );
       test.contract_cep78_package_hash =
         named_keys.find((key) => key.name === config.package_cep78_key)?.key ||
@@ -960,9 +960,8 @@ describe('Angular App Tests', () => {
       if (!test.contract_cep78_entity) {
         throw 'test.contract_cep78_entity missing';
       }
-      test.contract_cep78_hash = test.contract_cep78_entity.replace(
-        'entity-contract',
-        'hash'
+      test.contract_cep78_hash = contractHashKeyForGlobalState(
+        test.contract_cep78_entity
       );
     });
   });
@@ -2706,7 +2705,7 @@ describe('Angular App Tests', () => {
             named.find((k: any) => k.name === config.contract_cep78_key)?.key ||
             '';
           test.contract_cep78_entity = entity;
-          contractHash = entity.replace('entity-contract', 'hash');
+          contractHash = contractHashKeyForGlobalState(entity);
           test.contract_cep78_hash = contractHash;
         }
         expect(contractHash).toBeTruthy();

--- a/tests/integration/rust/Cargo.toml
+++ b/tests/integration/rust/Cargo.toml
@@ -6,11 +6,11 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-casper-rust-wasm-sdk = { path = "../../../", version = "2.2.2", features = ["SSE"] }
+casper-rust-wasm-sdk = { path = "../../../", version = "2.2.2", features = [
+    "SSE",
+] }
 tokio = { version = "1", features = ["full"] }
-once_cell = "*"
 chrono = "0.4"
-lazy_static = "*"
 serde_json = "*"
 dotenvy = "0.15.7"
 

--- a/tests/integration/rust/src/config.rs
+++ b/tests/integration/rust/src/config.rs
@@ -4,7 +4,7 @@ use crate::tests::helpers::{
 };
 use casper_rust_wasm_sdk::types::verbosity::Verbosity;
 use casper_rust_wasm_sdk::{helpers::public_key_from_secret_key, types::public_key::PublicKey};
-use lazy_static::lazy_static;
+use std::sync::OnceLock;
 use std::time::{self, Duration};
 use tokio::sync::{Mutex, RwLock};
 
@@ -14,8 +14,7 @@ pub const SPECULATIVE_ADDRESS: &str = "http://127.0.0.1:25101";
 pub const DEFAULT_NODE_ADDRESS: &str = "127.0.0.1:28101";
 pub const DEFAULT_CHAIN_NAME: &str = "casper-net-1";
 pub const DEFAULT_SECRET_KEY_NAME: &str = "secret_key.pem";
-// Hyper/reqwest + lazy_static can error with "runtime dropped the dispatch task"
-// (hyperium/hyper#2112, seanmonstar/reqwest#1148).
+/// Sleep so two wall-clock timestamps differ in integration assertions.
 pub const TIMESTAMP_WAIT_TIME: Duration = time::Duration::from_millis(1000);
 pub const DEPLOY_TIME: Duration = time::Duration::from_millis(45000);
 // read_pem_file will look SECRET_KEY_NAME to root directory if relative path is not found (relative to root)
@@ -89,10 +88,15 @@ pub(crate) enum InitializationState {
     InstallComplete,      // install cep_78 has occured
 }
 
-lazy_static! {
-    pub(crate) static ref CONFIG: Mutex<Option<TestConfig>> = Mutex::new(None);
-    pub(crate) static ref INITIALIZATION_STATE: RwLock<InitializationState> =
-        RwLock::new(InitializationState::NotInitialized);
+static CONFIG: OnceLock<Mutex<Option<TestConfig>>> = OnceLock::new();
+static INITIALIZATION_STATE: OnceLock<RwLock<InitializationState>> = OnceLock::new();
+
+pub(crate) fn config() -> &'static Mutex<Option<TestConfig>> {
+    CONFIG.get_or_init(|| Mutex::new(None))
+}
+
+fn initialization_state() -> &'static RwLock<InitializationState> {
+    INITIALIZATION_STATE.get_or_init(|| RwLock::new(InitializationState::NotInitialized))
 }
 
 pub async fn initialize_test_config(
@@ -101,11 +105,11 @@ pub async fn initialize_test_config(
     use crate::tests::helpers::{get_contract_cep78_hash_keys, install_cep78_if_needed, mint_nft};
     use dotenvy::dotenv;
 
-    let mut initialization_state = INITIALIZATION_STATE.write().await;
+    let mut initialization_state = initialization_state().write().await;
 
     if *initialization_state == InitializationState::InstallComplete {
         // If already fully initialized, skip initialization
-        return Ok(CONFIG.lock().await.clone().unwrap());
+        return Ok(config().lock().await.clone().unwrap());
     }
 
     dotenv().ok();
@@ -212,9 +216,9 @@ pub async fn initialize_test_config(
 }
 
 pub async fn get_config(skip_install: bool) -> TestConfig {
-    let mut config_guard = CONFIG.lock().await;
+    let mut config_guard = config().lock().await;
     // Acquire the initialization state
-    let initialization_state = INITIALIZATION_STATE.read().await;
+    let initialization_state = initialization_state().read().await;
 
     // If the initialization state is NotInitialized, initialize based on `skip_install`
     if *initialization_state == InitializationState::NotInitialized {

--- a/tests/integration/rust/src/config.rs
+++ b/tests/integration/rust/src/config.rs
@@ -14,8 +14,8 @@ pub const SPECULATIVE_ADDRESS: &str = "http://127.0.0.1:25101";
 pub const DEFAULT_NODE_ADDRESS: &str = "127.0.0.1:28101";
 pub const DEFAULT_CHAIN_NAME: &str = "casper-net-1";
 pub const DEFAULT_SECRET_KEY_NAME: &str = "secret_key.pem";
-// TODO fix mutex bug https://github.com/hyperium/hyper/issues/2112 lazy_static erroring with runtime dropped the dispatch task
-// https://github.com/seanmonstar/reqwest/issues/1148#issuecomment-910868788
+// Hyper/reqwest + lazy_static can error with "runtime dropped the dispatch task"
+// (hyperium/hyper#2112, seanmonstar/reqwest#1148).
 pub const TIMESTAMP_WAIT_TIME: Duration = time::Duration::from_millis(1000);
 pub const DEPLOY_TIME: Duration = time::Duration::from_millis(45000);
 // read_pem_file will look SECRET_KEY_NAME to root directory if relative path is not found (relative to root)

--- a/tests/integration/rust/src/main.rs
+++ b/tests/integration/rust/src/main.rs
@@ -3,9 +3,9 @@
 
 pub mod config;
 pub mod tests;
+use config::config;
 use config::initialize_test_config;
-use config::CONFIG;
-use lazy_static::lazy_static;
+use std::sync::OnceLock;
 use tokio::sync::Mutex;
 
 #[tokio::main]
@@ -13,16 +13,18 @@ async fn main() {
     tests::run_tests_or_examples().await;
 }
 
-lazy_static! {
-    pub static ref INITIALIZED: Mutex<bool> = Mutex::new(false);
+static INITIALIZED: OnceLock<Mutex<bool>> = OnceLock::new();
+
+fn initialized() -> &'static Mutex<bool> {
+    INITIALIZED.get_or_init(|| Mutex::new(false))
 }
 
 // Run async_main if you need to initialize config before running some specific actions that require tests config (not required for examples or basic tests)
 pub async fn async_main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut initialized_guard = INITIALIZED.lock().await;
+    let mut initialized_guard = initialized().lock().await;
     if !*initialized_guard {
-        let config = initialize_test_config(true).await?;
-        *CONFIG.lock().await = Some(config);
+        let test_config = initialize_test_config(true).await?;
+        *config().lock().await = Some(test_config);
         *initialized_guard = true;
     }
     Ok(())

--- a/tests/integration/rust/src/tests/helpers.rs
+++ b/tests/integration/rust/src/tests/helpers.rs
@@ -112,7 +112,7 @@ pub(crate) mod intern {
             params.set_entity_named_key(contract_entity, dictionary_name, dictionary_item_key);
         } else {
             params.set_contract_named_key(
-                &contract_entity.replace("entity-contract", "hash"),
+                &casper_rust_wasm_sdk::helpers::contract_hash_key_for_global_state(contract_entity),
                 dictionary_name,
                 dictionary_item_key,
             );
@@ -179,7 +179,11 @@ pub(crate) mod intern {
         } else {
             // Prepare the query parameters
             let query_params = QueryGlobalStateParams {
-                key: KeyIdentifierInput::String(contract_entity.replace("entity-contract", "hash")),
+                key: KeyIdentifierInput::String(
+                    casper_rust_wasm_sdk::helpers::contract_hash_key_for_global_state(
+                        contract_entity,
+                    ),
+                ),
                 path: None,
                 maybe_global_state_identifier: None,
                 state_root_hash: None,

--- a/tests/integration/rust/src/tests/helpers.rs
+++ b/tests/integration/rust/src/tests/helpers.rs
@@ -18,7 +18,6 @@ use casper_rust_wasm_sdk::{
     },
     watcher::EventParseResult,
 };
-use lazy_static::lazy_static;
 use serde_json::{to_string, Value};
 use std::{
     env,
@@ -26,16 +25,23 @@ use std::{
     io::{self, Read},
     path::PathBuf,
     process,
+    sync::OnceLock,
 };
 use tokio::sync::Mutex;
 
-lazy_static! {
-    pub static ref CEP78_INSTALLED_GUARD: Mutex<bool> = Mutex::new(false);
-    pub static ref CEP78_REINSTALL_GUARD: Mutex<bool> = Mutex::new(false);
+static CEP78_INSTALLED_GUARD: OnceLock<Mutex<bool>> = OnceLock::new();
+static CEP78_REINSTALL_GUARD: OnceLock<Mutex<bool>> = OnceLock::new();
+
+fn cep78_installed_guard() -> &'static Mutex<bool> {
+    CEP78_INSTALLED_GUARD.get_or_init(|| Mutex::new(false))
+}
+
+fn cep78_reinstall_guard() -> &'static Mutex<bool> {
+    CEP78_REINSTALL_GUARD.get_or_init(|| Mutex::new(false))
 }
 
 pub(crate) mod intern {
-    use super::{get_enable_addressable_entity, read_wasm_file, CEP78_REINSTALL_GUARD};
+    use super::{cep78_reinstall_guard, get_enable_addressable_entity, read_wasm_file};
     use crate::config::{
         TestConfig, ARGS_JSON, CEP78_CONTRACT, PAYMENT_AMOUNT_CONTRACT_CEP78, WASM_PATH,
     };
@@ -221,7 +227,7 @@ pub(crate) mod intern {
         path: Option<&str>,
         network_constants: (&str, &str, &str),
     ) -> Result<String, Box<dyn std::error::Error>> {
-        let mut cep78_reinstall_guard = CEP78_REINSTALL_GUARD.lock().await;
+        let mut cep78_reinstall_guard = cep78_reinstall_guard().lock().await;
         if *cep78_reinstall_guard {
             return Err("CEP78 contract already installed".into());
         }
@@ -410,7 +416,7 @@ pub async fn install_cep78_if_needed(
     path: Option<&str>,
     network_constants: (&str, &str, &str),
 ) -> Option<String> {
-    let mut install_guard = CEP78_INSTALLED_GUARD.lock().await;
+    let mut install_guard = cep78_installed_guard().lock().await;
     if !(*install_guard) {
         let deploy_hash = install_cep78(account, secret_key, path, network_constants)
             .await

--- a/tests/integration/rust/src/tests/integration/contract/mod.rs
+++ b/tests/integration/rust/src/tests/integration/contract/mod.rs
@@ -121,9 +121,9 @@ pub mod test_module {
         );
         let session_params = SessionStrParams::default();
         session_params.set_session_hash(
-            &config
-                .contract_cep78_key
-                .replace("entity-contract-", "hash-"),
+            &casper_rust_wasm_sdk::helpers::contract_hash_key_for_global_state(
+                &config.contract_cep78_key,
+            ),
         );
         session_params.set_session_entry_point(ENTRYPOINT_MINT);
         session_params.set_session_args_json(ARGS_JSON);
@@ -263,12 +263,6 @@ pub mod test_module {
         let result = query_result.unwrap().result;
 
         assert!(!result.api_version.to_string().is_empty());
-        // TODO Check as_addressable_entity
-        // assert!(result
-        //     .stored_value
-        //     .as_addressable_entity()
-        //     .unwrap()
-        //     .is_account_kind());
     }
 
     pub async fn test_call_entrypoint_transaction() {

--- a/tests/integration/rust/src/tests/integration/deploy/mod.rs
+++ b/tests/integration/rust/src/tests/integration/deploy/mod.rs
@@ -22,9 +22,9 @@ pub mod test_module {
         );
         let session_params = SessionStrParams::default();
         session_params.set_session_hash(
-            &config
-                .contract_cep78_key
-                .replace("entity-contract-", "hash-"),
+            &casper_rust_wasm_sdk::helpers::contract_hash_key_for_global_state(
+                &config.contract_cep78_key,
+            ),
         );
         session_params.set_session_entry_point(ENTRYPOINT_MINT);
         let payment_params = PaymentStrParams::default();
@@ -98,9 +98,9 @@ pub mod test_module {
         );
         let session_params = SessionStrParams::default();
         session_params.set_session_hash(
-            &config
-                .contract_cep78_key
-                .replace("entity-contract-", "hash-"),
+            &casper_rust_wasm_sdk::helpers::contract_hash_key_for_global_state(
+                &config.contract_cep78_key,
+            ),
         );
         session_params.set_session_entry_point(ENTRYPOINT_MINT);
         let payment_params = PaymentStrParams::default();

--- a/tests/integration/rust/src/tests/integration/deploy_utils/mod.rs
+++ b/tests/integration/rust/src/tests/integration/deploy_utils/mod.rs
@@ -23,9 +23,9 @@ pub mod test_module {
         );
         let session_params = SessionStrParams::default();
         session_params.set_session_hash(
-            &config
-                .contract_cep78_key
-                .replace("entity-contract-", "hash-"),
+            &casper_rust_wasm_sdk::helpers::contract_hash_key_for_global_state(
+                &config.contract_cep78_key,
+            ),
         );
         session_params.set_session_entry_point(ENTRYPOINT_DECIMALS);
         let payment_params = PaymentStrParams::default();
@@ -78,9 +78,9 @@ pub mod test_module {
         );
         let session_params = SessionStrParams::default();
         session_params.set_session_hash(
-            &config
-                .contract_cep78_key
-                .replace("entity-contract-", "hash-"),
+            &casper_rust_wasm_sdk::helpers::contract_hash_key_for_global_state(
+                &config.contract_cep78_key,
+            ),
         );
         session_params.set_session_entry_point(ENTRYPOINT_DECIMALS);
         let payment_params = PaymentStrParams::default();

--- a/tests/integration/rust/src/tests/integration/params/mod.rs
+++ b/tests/integration/rust/src/tests/integration/params/mod.rs
@@ -57,16 +57,16 @@ pub mod test_module {
         let config: TestConfig = get_config(true).await;
         let session_params = SessionStrParams::default();
         session_params.set_session_hash(
-            &config
-                .contract_cep78_key
-                .replace("entity-contract-", "hash-"),
+            &casper_rust_wasm_sdk::helpers::contract_hash_key_for_global_state(
+                &config.contract_cep78_key,
+            ),
         );
         session_params.set_session_entry_point(ENTRYPOINT_MINT);
         assert_eq!(
             session_params.session_hash().unwrap(),
-            config
-                .contract_cep78_key
-                .replace("entity-contract-", "hash-")
+            casper_rust_wasm_sdk::helpers::contract_hash_key_for_global_state(
+                &config.contract_cep78_key
+            )
         );
         assert_eq!(
             session_params.session_entry_point().unwrap(),

--- a/tests/integration/rust/src/tests/integration/rpcs/mod.rs
+++ b/tests/integration/rust/src/tests/integration/rpcs/mod.rs
@@ -296,7 +296,9 @@ pub mod test_module {
             );
         } else {
             params.set_contract_named_key(
-                &config.contract_cep78_key.replace("entity-contract", "hash"),
+                &casper_rust_wasm_sdk::helpers::contract_hash_key_for_global_state(
+                    &config.contract_cep78_key,
+                ),
                 DICTIONARY_NAME,
                 DICTIONARY_ITEM_KEY,
             );
@@ -333,7 +335,9 @@ pub mod test_module {
             );
         } else {
             params.set_contract_named_key(
-                &config.contract_cep78_key.replace("entity-contract", "hash"),
+                &casper_rust_wasm_sdk::helpers::contract_hash_key_for_global_state(
+                    &config.contract_cep78_key,
+                ),
                 DICTIONARY_NAME,
                 DICTIONARY_ITEM_KEY,
             );
@@ -475,10 +479,9 @@ pub mod test_module {
         let key = if get_enable_addressable_entity() {
             config.to_owned().contract_cep78_key
         } else {
-            config
-                .to_owned()
-                .contract_cep78_key
-                .replace("entity-contract", "hash")
+            casper_rust_wasm_sdk::helpers::contract_hash_key_for_global_state(
+                &config.to_owned().contract_cep78_key,
+            )
         };
 
         let query_params: QueryGlobalStateParams = QueryGlobalStateParams {

--- a/tests/integration/rust/src/tests/integration/types/deploy.rs
+++ b/tests/integration/rust/src/tests/integration/types/deploy.rs
@@ -88,9 +88,9 @@ pub mod test_module_deploy {
         );
         let session_params = SessionStrParams::default();
         session_params.set_session_hash(
-            &config
-                .contract_cep78_key
-                .replace("entity-contract-", "hash-"),
+            &casper_rust_wasm_sdk::helpers::contract_hash_key_for_global_state(
+                &config.contract_cep78_key,
+            ),
         );
         session_params.set_session_entry_point(ENTRYPOINT_MINT);
         let payment_params = PaymentStrParams::default();
@@ -204,9 +204,9 @@ pub mod test_module_deploy {
         );
         let session_params = SessionStrParams::default();
         session_params.set_session_hash(
-            &config
-                .contract_cep78_key
-                .replace("entity-contract-", "hash-"),
+            &casper_rust_wasm_sdk::helpers::contract_hash_key_for_global_state(
+                &config.contract_cep78_key,
+            ),
         );
         session_params.set_session_entry_point(ENTRYPOINT_MINT);
         let payment_params = PaymentStrParams::default();
@@ -233,9 +233,9 @@ pub mod test_module_deploy {
         );
         let session_params = SessionStrParams::default();
         session_params.set_session_hash(
-            &config
-                .contract_cep78_key
-                .replace("entity-contract-", "hash-"),
+            &casper_rust_wasm_sdk::helpers::contract_hash_key_for_global_state(
+                &config.contract_cep78_key,
+            ),
         );
         session_params.set_session_entry_point(ENTRYPOINT_MINT);
         let payment_params = PaymentStrParams::default();
@@ -403,9 +403,9 @@ pub mod test_module_deploy {
         );
         let session_params = SessionStrParams::default();
         session_params.set_session_hash(
-            &config
-                .contract_cep78_key
-                .replace("entity-contract-", "hash-"),
+            &casper_rust_wasm_sdk::helpers::contract_hash_key_for_global_state(
+                &config.contract_cep78_key,
+            ),
         );
         session_params.set_session_entry_point(ENTRYPOINT_MINT);
         let payment_params = PaymentStrParams::default();
@@ -499,9 +499,9 @@ pub mod test_module_deploy {
         );
         let session_params = SessionStrParams::default();
         session_params.set_session_hash(
-            &config
-                .contract_cep78_key
-                .replace("entity-contract-", "hash-"),
+            &casper_rust_wasm_sdk::helpers::contract_hash_key_for_global_state(
+                &config.contract_cep78_key,
+            ),
         );
         session_params.set_session_entry_point(ENTRYPOINT_MINT);
         let payment_params = PaymentStrParams::default();
@@ -525,9 +525,9 @@ pub mod test_module_deploy {
         );
         let mut session_params = SessionStrParams::default();
         session_params.set_session_hash(
-            &config
-                .contract_cep78_key
-                .replace("entity-contract-", "hash-"),
+            &casper_rust_wasm_sdk::helpers::contract_hash_key_for_global_state(
+                &config.contract_cep78_key,
+            ),
         );
         session_params.set_session_entry_point(ENTRYPOINT_MINT);
         let args = Vec::from([
@@ -557,9 +557,9 @@ pub mod test_module_deploy {
         );
         let session_params = SessionStrParams::default();
         session_params.set_session_hash(
-            &config
-                .contract_cep78_key
-                .replace("entity-contract-", "hash-"),
+            &casper_rust_wasm_sdk::helpers::contract_hash_key_for_global_state(
+                &config.contract_cep78_key,
+            ),
         );
         session_params.set_session_entry_point(ENTRYPOINT_MINT);
         session_params.set_session_args_json(ARGS_JSON);
@@ -585,9 +585,9 @@ pub mod test_module_deploy {
         );
         let session_params = SessionStrParams::default();
         session_params.set_session_hash(
-            &config
-                .contract_cep78_key
-                .replace("entity-contract-", "hash-"),
+            &casper_rust_wasm_sdk::helpers::contract_hash_key_for_global_state(
+                &config.contract_cep78_key,
+            ),
         );
         session_params.set_session_entry_point(ENTRYPOINT_MINT);
         let payment_params = PaymentStrParams::default();
@@ -618,9 +618,9 @@ pub mod test_module_deploy {
         );
         let session_params = SessionStrParams::default();
         session_params.set_session_hash(
-            &config
-                .contract_cep78_key
-                .replace("entity-contract-", "hash-"),
+            &casper_rust_wasm_sdk::helpers::contract_hash_key_for_global_state(
+                &config.contract_cep78_key,
+            ),
         );
         session_params.set_session_entry_point(ENTRYPOINT_MINT);
         let payment_params = PaymentStrParams::default();

--- a/tests/integration/rust/src/tests/integration/types/transaction.rs
+++ b/tests/integration/rust/src/tests/integration/types/transaction.rs
@@ -259,12 +259,6 @@ pub mod test_module_transaction {
         transaction_params.set_payment_amount(PAYMENT_AMOUNT);
         let transaction = Transaction::new_session(builder_params, transaction_params).unwrap();
         assert!(transaction.verify());
-        // TODO
-        //assert!(transaction.is_stored_contract());
-        // assert_eq!(
-        //     transaction.by_name().unwrap().to_string(),
-        //     CONTRACT_CEP78_KEY
-        // );
     }
 
     pub async fn test_transaction_type_with_package_hash() {
@@ -379,32 +373,6 @@ pub mod test_module_transaction {
         assert!(transaction.verify());
     }
 
-    // TODO
-    // pub async fn test_transaction_type_with_standard_payment() {
-    //     let config: TestConfig = get_config(true).await;
-    //     let transaction_params = TransactionStrParams::new_with_defaults(
-    //         &config.chain_name,
-    //         Some(config.account),
-    //         Some(config.secret_key.clone()),
-    //         Some(TTL.to_string()),
-    //     );
-
-    //     let builder_params =
-    //     TransactionBuilderParams::new_invocable_entity(&config.contract_cep78_key, ENTRYPOINT_MINT);
-
-    //     transaction_params.set_payment_amount(PAYMENT_AMOUNT);
-    //     let mut transaction = Transaction::new_session(builder_params, transaction_params).unwrap();
-    //     assert!(transaction.verify());
-    //     assert_eq!(transaction.payment_amount(1_u8).to_string(), PAYMENT_AMOUNT);
-    //     let new_payment_amount = "1111111111";
-    //     transaction = transaction.with_standard_payment(new_payment_amount, None);
-    //     assert!(!transaction.verify());
-    //     assert_eq!(
-    //         transaction.payment_amount(1_u8).to_string(),
-    //         new_payment_amount
-    //     );
-    // }
-
     pub async fn test_transaction_type_is_expired() {
         let config: TestConfig = get_config(true).await;
         let old_timestamp = "2023-09-05T16:53:46";
@@ -486,7 +454,7 @@ pub mod test_module_transaction {
         transaction_params.set_payment_amount(PAYMENT_AMOUNT);
         let transaction = Transaction::new_session(builder_params, transaction_params).unwrap();
         assert!(transaction.verify());
-        assert!(transaction.session_args().is_empty());
+        assert!(transaction.session_args().unwrap().is_empty());
     }
 
     pub async fn test_transaction_type_args() {
@@ -511,8 +479,8 @@ pub mod test_module_transaction {
 
         let transaction = Transaction::new_session(builder_params, transaction_params).unwrap();
         assert!(transaction.verify());
-        assert!(!transaction.session_args().is_empty());
-        assert_eq!(transaction.session_args().len(), args.len());
+        assert!(!transaction.session_args().unwrap().is_empty());
+        assert_eq!(transaction.session_args().unwrap().len(), args.len());
     }
 
     pub async fn test_transaction_type_args_json() {
@@ -534,8 +502,8 @@ pub mod test_module_transaction {
 
         let transaction = Transaction::new_session(builder_params, transaction_params).unwrap();
         assert!(transaction.verify());
-        assert!(!transaction.session_args().is_empty());
-        assert_eq!(transaction.session_args().len(), 11);
+        assert!(!transaction.session_args().unwrap().is_empty());
+        assert_eq!(transaction.session_args().unwrap().len(), 11);
     }
 
     pub async fn test_transaction_type_add_arg() {
@@ -555,15 +523,18 @@ pub mod test_module_transaction {
         transaction_params.set_payment_amount(PAYMENT_AMOUNT);
         let mut transaction = Transaction::new_session(builder_params, transaction_params).unwrap();
         assert!(transaction.verify());
-        assert!(transaction.session_args().is_empty());
-        transaction =
-            transaction.add_arg("foo:bool='false".into(), Some(config.secret_key.clone()));
+        assert!(transaction.session_args().unwrap().is_empty());
+        transaction = transaction
+            .add_arg("foo:bool='false".into(), Some(config.secret_key.clone()))
+            .unwrap();
         assert!(transaction.verify());
-        assert_eq!(transaction.session_args().len(), 1);
+        assert_eq!(transaction.session_args().unwrap().len(), 1);
         let arg_json = r#"{"name": "bar", "type": "U256", "value": 1}"#; // No brackets only one arg
-        transaction = transaction.add_arg(arg_json.into(), Some(config.secret_key.clone()));
+        transaction = transaction
+            .add_arg(arg_json.into(), Some(config.secret_key.clone()))
+            .unwrap();
         assert!(transaction.verify());
-        assert_eq!(transaction.session_args().len(), 2);
+        assert_eq!(transaction.session_args().unwrap().len(), 2);
     }
 
     pub async fn test_transaction_type_add_signature() {
@@ -663,11 +634,6 @@ mod tests_transaction {
     pub async fn test_transaction_type_test_with_secret_key_test() {
         test_transaction_type_with_secret_key().await;
     }
-    // TODO
-    // #[test]
-    // pub async fn test_transaction_type_with_standard_payment_test() {
-    //     test_transaction_type_with_standard_payment().await;
-    // }
     #[test]
     pub async fn test_transaction_type_is_expired_test() {
         test_transaction_type_is_expired().await;


### PR DESCRIPTION
## Summary
- Hygiene: strip stale TODO/FIXME in product code; keep intentional docs npm/Mac/`## Todo` tracking.
- Transaction: dual Named/Bytesrepr session-args accessors; selectable `VmCasperV1`/`V2` on builder (V2 default); classic `SDK::install` / HELLO tests pin V1.
- AE-off: `helpers::contract_hash_key_for_global_state` (+ JS) replaces ad-hoc `entity-contract`↔`hash` remaps; CES/`query_contract_key`/tests routed through it ([#96](https://github.com/casper-ecosystem/casper-rust-wasm-sdk/issues/96)).
- CES: lock List\<U8\> decode on `Bytes` + regression units (fix already in #94; tests close the loop).
- README: refresh Rust/TS API TOC + Todo; preserve tip MCP Hub `:dev` / `:latest`=`:2.2.2` / `dev-preview` lines from #97.

## Test plan
- [x] `RUSTUP_TOOLCHAIN=stable make check-lint`
- [x] Unit: helpers AE key, transaction runtime, Bytesrepr accessors, CES Bytes, install/put-transaction HELLO
- [ ] CI green on this PR
- [ ] Optional: NCTL live CES/AE paths if convenient


Made with [Cursor](https://cursor.com)