### PR TITLE
ci: attach Electron + MCP assets to overnight dev-preview

### DIFF
--- a/.github/workflows/dev-preview-release.yml
+++ b/.github/workflows/dev-preview-release.yml
@@ -1,5 +1,6 @@
 # Overwrite one GitHub Pre-release after green overnight tests (not Latest).
 # Fixed tag: dev-preview (does not match crates v*.*.*; does not collide with branch dev).
+# Builds Electron + MCP in-workflow: GITHUB_TOKEN release:created does not start Publish docs.
 name: Dev preview release
 
 on:
@@ -18,6 +19,8 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
+    outputs:
+      sha: ${{ steps.sha.outputs.sha }}
 
     steps:
       - name: Resolve SHA
@@ -49,6 +52,13 @@ jobs:
           NOTES="Nightly-green tip of \`dev\` @ \`${SHORT}\` (\`${SHA}\`).
 
           Overwritten on each successful [nightly-scheduled-test](https://github.com/${{ github.repository }}/actions/workflows/nightly-scheduled-test.yml). Not Latest — that remains the node-aligned semver release (e.g. v2.2.2).
+
+          ## Desktop / MCP assets
+          Attached by CI after this Pre-release is recreated:
+          - \`Casper.Webclient.dev-preview.exe\`
+          - \`Casper.Webclient-dev-preview.AppImage\`
+          - \`casper-webclient_dev-preview_amd64.snap\`
+          - \`casper-rust-wasm-sdk-mcp-dev-preview-linux-x86_64\`
           "
 
           # Drop prior Pre-release entry (keep tag for now); then repoint tag and recreate.
@@ -58,9 +68,18 @@ jobs:
           git tag -f "$TAG" "$SHA"
           git push -f origin "refs/tags/$TAG"
 
-          # Recreate so publish-docs (release: created) rebuilds desktop assets.
           gh release create "$TAG" \
             --prerelease \
             --title "dev preview" \
             --notes "$NOTES" \
             --target "$SHA"
+
+  upload-assets:
+    name: Upload Electron + MCP assets
+    needs: overwrite-prerelease
+    if: needs.overwrite-prerelease.result == 'success'
+    uses: ./.github/workflows/upload-release-assets.yml
+    with:
+      tag: dev-preview
+      ref: ${{ needs.overwrite-prerelease.outputs.sha }}
+    secrets: inherit

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -2,7 +2,8 @@ name: Publish docs
 
 on:
   release:
-    # created: semver cuts and each overwrite of Pre-release tag (delete+recreate).
+    # Semver cuts created outside Actions (PAT / UI). Tip Pre-release assets are
+    # built in Dev preview release (GITHUB_TOKEN cannot chain release→workflow).
     types: [created]
 
 permissions:
@@ -43,75 +44,10 @@ jobs:
           folder: docs # The folder the action should deploy.
 
   desktop-assets:
-    # Electron demos on product releases and the overwritten dev-preview Pre-release.
+    # Electron + MCP on product releases (not tags that only ship MCP crates).
     if: ${{ !contains(github.event.release.tag_name, 'mcp') }}
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout release tag
-        uses: actions/checkout@v5
-        with:
-          ref: ${{ github.event.release.tag_name }}
-
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y pkg-config libssl-dev fuse libfuse2
-          sudo snap install snapcraft --classic
-
-      - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: wasm32-unknown-unknown
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v5
-        with:
-          node-version: "24"
-          package-manager-cache: false
-
-      - name: Install wasm-pack
-        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
-
-      - name: Build Wasm packages
-        run: make pack
-
-      - name: Build Angular frontend
-        run: |
-          cd examples/frontend/angular
-          npm install
-          npm run build
-
-      - name: Build Electron desktop assets
-        working-directory: examples/desktop/electron
-        env:
-          SNAPCRAFT_BUILD_ENVIRONMENT: host
-        run: |
-          npm install
-          npx electron-builder --win portable --linux AppImage snap --publish never
-
-      - name: Upload desktop assets to release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          RELEASE_DIR="examples/desktop/electron/release"
-          TAG="${{ github.event.release.tag_name }}"
-          # electron-builder names files from package.json version, not the git tag
-          # (e.g. tag v2.2.2-mcp still builds Casper Webclient 2.2.2.exe).
-          PKG_VERSION=$(jq -r .version examples/desktop/electron/package.json)
-
-          EXE="$RELEASE_DIR/Casper Webclient ${PKG_VERSION}.exe"
-          APPIMAGE="$RELEASE_DIR/Casper Webclient-${PKG_VERSION}.AppImage"
-          SNAP="$RELEASE_DIR/casper-webclient_${PKG_VERSION}_amd64.snap"
-
-          for f in "$EXE" "$APPIMAGE" "$SNAP"; do
-            if [[ ! -f "$f" ]]; then
-              echo "Missing asset: $f"
-              ls -la "$RELEASE_DIR" || true
-              exit 1
-            fi
-          done
-
-          # Upload versioned electron-builder names only (docs link to the Releases page).
-          gh release upload "$TAG" "$EXE" "$APPIMAGE" "$SNAP" --clobber
+    uses: ./.github/workflows/upload-release-assets.yml
+    with:
+      tag: ${{ github.event.release.tag_name }}
+      ref: ${{ github.event.release.tag_name }}
+    secrets: inherit

--- a/.github/workflows/upload-release-assets.yml
+++ b/.github/workflows/upload-release-assets.yml
@@ -1,0 +1,107 @@
+# Build Electron demos + MCP binary and attach them to a GitHub Release.
+# Called from Publish docs (semver) and Dev preview release (same job — GITHUB_TOKEN
+# release:created events do not start other workflows).
+name: Upload release assets
+
+on:
+  workflow_call:
+    inputs:
+      tag:
+        description: GitHub Release tag to upload into
+        required: true
+        type: string
+      ref:
+        description: Git ref to build (tag or commit SHA)
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  desktop-and-mcp:
+    name: Build and upload desktop + MCP assets
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y pkg-config libssl-dev fuse libfuse2
+          sudo snap install snapcraft --classic
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: "24"
+          package-manager-cache: false
+
+      - name: Install wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+
+      - name: Build Wasm packages
+        run: make pack
+
+      - name: Build Angular frontend
+        run: |
+          cd examples/frontend/angular
+          npm install
+          npm run build
+
+      - name: Build Electron desktop assets
+        working-directory: examples/desktop/electron
+        env:
+          SNAPCRAFT_BUILD_ENVIRONMENT: host
+        run: |
+          npm install
+          npx electron-builder --win portable --linux AppImage snap --publish never
+
+      - name: Build MCP release binary
+        run: cargo build -p casper-rust-wasm-sdk-mcp --release
+
+      - name: Upload assets to release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          RELEASE_DIR="examples/desktop/electron/release"
+          # electron-builder names files from package.json version, not the git tag.
+          PKG_VERSION=$(jq -r .version examples/desktop/electron/package.json)
+          ASSET_LABEL=${TAG#v}
+
+          EXE="$RELEASE_DIR/Casper Webclient ${PKG_VERSION}.exe"
+          APPIMAGE="$RELEASE_DIR/Casper Webclient-${PKG_VERSION}.AppImage"
+          SNAP="$RELEASE_DIR/casper-webclient_${PKG_VERSION}_amd64.snap"
+          MCP_SRC="target/release/casper-rust-wasm-sdk-mcp"
+          MCP_DST="casper-rust-wasm-sdk-mcp-${ASSET_LABEL}-linux-x86_64"
+
+          for f in "$EXE" "$APPIMAGE" "$SNAP" "$MCP_SRC"; do
+            if [[ ! -f "$f" ]]; then
+              echo "Missing asset: $f"
+              ls -la "$RELEASE_DIR" || true
+              ls -la target/release || true
+              exit 1
+            fi
+          done
+
+          cp "$MCP_SRC" "$MCP_DST"
+          chmod +x "$MCP_DST"
+
+          # Upload with release-facing names (Latest uses semver; tip uses tag label).
+          gh release upload "$TAG" \
+            "$EXE#Casper.Webclient.${ASSET_LABEL}.exe" \
+            "$APPIMAGE#Casper.Webclient-${ASSET_LABEL}.AppImage" \
+            "$SNAP#casper-webclient_${ASSET_LABEL}_amd64.snap" \
+            "$MCP_DST" \
+            --clobber

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -73,7 +73,7 @@ Complex inputs use JSON strings — see [TOOLS.md](TOOLS.md) and `tools/params.r
 
 ## MCP client config
 
-Hub tags for `interchouette/casper-rust-wasm-sdk-mcp` and `interchouette/casper-webclient`: **`dev`** (tip), **`latest`** = current stable semver (e.g. **`2.2.2`**). GitHub Pre-release **`dev-preview`** carries overnight tip desktop assets (not Latest).
+Hub tags for `interchouette/casper-rust-wasm-sdk-mcp` and `interchouette/casper-webclient`: **`dev`** (tip), **`latest`** = current stable semver (e.g. **`2.2.2`**). GitHub Pre-release **`dev-preview`** is overwritten after green nightly and attaches tip Electron (exe / AppImage / snap) plus the MCP linux binary (not Latest).
 
 | Server name (example)       | Transport | Backing                                                       |
 | --------------------------- | --------- | ------------------------------------------------------------- |


### PR DESCRIPTION
## Summary
- **Root cause:** `gh release create` with `GITHUB_TOKEN` does not fire `on: release` workflows, so Publish docs never uploaded tip Pre-release assets.
- Add reusable [`.github/workflows/upload-release-assets.yml`](.github/workflows/upload-release-assets.yml) (Electron exe / AppImage / snap + MCP linux binary).
- **Dev preview release** calls it after recreating `dev-preview`.
- **Publish docs** uses the same reusable job for semver releases (and now includes MCP, which was only on Latest by hand).

## Test plan
- [ ] Merge to `dev`
- [ ] Actions → **Dev preview release** → Run workflow
- [ ] Confirm Pre-release `dev-preview` has exe, AppImage, snap, and `casper-rust-wasm-sdk-mcp-dev-preview-linux-x86_64`


Made with [Cursor](https://cursor.com)