### PR TITLE
feat(webclient): DEBUG_MODE gated cold-start boot timings

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -30,16 +30,23 @@ if [ ! -f "$INDEX_FILE" ]; then
 fi
 
 # Generate runtime config.js file
+# DEBUG_MODE=1|true enables colored [wc:boot] console timings in the browser.
+DEBUG_MODE_FLAG=false
+case "${DEBUG_MODE:-}" in
+  1|true|TRUE|yes|YES) DEBUG_MODE_FLAG=true ;;
+esac
+
 cat > "$CONFIG_FILE" <<EOF
 window.__APP_CONFIG__ = {
   cors_anywhere_url: '${CORS_ANYWHERE_URL:-}',
   network_rpc_url: '${NETWORK_RPC_URL:-}',
   network_node_url: '${NETWORK_NODE_URL:-}',
   app_version: '${APP_VERSION}',
-  git_sha: '${GIT_SHA_SHORT}'
+  git_sha: '${GIT_SHA_SHORT}',
+  debug_mode: ${DEBUG_MODE_FLAG}
 };
 EOF
-echo "Generated runtime config.js"
+echo "Generated runtime config.js (debug_mode=${DEBUG_MODE_FLAG})"
 
 # Inject config.js script tag into index.html if not already present
 if ! grep -q '<script src="config.js">' "$INDEX_FILE"; then

--- a/docker/serve.mjs
+++ b/docker/serve.mjs
@@ -17,6 +17,12 @@ const ENABLE_MCP_PROXY =
   process.env.ENABLE_MCP_PROXY === 'true' ||
   process.env.ENABLE_MCP === '1' ||
   process.env.ENABLE_MCP === 'true';
+const DEBUG_MODE =
+  process.env.DEBUG_MODE === '1' ||
+  process.env.DEBUG_MODE === 'true' ||
+  process.env.DEBUG_MODE === 'TRUE';
+const PROCESS_STARTED_AT = Date.now();
+let firstHitLogged = false;
 
 const MIME = {
   '.html': 'text/html; charset=utf-8',
@@ -106,6 +112,13 @@ function proxyMcp(req, res) {
 
 const server = http.createServer((req, res) => {
   const urlPath = req.url || '/';
+  if (DEBUG_MODE && !firstHitLogged) {
+    firstHitLogged = true;
+    const sinceStartMs = Date.now() - PROCESS_STARTED_AT;
+    console.error(
+      `[serve] first-hit path=${urlPath.split('?')[0]} since_start_ms=${sinceStartMs}`,
+    );
+  }
   if (ENABLE_MCP_PROXY && (urlPath === '/mcp' || urlPath.startsWith('/mcp/'))) {
     proxyMcp(req, res);
     return;
@@ -115,6 +128,11 @@ const server = http.createServer((req, res) => {
 
 server.listen(PORT, '0.0.0.0', () => {
   console.error(
-    `[serve] listening on :${PORT} dist=${DIST} mcp_proxy=${ENABLE_MCP_PROXY ? MCP_UPSTREAM : 'off'}`,
+    `[serve] listening on :${PORT} dist=${DIST} mcp_proxy=${ENABLE_MCP_PROXY ? MCP_UPSTREAM : 'off'} debug_mode=${DEBUG_MODE}`,
   );
+  if (DEBUG_MODE) {
+    console.error(
+      `[serve] up pid=${process.pid} started_at=${new Date(PROCESS_STARTED_AT).toISOString()}`,
+    );
+  }
 });

--- a/examples/frontend/angular/libs/components/src/lib/action/action.component.ts
+++ b/examples/frontend/angular/libs/components/src/lib/action/action.component.ts
@@ -10,7 +10,7 @@ import {
 } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { SDK } from 'casper-rust-wasm-sdk';
-import { SDK_TOKEN } from '@util/wasm';
+import { SDK_TOKEN, wcBoot } from '@util/wasm';
 import { Subscription } from 'rxjs';
 import { State, StateService } from '@util/state';
 import { CONFIG, EnvironmentConfig } from '@util/config';
@@ -46,6 +46,7 @@ export class ActionComponent implements AfterViewInit, OnDestroy {
   ) {}
 
   async ngAfterViewInit(): Promise<void> {
+    wcBoot.mark('action_build_start');
     const seeded = this.stateService.getValue()?.action;
     if (seeded) {
       this.action = seeded;
@@ -195,6 +196,10 @@ export class ActionComponent implements AfterViewInit, OnDestroy {
     );
     this.setStateSubscription();
     this.changeDetectorRef.detectChanges();
+    wcBoot.mark('action_build_done', {
+      action: this.action || '',
+      rpc_methods: this.sdk_rpc_methods?.length ?? 0,
+    });
   }
 
   ngOnDestroy() {

--- a/examples/frontend/angular/libs/components/src/lib/header/header.component.ts
+++ b/examples/frontend/angular/libs/components/src/lib/header/header.component.ts
@@ -11,7 +11,7 @@ import {
 import { CommonModule, DOCUMENT } from '@angular/common';
 import { CONFIG, ENV, EnvironmentConfig, Network } from '@util/config';
 import { PeerEntry, SDK } from 'casper-rust-wasm-sdk';
-import { SDK_TOKEN } from '@util/wasm';
+import { SDK_TOKEN, wcBoot } from '@util/wasm';
 import { StateService } from '@util/state';
 import { StorageService } from '@util/storage';
 
@@ -387,6 +387,15 @@ export class HeaderComponent implements AfterViewInit {
       } else {
         this.sdk.setNodeAddress(this.node_address);
       }
+      const rpc =
+        typeof (this.sdk as { getRPCAddress?: () => string }).getRPCAddress ===
+        'function'
+          ? (this.sdk as { getRPCAddress: () => string }).getRPCAddress()
+          : this.rpc_address;
+      wcBoot.mark('header_rpc_set', {
+        rpc,
+        node: this.node_address,
+      });
     } catch (e) {
       console.error(e);
     }

--- a/examples/frontend/angular/libs/components/src/lib/status/status.component.ts
+++ b/examples/frontend/angular/libs/components/src/lib/status/status.component.ts
@@ -10,6 +10,7 @@ import {
 import { CommonModule } from '@angular/common';
 import { Subscription } from 'rxjs';
 import { State, StateService } from '@util/state';
+import { wcBoot } from '@util/wasm';
 
 @Component({
   selector: 'comp-status',
@@ -49,8 +50,18 @@ export class StatusComponent implements OnInit, OnDestroy {
       .subscribe((state: State) => {
         state.account_hash && (this.account_hash = state.account_hash);
         state.main_purse && (this.main_purse = state.main_purse);
+        const prevLoading = this.status_loading;
+        const hadSrh = !!this.state_root_hash;
         state.state_root_hash && (this.state_root_hash = state.state_root_hash);
         this.status_loading = !!state.status_loading;
+        if (prevLoading !== this.status_loading) {
+          wcBoot.mark('status_loading', { value: this.status_loading });
+        }
+        if (!hadSrh && this.state_root_hash) {
+          wcBoot.mark('status_srh_set', {
+            state_root_hash: this.state_root_hash,
+          });
+        }
         this.changeDetectorRef.markForCheck();
       });
   }

--- a/examples/frontend/angular/libs/util/config/src/config.ts
+++ b/examples/frontend/angular/libs/util/config/src/config.ts
@@ -94,4 +94,5 @@ export const config: EnvironmentConfig = {
   // network_rpc_url: optional, overrides selected network's rpc_address (ntcl/dev)
   // network_node_url: optional, overrides selected network's node_address
   // allow_secret_key_load: optional boolean override
+  // debug_mode: optional; DEBUG_MODE env enables [wc:boot] console timings
 };

--- a/examples/frontend/angular/libs/util/services/wasm/src/index.ts
+++ b/examples/frontend/angular/libs/util/services/wasm/src/index.ts
@@ -1,2 +1,4 @@
 export * from './lib/wasm.module';
 export * from './lib/wasm.factory';
+export * from './lib/wc-console';
+export * from './lib/boot-timing';

--- a/examples/frontend/angular/libs/util/services/wasm/src/lib/boot-timing.ts
+++ b/examples/frontend/angular/libs/util/services/wasm/src/lib/boot-timing.ts
@@ -1,0 +1,128 @@
+/**
+ * DEBUG_MODE-gated boot marks (OT bootDiagnostics shape).
+ * When disabled, mark/measure are no-ops.
+ */
+
+import { wcConsoleWrite, wcNowMs } from './wc-console';
+
+interface WcBootState {
+  enabled: boolean;
+  t0: number;
+}
+
+const state: WcBootState = {
+  enabled: false,
+  t0: 0,
+};
+
+declare global {
+  interface Window {
+    __bootT0?: number;
+    __APP_CONFIG__?: {
+      cors_anywhere_url?: string;
+      network_rpc_url?: string;
+      network_node_url?: string;
+      app_version?: string;
+      git_sha?: string;
+      allow_secret_key_load?: boolean;
+      debug_mode?: boolean;
+    };
+  }
+}
+
+function resolveT0(): number {
+  if (state.t0 > 0) {
+    return state.t0;
+  }
+  if (typeof performance !== 'undefined') {
+    const fromWindow =
+      typeof globalThis !== 'undefined' &&
+      'window' in globalThis &&
+      (globalThis as Window & typeof globalThis).window?.__bootT0;
+    state.t0 =
+      typeof fromWindow === 'number' && Number.isFinite(fromWindow)
+        ? fromWindow
+        : performance.now();
+  }
+  return state.t0;
+}
+
+/** True when query has debug=1 / DEBUG_MODE=1. */
+export function wcBootQueryEnabled(): boolean {
+  if (typeof globalThis === 'undefined' || !('location' in globalThis)) {
+    return false;
+  }
+  try {
+    const params = new URLSearchParams(
+      (globalThis as Window & typeof globalThis).location.search,
+    );
+    const q =
+      params.get('debug') ??
+      params.get('DEBUG_MODE') ??
+      params.get('debug_mode');
+    return q === '1' || q === 'true';
+  } catch {
+    return false;
+  }
+}
+
+/** Resolve DEBUG_MODE from query, __APP_CONFIG__, or non-production default. */
+export function resolveWcBootEnabled(production: boolean): boolean {
+  if (wcBootQueryEnabled()) {
+    return true;
+  }
+  if (
+    typeof window !== 'undefined' &&
+    window.__APP_CONFIG__?.debug_mode === true
+  ) {
+    return true;
+  }
+  return !production;
+}
+
+/** Marks named boot steps when DEBUG_MODE enables `wc:boot`. */
+export const wcBoot = {
+  configure(config: { enabled: boolean }): void {
+    state.enabled = config.enabled;
+    if (config.enabled && state.t0 === 0) {
+      resolveT0();
+    }
+  },
+
+  isEnabled(): boolean {
+    return state.enabled;
+  },
+
+  mark(phase: string, kv?: Record<string, unknown>): void {
+    if (!state.enabled) {
+      return;
+    }
+    const elapsed = wcNowMs() - resolveT0();
+    wcConsoleWrite({
+      ns: 'wc:boot',
+      topic: phase,
+      ms: elapsed,
+      kv,
+    });
+  },
+
+  async measure<T>(
+    phase: string,
+    work: () => Promise<T>,
+    kv?: Record<string, unknown>,
+  ): Promise<T> {
+    if (!state.enabled) {
+      return work();
+    }
+    this.mark(`${phase}_start`, kv);
+    try {
+      const result = await work();
+      this.mark(`${phase}_done`, kv);
+      return result;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      this.mark(`${phase}_error`, { ...(kv ?? {}), error: message });
+      throw err;
+    }
+  },
+};

--- a/examples/frontend/angular/libs/util/services/wasm/src/lib/wasm.factory.ts
+++ b/examples/frontend/angular/libs/util/services/wasm/src/lib/wasm.factory.ts
@@ -6,6 +6,7 @@ import {
   Provider,
 } from '@angular/core';
 import init, { SDK, Verbosity } from 'casper-rust-wasm-sdk';
+import { wcBoot } from './boot-timing';
 
 export const SDK_TOKEN = new InjectionToken<SDK>('SDK');
 export const WASM_ASSET_PATH = new InjectionToken<string>('wasm_asset_path');
@@ -21,11 +22,18 @@ type Params = {
 };
 
 export const fetchWasmFactory = async (params: Params): Promise<SDK> => {
-  // console.log('Loading wasm from', params.wasm_asset_path);
-  const wasm = await init({ module_or_path: params.wasm_asset_path });
-  return (
-    wasm && new SDK(params.rpc_address, params.node_address, params.verbosity)
+  await wcBoot.measure(
+    'wasm_init',
+    async () => {
+      await init({ module_or_path: params.wasm_asset_path });
+    },
+    { path: params.wasm_asset_path },
   );
+  wcBoot.mark('sdk_ctor', {
+    rpc: params.rpc_address,
+    node: params.node_address,
+  });
+  return new SDK(params.rpc_address, params.node_address, params.verbosity);
 };
 
 export function provideSafeAsync<T>(

--- a/examples/frontend/angular/libs/util/services/wasm/src/lib/wc-console.ts
+++ b/examples/frontend/angular/libs/util/services/wasm/src/lib/wc-console.ts
@@ -1,0 +1,88 @@
+/**
+ * Styled console lines for `[wc:boot]` (OT ot-console shape).
+ * Fluorescent tag, wall-clock, nav-relative ms, flat key=value — no raw Object dumps.
+ */
+
+export type WcConsoleNamespace = 'wc:boot';
+
+const NS_TAG_COLOR: Record<WcConsoleNamespace, string> = {
+  'wc:boot': '#00ff9c',
+};
+
+const STYLE_LABEL = 'color:#e8f7ff;font-weight:600';
+const STYLE_CLOCK = 'color:#80cbc4;font-weight:600';
+const STYLE_MS = 'color:#ffea00;font-weight:700';
+const STYLE_KV = 'color:inherit;font-weight:normal;background:transparent';
+
+function tagStyle(ns: WcConsoleNamespace): string {
+  const fg = NS_TAG_COLOR[ns];
+  return `color:${fg};font-weight:700;background:#0a0a0a;padding:0.1em 0.35em;border-radius:0.2em`;
+}
+
+export function wcFormatKvValue(value: unknown): string {
+  if (value === null || value === undefined) {
+    return String(value);
+  }
+  if (
+    typeof value === 'string' ||
+    typeof value === 'number' ||
+    typeof value === 'boolean'
+  ) {
+    return String(value);
+  }
+  return JSON.stringify(value);
+}
+
+export function wcFormatKv(kv?: Record<string, unknown>): string {
+  if (!kv || Object.keys(kv).length === 0) {
+    return '';
+  }
+  return Object.entries(kv)
+    .map(([k, v]) => `${k}=${wcFormatKvValue(v)}`)
+    .join(' ');
+}
+
+export function wcNowMs(): number {
+  if (typeof performance === 'undefined') {
+    return 0;
+  }
+  return performance.now();
+}
+
+function pad2(n: number, width = 2): string {
+  return String(Math.trunc(n)).padStart(width, '0');
+}
+
+export function wcClockStamp(date: Date = new Date()): string {
+  return (
+    `${date.getFullYear()}-${pad2(date.getMonth() + 1)}-${pad2(date.getDate())} ` +
+    `${pad2(date.getHours())}:${pad2(date.getMinutes())}:${pad2(date.getSeconds())}.` +
+    `${pad2(date.getMilliseconds(), 3)}`
+  );
+}
+
+export type WcConsoleWriteOptions = {
+  ns: WcConsoleNamespace;
+  topic: string;
+  ms?: number;
+  kv?: Record<string, unknown>;
+  level?: 'log' | 'warn' | 'info';
+};
+
+/** One styled `[wc:boot] topic clock N.Nms key=value…` line. */
+export function wcConsoleWrite(options: WcConsoleWriteOptions): void {
+  const { ns, topic, kv, level = 'log' } = options;
+  const ms = options.ms ?? wcNowMs();
+  const clock = wcClockStamp();
+  const kvStr = wcFormatKv(kv);
+  const suffix = kvStr.length > 0 ? ` ${kvStr}` : '';
+  console[level](
+    `%c[${ns}]%c ${topic} %c${clock}%c %c${ms.toFixed(1)}ms%c${suffix}`,
+    tagStyle(ns),
+    STYLE_LABEL,
+    STYLE_CLOCK,
+    STYLE_KV,
+    STYLE_MS,
+    STYLE_KV,
+  );
+}

--- a/examples/frontend/angular/src/app/home/home.component.ts
+++ b/examples/frontend/angular/src/app/home/home.component.ts
@@ -10,7 +10,7 @@ import {
   ViewChild,
 } from '@angular/core';
 import { CONFIG, ENV, EnvironmentConfig } from '@util/config';
-import { SDK_TOKEN } from '@util/wasm';
+import { SDK_TOKEN, wcBoot } from '@util/wasm';
 import { SDK, PeerEntry, Transaction } from 'casper-rust-wasm-sdk';
 import {
   ResultComponent,
@@ -91,6 +91,7 @@ export class HomeComponent implements OnInit, AfterViewInit, OnDestroy {
       action,
       status_loading: true,
     });
+    wcBoot.mark('home_init', { action, status_loading: true });
   }
 
   public ngOnDestroy() {
@@ -111,38 +112,47 @@ export class HomeComponent implements OnInit, AfterViewInit, OnDestroy {
       this.action ||
       this.storageService.get('action') ||
       this.config['default_action'].toString();
+    wcBoot.mark('home_after_view', { action });
     void this.bootstrapChainStatus(action);
   }
 
   private async bootstrapChainStatus(action: string) {
     const generation = ++this.bootstrapGeneration;
     const no_mark_for_check = true;
-    try {
-      if (action == this.config['default_action'].toString()) {
-        const get_node_status = await this.sdk.get_node_status();
+    await wcBoot.measure('bootstrap_chain', async () => {
+      try {
+        if (action == this.config['default_action'].toString()) {
+          const get_node_status = await wcBoot.measure(
+            'rpc_get_node_status',
+            () => this.sdk.get_node_status(),
+          );
+          if (generation !== this.bootstrapGeneration) {
+            return;
+          }
+          if (get_node_status) {
+            await this.resultService.setResult(get_node_status.toJson());
+          }
+        }
         if (generation !== this.bootstrapGeneration) {
           return;
         }
-        if (get_node_status) {
-          await this.resultService.setResult(get_node_status.toJson());
+        await wcBoot.measure('rpc_get_srh', () =>
+          this.get_state_root_hash(no_mark_for_check),
+        );
+      } catch (error) {
+        if (generation === this.bootstrapGeneration) {
+          console.error(error);
+          this.errorService.setError(error as string);
+        }
+      } finally {
+        if (generation === this.bootstrapGeneration) {
+          this.stateService.setState({
+            status_loading: false,
+          });
+          wcBoot.mark('status_loading_false');
         }
       }
-      if (generation !== this.bootstrapGeneration) {
-        return;
-      }
-      await this.get_state_root_hash(no_mark_for_check);
-    } catch (error) {
-      if (generation === this.bootstrapGeneration) {
-        console.error(error);
-        this.errorService.setError(error as string);
-      }
-    } finally {
-      if (generation === this.bootstrapGeneration) {
-        this.stateService.setState({
-          status_loading: false,
-        });
-      }
-    }
+    });
   }
 
   async selectAction(action: string) {

--- a/examples/frontend/angular/src/index.html
+++ b/examples/frontend/angular/src/index.html
@@ -28,6 +28,57 @@
     ></script>
   </head>
   <body>
+    <script>
+      (function () {
+        try {
+          var params = new URLSearchParams(location.search);
+          var q =
+            params.get('debug') ||
+            params.get('DEBUG_MODE') ||
+            params.get('debug_mode');
+          var fromQuery = q === '1' || q === 'true';
+          var fromConfig =
+            window.__APP_CONFIG__ && window.__APP_CONFIG__.debug_mode === true;
+          if (!fromQuery && !fromConfig) {
+            return;
+          }
+          window.__bootT0 = performance.now();
+          var ms = performance.now();
+          var d = new Date();
+          function pad(n, w) {
+            w = w || 2;
+            return String(Math.trunc(n)).padStart(w, '0');
+          }
+          var clock =
+            d.getFullYear() +
+            '-' +
+            pad(d.getMonth() + 1) +
+            '-' +
+            pad(d.getDate()) +
+            ' ' +
+            pad(d.getHours()) +
+            ':' +
+            pad(d.getMinutes()) +
+            ':' +
+            pad(d.getSeconds()) +
+            '.' +
+            pad(d.getMilliseconds(), 3);
+          console.log(
+            '%c[wc:boot]%c html_body %c' +
+              clock +
+              '%c %c' +
+              ms.toFixed(1) +
+              'ms%c splash=1',
+            'color:#00ff9c;font-weight:700;background:#0a0a0a;padding:0.1em 0.35em;border-radius:0.2em',
+            'color:#e8f7ff;font-weight:600',
+            'color:#80cbc4;font-weight:600',
+            'color:inherit;font-weight:normal;background:transparent',
+            'color:#ffea00;font-weight:700',
+            'color:inherit;font-weight:normal;background:transparent',
+          );
+        } catch (e) {}
+      })();
+    </script>
     <app-root>
       <div
         style="

--- a/examples/frontend/angular/src/main.ts
+++ b/examples/frontend/angular/src/main.ts
@@ -13,6 +13,8 @@ import {
   VERBOSITY,
   WASM_ASSET_PATH,
   WasmModule,
+  resolveWcBootEnabled,
+  wcBoot,
 } from '@util/wasm';
 import { config, CONFIG, ENV, Network } from '@util/config';
 import { environment } from './environments/environment';
@@ -22,19 +24,8 @@ import { HomeComponent } from './app/home/home.component';
 import { Verbosity } from 'casper-rust-wasm-sdk';
 import { ResultModule } from '@util/result';
 
-// Declare global window interface for runtime config
-declare global {
-  interface Window {
-    __APP_CONFIG__?: {
-      cors_anywhere_url?: string;
-      network_rpc_url?: string;
-      network_node_url?: string;
-      app_version?: string;
-      git_sha?: string;
-      allow_secret_key_load?: boolean;
-    };
-  }
-}
+wcBoot.configure({ enabled: resolveWcBootEnabled(!!environment.production) });
+wcBoot.mark('main_enter');
 
 /** Electron loads the UI via file://; PathLocationStrategy breaks asset URLs there. */
 function isElectronShell(): boolean {
@@ -105,6 +96,9 @@ if (typeof window !== 'undefined' && window.__APP_CONFIG__) {
   if (typeof runtimeConfig.allow_secret_key_load === 'boolean') {
     config['allow_secret_key_load'] = runtimeConfig.allow_secret_key_load;
   }
+  if (typeof runtimeConfig.debug_mode === 'boolean') {
+    config['debug_mode'] = runtimeConfig.debug_mode;
+  }
 }
 
 const routes: Routes = [
@@ -136,8 +130,9 @@ const providers: Array<Provider | EnvironmentProviders> = [
 
 bootstrapApplication(AppComponent, { providers })
   .then(() => {
-    //
+    wcBoot.mark('bootstrap_done');
   })
-  .catch(() => {
-    //
+  .catch((err) => {
+    const message = err instanceof Error ? err.message : String(err);
+    wcBoot.mark('bootstrap_error', { error: message });
   });


### PR DESCRIPTION
## Summary
- Add `DEBUG_MODE`-gated OT-style colored `[wc:boot]` console timings across WebClient cold start (HTML splash → WASM → Action/Status paint → get_node_status / SRH).
- Wire Docker/Render env `DEBUG_MODE` → `__APP_CONFIG__.debug_mode` via entrypoint; on by default for local non-production builds.
- Log host process start / first HTTP hit in `serve.mjs` when `DEBUG_MODE` is set.

Instrumentation only — no UI/paint fix.

## Test plan
- [ ] Local `ng serve`: `[wc:boot]` timeline appears
- [ ] Production/docker without `DEBUG_MODE`: no `[wc:boot]` spam
- [ ] Production/docker with `DEBUG_MODE=1`: full timeline including `action=get_node_status`, wasm, RPC marks
- [ ] `serve.mjs` with `DEBUG_MODE=1`: first-hit log on first request