### PR TITLE
fix(webclient): paint status loading banner before cold-start RPCs

### DIFF
--- a/examples/frontend/angular/libs/components/src/lib/action/action.component.ts
+++ b/examples/frontend/angular/libs/components/src/lib/action/action.component.ts
@@ -46,6 +46,11 @@ export class ActionComponent implements AfterViewInit, OnDestroy {
   ) {}
 
   async ngAfterViewInit(): Promise<void> {
+    // Home sets action in ngOnInit; pick it up before the first options paint.
+    const seeded = this.stateService.getValue()?.action;
+    if (seeded) {
+      this.action = seeded;
+    }
     this.sdk_methods = Object.getOwnPropertyNames(
       Object.getPrototypeOf(this.sdk),
     )

--- a/examples/frontend/angular/libs/components/src/lib/action/action.component.ts
+++ b/examples/frontend/angular/libs/components/src/lib/action/action.component.ts
@@ -46,7 +46,6 @@ export class ActionComponent implements AfterViewInit, OnDestroy {
   ) {}
 
   async ngAfterViewInit(): Promise<void> {
-    // Home sets action in ngOnInit; pick it up before the first options paint.
     const seeded = this.stateService.getValue()?.action;
     if (seeded) {
       this.action = seeded;

--- a/examples/frontend/angular/libs/components/src/lib/status/status.component.html
+++ b/examples/frontend/angular/libs/components/src/lib/status/status.component.html
@@ -8,7 +8,6 @@
       <span class="ellipsis-container"
         >Loading status… fetching state root hash</span
       >
-      <!-- Same footprint as the success banner Refresh control (avoids layout jump). -->
       <button
         type="button"
         class="btn me-0 status-banner-spacer"

--- a/examples/frontend/angular/libs/components/src/lib/status/status.component.html
+++ b/examples/frontend/angular/libs/components/src/lib/status/status.component.html
@@ -1,14 +1,26 @@
 <div class="row">
   <div class="col-sm-12">
     <div
-      class="alert alert-info d-flex mb-1 mb-md-3"
+      class="alert alert-info status-banner d-flex flex-md-row flex-column justify-content-between align-items-center mb-1 mb-md-3"
       *ngIf="status_loading && !state_root_hash"
       e2e-id="status_loading"
     >
-      <span>Loading status… fetching state root hash</span>
+      <span class="ellipsis-container"
+        >Loading status… fetching state root hash</span
+      >
+      <!-- Same footprint as the success banner Refresh control (avoids layout jump). -->
+      <button
+        type="button"
+        class="btn me-0 status-banner-spacer"
+        tabindex="-1"
+        aria-hidden="true"
+        disabled
+      >
+        Refresh
+      </button>
     </div>
     <div
-      class="alert alert-success d-flex flex-md-row flex-column justify-content-between align-items-center mb-1 mb-md-3"
+      class="alert alert-success status-banner d-flex flex-md-row flex-column justify-content-between align-items-center mb-1 mb-md-3"
       *ngIf="state_root_hash"
     >
       <span class="ellipsis-container" e2e-id="state_root_hash"

--- a/examples/frontend/angular/libs/components/src/lib/status/status.component.scss
+++ b/examples/frontend/angular/libs/components/src/lib/status/status.component.scss
@@ -1,3 +1,12 @@
+.status-banner {
+  min-height: 3rem;
+}
+
+.status-banner-spacer {
+  visibility: hidden;
+  pointer-events: none;
+}
+
 .ellipsis-container {
   white-space: nowrap;
   overflow: hidden;

--- a/examples/frontend/angular/libs/components/src/lib/status/status.component.ts
+++ b/examples/frontend/angular/libs/components/src/lib/status/status.component.ts
@@ -1,10 +1,10 @@
 import {
-  AfterViewInit,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   EventEmitter,
   OnDestroy,
+  OnInit,
   Output,
 } from '@angular/core';
 import { CommonModule } from '@angular/common';
@@ -19,7 +19,7 @@ import { State, StateService } from '@util/state';
   styleUrls: ['./status.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class StatusComponent implements AfterViewInit, OnDestroy {
+export class StatusComponent implements OnInit, OnDestroy {
   account_hash!: string;
   main_purse!: string;
   state_root_hash!: string;
@@ -35,6 +35,11 @@ export class StatusComponent implements AfterViewInit, OnDestroy {
     private readonly changeDetectorRef: ChangeDetectorRef,
   ) {}
 
+  ngOnInit() {
+    // Subscribe before first paint so Home ngOnInit status_loading is visible.
+    this.setStateSubscription();
+  }
+
   ngOnDestroy() {
     this.stateSubscription && this.stateSubscription.unsubscribe();
   }
@@ -47,12 +52,8 @@ export class StatusComponent implements AfterViewInit, OnDestroy {
         state.main_purse && (this.main_purse = state.main_purse);
         state.state_root_hash && (this.state_root_hash = state.state_root_hash);
         this.status_loading = !!state.status_loading;
-        state && this.changeDetectorRef.markForCheck();
+        this.changeDetectorRef.markForCheck();
       });
-  }
-
-  async ngAfterViewInit() {
-    this.setStateSubscription();
   }
 
   get_state_root_hash() {

--- a/examples/frontend/angular/libs/components/src/lib/status/status.component.ts
+++ b/examples/frontend/angular/libs/components/src/lib/status/status.component.ts
@@ -36,7 +36,6 @@ export class StatusComponent implements OnInit, OnDestroy {
   ) {}
 
   ngOnInit() {
-    // Subscribe before first paint so Home ngOnInit status_loading is visible.
     this.setStateSubscription();
   }
 

--- a/examples/frontend/angular/src/app/home/home.component.ts
+++ b/examples/frontend/angular/src/app/home/home.component.ts
@@ -64,7 +64,6 @@ export class HomeComponent implements OnInit, AfterViewInit, OnDestroy {
 
   private wasm!: Uint8Array | undefined;
   private stateSubscription!: Subscription;
-  /** Bumped to ignore late cold-start RPC results after the user changes action. */
   private bootstrapGeneration = 0;
 
   constructor(
@@ -115,7 +114,6 @@ export class HomeComponent implements OnInit, AfterViewInit, OnDestroy {
     void this.bootstrapChainStatus(action);
   }
 
-  /** Cold-start status + SRH; must not block Action/form paint. */
   private async bootstrapChainStatus(action: string) {
     const generation = ++this.bootstrapGeneration;
     const no_mark_for_check = true;

--- a/examples/frontend/angular/src/app/home/home.component.ts
+++ b/examples/frontend/angular/src/app/home/home.component.ts
@@ -82,8 +82,17 @@ export class HomeComponent implements OnInit, AfterViewInit, OnDestroy {
     this.setStateSubscription();
   }
 
-  public async ngOnInit(): Promise<void> {
+  public ngOnInit(): void {
     console.info(this.sdk);
+    // Seed before child first paint so Status shows the loading banner immediately.
+    const action =
+      this.storageService.get('action') ||
+      this.config['default_action'].toString();
+    this.action = action;
+    this.stateService.setState({
+      action,
+      status_loading: true,
+    });
   }
 
   public ngOnDestroy() {
@@ -100,13 +109,11 @@ export class HomeComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   public ngAfterViewInit() {
+    // After Header has set CORS/RPC; do not block Action paint on these RPCs.
     const action =
+      this.action ||
       this.storageService.get('action') ||
       this.config['default_action'].toString();
-    this.stateService.setState({
-      action,
-      status_loading: true,
-    });
     void this.bootstrapChainStatus(action);
   }
 

--- a/examples/frontend/angular/src/app/home/home.component.ts
+++ b/examples/frontend/angular/src/app/home/home.component.ts
@@ -84,7 +84,6 @@ export class HomeComponent implements OnInit, AfterViewInit, OnDestroy {
 
   public ngOnInit(): void {
     console.info(this.sdk);
-    // Seed before child first paint so Status shows the loading banner immediately.
     const action =
       this.storageService.get('action') ||
       this.config['default_action'].toString();
@@ -109,7 +108,6 @@ export class HomeComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   public ngAfterViewInit() {
-    // After Header has set CORS/RPC; do not block Action paint on these RPCs.
     const action =
       this.action ||
       this.storageService.get('action') ||

--- a/examples/frontend/angular/src/index.html
+++ b/examples/frontend/angular/src/index.html
@@ -32,8 +32,13 @@
       <div
         style="
           font-family: system-ui, sans-serif;
-          padding: 2rem;
-          color: #555;
+          max-width: 40rem;
+          margin: 2rem auto;
+          padding: 1rem 1.25rem;
+          border-radius: 0.375rem;
+          background: #cff4fc;
+          color: #055160;
+          border: 1px solid #9eeaf9;
           text-align: center;
         "
       >


### PR DESCRIPTION
## Summary
- Seed `action` / `status_loading` in Home `ngOnInit` and subscribe Status before first paint so the blue loading banner appears while status and state-root-hash RPCs run (OnPush race after #107 left the bar invisible until RPCs finished).
- Match blue/green status banner layout (shared flex + spacer Refresh + min-height) so the UI does not jump when SRH arrives.
- Strengthen the `index.html` WASM boot placeholder while `APP_INITIALIZER` blocks Angular.

## Test plan
- [ ] Cold load https://casper-webclient.interchouette.net/ (or local serve): blue info banner shows immediately after app paint while status/SRH fetch
- [ ] Green SRH banner replaces blue without height jump; Action select usable during fetch
- [ ] Hard refresh / cold WASM: blue-ish “compiling WASM” placeholder before app boot
- [ ] Changing Action mid-bootstrap still cancels late cold-start results without freezing the select


Made with [Cursor](https://cursor.com)