### PR TITLE
fix(webclient): unlock Action select during cold-start status fetch

### DIFF
--- a/examples/frontend/angular/libs/components/src/lib/action/action.component.ts
+++ b/examples/frontend/angular/libs/components/src/lib/action/action.component.ts
@@ -190,6 +190,7 @@ export class ActionComponent implements AfterViewInit, OnDestroy {
         ].includes(name),
     );
     this.setStateSubscription();
+    this.changeDetectorRef.detectChanges();
   }
 
   ngOnDestroy() {

--- a/examples/frontend/angular/libs/components/src/lib/status/status.component.html
+++ b/examples/frontend/angular/libs/components/src/lib/status/status.component.html
@@ -1,6 +1,13 @@
 <div class="row">
   <div class="col-sm-12">
     <div
+      class="alert alert-info d-flex mb-1 mb-md-3"
+      *ngIf="status_loading && !state_root_hash"
+      e2e-id="status_loading"
+    >
+      <span>Loading status… fetching state root hash</span>
+    </div>
+    <div
       class="alert alert-success d-flex flex-md-row flex-column justify-content-between align-items-center mb-1 mb-md-3"
       *ngIf="state_root_hash"
     >

--- a/examples/frontend/angular/libs/components/src/lib/status/status.component.ts
+++ b/examples/frontend/angular/libs/components/src/lib/status/status.component.ts
@@ -1,4 +1,12 @@
-import { AfterViewInit, ChangeDetectionStrategy, ChangeDetectorRef, Component, EventEmitter, OnDestroy, Output } from '@angular/core';
+import {
+  AfterViewInit,
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  EventEmitter,
+  OnDestroy,
+  Output,
+} from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { Subscription } from 'rxjs';
 import { State, StateService } from '@util/state';
@@ -15,34 +23,37 @@ export class StatusComponent implements AfterViewInit, OnDestroy {
   account_hash!: string;
   main_purse!: string;
   state_root_hash!: string;
+  status_loading = false;
 
-  @Output() get_state_root_hash_output: EventEmitter<boolean> = new EventEmitter<boolean>();
+  @Output() get_state_root_hash_output: EventEmitter<boolean> =
+    new EventEmitter<boolean>();
 
   private stateSubscription!: Subscription;
 
   constructor(
     private readonly stateService: StateService,
-    private readonly changeDetectorRef: ChangeDetectorRef
-  ) {
-  }
+    private readonly changeDetectorRef: ChangeDetectorRef,
+  ) {}
 
   ngOnDestroy() {
     this.stateSubscription && this.stateSubscription.unsubscribe();
   }
 
   private setStateSubscription() {
-    this.stateSubscription = this.stateService.getState().subscribe((state: State) => {
-      state.account_hash && (this.account_hash = state.account_hash);
-      state.main_purse && (this.main_purse = state.main_purse);
-      state.state_root_hash && (this.state_root_hash = state.state_root_hash);
-      state && this.changeDetectorRef.markForCheck();
-    });
+    this.stateSubscription = this.stateService
+      .getState()
+      .subscribe((state: State) => {
+        state.account_hash && (this.account_hash = state.account_hash);
+        state.main_purse && (this.main_purse = state.main_purse);
+        state.state_root_hash && (this.state_root_hash = state.state_root_hash);
+        this.status_loading = !!state.status_loading;
+        state && this.changeDetectorRef.markForCheck();
+      });
   }
 
   async ngAfterViewInit() {
     this.setStateSubscription();
   }
-
 
   get_state_root_hash() {
     const no_mark_for_check = true;

--- a/examples/frontend/angular/libs/util/services/state/src/lib/state.ts
+++ b/examples/frontend/angular/libs/util/services/state/src/lib/state.ts
@@ -8,6 +8,8 @@ export type State = {
   enity?: string;
   main_purse?: string;
   state_root_hash?: string;
+  /** True while cold-start status / state-root-hash RPCs are in flight. */
+  status_loading?: boolean;
   action?: string;
   public_key?: string;
   secret_key?: string;

--- a/examples/frontend/angular/src/app/home/home.component.ts
+++ b/examples/frontend/angular/src/app/home/home.component.ts
@@ -64,6 +64,8 @@ export class HomeComponent implements OnInit, AfterViewInit, OnDestroy {
 
   private wasm!: Uint8Array | undefined;
   private stateSubscription!: Subscription;
+  /** Bumped to ignore late cold-start RPC results after the user changes action. */
+  private bootstrapGeneration = 0;
 
   constructor(
     @Inject(SDK_TOKEN) private readonly sdk: SDK,
@@ -85,6 +87,7 @@ export class HomeComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   public ngOnDestroy() {
+    this.bootstrapGeneration++;
     this.stateSubscription && this.stateSubscription.unsubscribe();
   }
 
@@ -96,31 +99,56 @@ export class HomeComponent implements OnInit, AfterViewInit, OnDestroy {
       });
   }
 
-  public async ngAfterViewInit() {
-    const no_mark_for_check = true;
+  public ngAfterViewInit() {
     const action =
       this.storageService.get('action') ||
       this.config['default_action'].toString();
+    this.stateService.setState({
+      action,
+      status_loading: true,
+    });
+    void this.bootstrapChainStatus(action);
+  }
+
+  /** Cold-start status + SRH; must not block Action/form paint. */
+  private async bootstrapChainStatus(action: string) {
+    const generation = ++this.bootstrapGeneration;
+    const no_mark_for_check = true;
     try {
       if (action == this.config['default_action'].toString()) {
-        await this.handleAction(action, true);
+        const get_node_status = await this.sdk.get_node_status();
+        if (generation !== this.bootstrapGeneration) {
+          return;
+        }
+        if (get_node_status) {
+          await this.resultService.setResult(get_node_status.toJson());
+        }
+      }
+      if (generation !== this.bootstrapGeneration) {
+        return;
       }
       await this.get_state_root_hash(no_mark_for_check);
     } catch (error) {
-      console.error(error);
-      this.errorService.setError(error as string);
+      if (generation === this.bootstrapGeneration) {
+        console.error(error);
+        this.errorService.setError(error as string);
+      }
+    } finally {
+      if (generation === this.bootstrapGeneration) {
+        this.stateService.setState({
+          status_loading: false,
+        });
+      }
     }
-    this.stateService.setState({
-      action,
-    });
-    this.setStateSubscription();
   }
 
   async selectAction(action: string) {
-    await this.cleanResult();
+    this.bootstrapGeneration++;
     this.stateService.setState({
       action,
+      status_loading: false,
     });
+    await this.cleanResult();
     await this.handleAction(action);
     this.storageService.setState({
       action,

--- a/examples/frontend/angular/src/index.html
+++ b/examples/frontend/angular/src/index.html
@@ -28,6 +28,17 @@
     ></script>
   </head>
   <body>
-    <app-root></app-root>
+    <app-root>
+      <div
+        style="
+          font-family: system-ui, sans-serif;
+          padding: 2rem;
+          color: #555;
+          text-align: center;
+        "
+      >
+        Loading Casper WebClient…
+      </div>
+    </app-root>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- Publish Action state immediately on Home init and run `get_node_status` / state-root-hash in the background so Zone.js can paint the Action dropdown without waiting on RPC.
- Force Action OnPush `detectChanges()` after building SDK method lists; show a status loading banner and a static WASM boot placeholder in `index.html`.

## Test plan
- [ ] Cold load webclient: see “Loading Casper WebClient…” during WASM init
- [ ] After boot, Action optgroups appear before / without waiting for the state root hash banner
- [ ] Status shows “Loading status… fetching state root hash” until SRH arrives
- [ ] Changing Action during bootstrap clears loading and does not clobber the newer result
- [ ] Smoke against NCTL or testnet RPC used by the app


Made with [Cursor](https://cursor.com)