### PR TITLE
ci: keep tip tests on NCTL :dev after node v2.2.2 pin

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -40,6 +40,8 @@ jobs:
 
       - name: Start Casper NCTL Service
         run: |
+          # Hub :dev — compose pins BRANCH_NODE=v2.2.2 (same as :2.2) until
+          # casper-node branch dev advances past package 2.2.0; matches SDK types pin.
           docker run -d \
             --name casper-nctl \
             -p 11101-11105:11101-11105 \

--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -45,6 +45,8 @@ jobs:
 
       - name: Start Casper NCTL Service
         run: |
+          # Hub :dev — compose pins BRANCH_NODE=v2.2.2 (same as :2.2) until
+          # casper-node branch dev advances past package 2.2.0; matches SDK types pin.
           docker run -d \
             --name casper-nctl \
             -p 11101-11105:11101-11105 \


### PR DESCRIPTION
## Summary
- Tip `ci-test` / `nightly-test` stay on Hub `interchouette/casper-nctl-2-docker:dev` (not a permanent switch back to `:2.2`).
- Document that NCTL compose profile `dev` now pins `BRANCH_NODE=v2.2.2` (same as `:2.2`) after [casper-nctl-2-docker#22](https://github.com/Interchouette-ITC/casper-nctl-2-docker/pull/22), matching this SDK’s `casper-types` tag pin while casper-node branch `dev` still declares package `2.2.0`.
- Re-run CI against the rebuilt Hub `:dev` image to confirm wire compatibility after #110’s first red run.

## Test plan
- [ ] `ci-test` green on this PR (NCTL `:dev` pull + integration/e2e)
- [ ] Confirm workflow comments still reference `:dev` only
- [ ] Optional: local NCTL `:dev` + `sdk_get_node_status` / smoke RPC


Made with [Cursor](https://cursor.com)