### PR TITLE
fix(webclient): hide SSE_client and CES_parser from Action select

### DIFF
--- a/examples/frontend/angular/libs/components/src/lib/action/action.component.ts
+++ b/examples/frontend/angular/libs/components/src/lib/action/action.component.ts
@@ -69,6 +69,9 @@ export class ActionComponent implements AfterViewInit, OnDestroy {
             'setVerbosity',
             'watchDeploy',
             'waitDeploy',
+            // Factory helpers (not WebClient Action demos).
+            'SSE_client',
+            'CES_parser',
           ].includes(name),
       )
       .filter((name) => !name.endsWith('_options'))


### PR DESCRIPTION
## Summary
- Exclude `SSE_client` and `CES_parser` from the Angular Action select (same class as `watchDeploy` / setters).
- They are SDK factory helpers; selecting them produced `Method … is not defined on the component or clientService`.

## Test plan
- [ ] Action select has no `SSE_client` / `CES_parser` options
- [ ] Choosing other rpc methods still works
- [ ] No error banner from selecting those names (they are gone)


Made with [Cursor](https://cursor.com)