### PR TITLE
ci: redeploy Render from :dev via tip dispatch and release

### DIFF
--- a/.github/workflows/docker-build-push-release.yml
+++ b/.github/workflows/docker-build-push-release.yml
@@ -1,4 +1,5 @@
-# Frozen Hub semver + :latest (same digest). Tip of dev is CI/CD Image dev (:dev only).
+# Hub semver + :latest + :dev (same digest on release). Tip of ecosystem/dev
+# also builds :dev via CI/CD Image dev; Render should pull casper-webclient:dev.
 name: CI/CD Image release
 
 on:
@@ -69,10 +70,12 @@ jobs:
 
           docker build -f mcp/Dockerfile -t casper-rust-wasm-sdk-mcp:latest .
 
-          # Stable: :$APP_VERSION and :latest (same digest). Do not move :dev.
+          # Stable: :$APP_VERSION and :latest (same digest). Also move :dev so
+          # Render (casper-webclient:dev) picks up the release when redeployed.
           for image in casper-webclient cors-anywhere ws-proxy casper-rust-wasm-sdk-mcp; do
             docker tag "${image}:latest" "${{ secrets.DOCKER_USERNAME_ITC }}/${image}:${APP_VERSION}"
             docker tag "${image}:latest" "${{ secrets.DOCKER_USERNAME_ITC }}/${image}:latest"
+            docker tag "${image}:latest" "${{ secrets.DOCKER_USERNAME_ITC }}/${image}:dev"
           done
 
       - name: Push Docker images to Docker Hub
@@ -81,9 +84,11 @@ jobs:
           for image in casper-webclient cors-anywhere ws-proxy casper-rust-wasm-sdk-mcp; do
             docker push "${{ secrets.DOCKER_USERNAME_ITC }}/${image}:${APP_VERSION}"
             docker push "${{ secrets.DOCKER_USERNAME_ITC }}/${image}:latest"
+            docker push "${{ secrets.DOCKER_USERNAME_ITC }}/${image}:dev"
           done
 
-      # Hosted demo pulls :latest (stable). Tip of :dev is not redeployed here.
+      # Hosted demo pulls :dev (Render). Tip CI/CD Image dev can redeploy via
+      # workflow_dispatch without waiting for a release.
       - name: Trigger Render redeploy
         env:
           RENDER_DEPLOY_HOOK: ${{ secrets.RENDER_DEPLOY_HOOK }}
@@ -92,7 +97,7 @@ jobs:
             echo "RENDER_DEPLOY_HOOK secret not set; skipping Render redeploy"
             exit 0
           fi
-          echo "Triggering Render deploy hook…"
+          echo "Triggering Render deploy hook (image tag :dev)…"
           curl -fsS -X GET "${RENDER_DEPLOY_HOOK}"
           echo
           echo "Render deploy requested"

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -1,3 +1,5 @@
+# Tip Hub tag :dev. Hosted demo (Render) should pull interchouette/casper-webclient:dev.
+# Push to ecosystem/dev builds/pushes :dev only. Manual workflow_dispatch also triggers Render.
 name: CI/CD Image dev
 
 on:
@@ -35,7 +37,7 @@ jobs:
           # Slim MCP for Cursor/agents (stdio / HTTP :5790).
           docker build -f mcp/Dockerfile -t casper-rust-wasm-sdk-mcp:latest .
 
-          # Tip only: :dev. Semver (:$APP_VERSION) and :latest are owned by
+          # Tip: :dev. Semver (:$APP_VERSION) and :latest stay on
           # docker-build-push-release.yml (stable = last release).
           for image in casper-webclient cors-anywhere ws-proxy casper-rust-wasm-sdk-mcp; do
             docker tag "${image}:latest" "${{ secrets.DOCKER_USERNAME_ITC }}/${image}:dev"
@@ -46,3 +48,18 @@ jobs:
           for image in casper-webclient cors-anywhere ws-proxy casper-rust-wasm-sdk-mcp; do
             docker push "${{ secrets.DOCKER_USERNAME_ITC }}/${image}:dev"
           done
+
+      # Hosted demo pulls :dev. Only on manual Run workflow (not every tip push).
+      - name: Trigger Render redeploy
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          RENDER_DEPLOY_HOOK: ${{ secrets.RENDER_DEPLOY_HOOK }}
+        run: |
+          if [ -z "${RENDER_DEPLOY_HOOK}" ]; then
+            echo "RENDER_DEPLOY_HOOK secret not set; skipping Render redeploy"
+            exit 0
+          fi
+          echo "Triggering Render deploy hook (image tag :dev)…"
+          curl -fsS -X GET "${RENDER_DEPLOY_HOOK}"
+          echo
+          echo "Render deploy requested"


### PR DESCRIPTION
## Summary
- Tip **CI/CD Image dev**: after pushing `:dev`, **workflow_dispatch** (manual Run workflow) calls `RENDER_DEPLOY_HOOK`. Ordinary pushes to `dev` still build/push `:dev` only (no auto-redeploy).
- Release **CI/CD Image release**: also tags/pushes `:dev` to the release digest (with semver + `:latest`), then triggers the same Render hook.

## Ops (Render)
1. Change the webclient service image from `…/casper-webclient:latest` to `…/casper-webclient:dev`.
2. After this lands on `dev`, run **Actions → CI/CD Image dev → Run workflow** to rebuild tip `:dev` and redeploy.

## Test plan
- [ ] Merge; confirm tip push to `dev` does **not** auto-redeploy Render
- [ ] Manual dispatch of CI/CD Image dev: Hub `:dev` updated + Render hook fired
- [ ] After Render image tag → `:dev`, site footer SHA matches tip (or release digest after a release run)


Made with [Cursor](https://cursor.com)