### PR TITLE
fix(webclient): drop ?debug= query gate; pin docker Prettier

### DIFF
--- a/docker/.prettierrc
+++ b/docker/.prettierrc
@@ -1,0 +1,3 @@
+{
+  "singleQuote": true
+}

--- a/examples/frontend/angular/libs/util/services/wasm/src/lib/boot-timing.ts
+++ b/examples/frontend/angular/libs/util/services/wasm/src/lib/boot-timing.ts
@@ -47,30 +47,8 @@ function resolveT0(): number {
   return state.t0;
 }
 
-/** True when query has debug=1 / DEBUG_MODE=1. */
-export function wcBootQueryEnabled(): boolean {
-  if (typeof globalThis === 'undefined' || !('location' in globalThis)) {
-    return false;
-  }
-  try {
-    const params = new URLSearchParams(
-      (globalThis as Window & typeof globalThis).location.search,
-    );
-    const q =
-      params.get('debug') ??
-      params.get('DEBUG_MODE') ??
-      params.get('debug_mode');
-    return q === '1' || q === 'true';
-  } catch {
-    return false;
-  }
-}
-
-/** Resolve DEBUG_MODE from query, __APP_CONFIG__, or non-production default. */
+/** Resolve DEBUG_MODE from __APP_CONFIG__ (Docker env) or non-production default. */
 export function resolveWcBootEnabled(production: boolean): boolean {
-  if (wcBootQueryEnabled()) {
-    return true;
-  }
   if (
     typeof window !== 'undefined' &&
     window.__APP_CONFIG__?.debug_mode === true

--- a/examples/frontend/angular/src/index.html
+++ b/examples/frontend/angular/src/index.html
@@ -31,15 +31,12 @@
     <script>
       (function () {
         try {
-          var params = new URLSearchParams(location.search);
-          var q =
-            params.get('debug') ||
-            params.get('DEBUG_MODE') ||
-            params.get('debug_mode');
-          var fromQuery = q === '1' || q === 'true';
-          var fromConfig =
-            window.__APP_CONFIG__ && window.__APP_CONFIG__.debug_mode === true;
-          if (!fromQuery && !fromConfig) {
+          if (
+            !(
+              window.__APP_CONFIG__ &&
+              window.__APP_CONFIG__.debug_mode === true
+            )
+          ) {
             return;
           }
           window.__bootT0 = performance.now();


### PR DESCRIPTION
## Summary
- Follow-up to #113: remove the `?debug=` / query-string gate that landed because later commits were pushed after the squash merge.
- Gate `[wc:boot]` on Docker/Render `DEBUG_MODE` → `__APP_CONFIG__.debug_mode` only (local non-prod default unchanged).
- Add `docker/.prettierrc` with `singleQuote: true` so format-on-save stops flipping `serve.mjs` quotes.

## Test plan
- [ ] Production/docker without `DEBUG_MODE`: no `[wc:boot]` and no query-param enable path
- [ ] Production/docker with `DEBUG_MODE=1`: `[wc:boot]` timeline
- [ ] Local `ng serve`: still on by default
- [ ] Editing `docker/serve.mjs` does not rewrite quotes to double


Made with [Cursor](https://cursor.com)