### PR TITLE
ci: Render on Hub :dev push and after green nightly

### DIFF
--- a/.github/workflows/hub-images-dev.yml
+++ b/.github/workflows/hub-images-dev.yml
@@ -1,4 +1,4 @@
-# Hub tip images (:dev). Render redeploy only on manual Run workflow.
+# Hub tip images (:dev). Push + Render on every push to `dev` (and manual Run).
 name: hub-images-dev
 
 on:
@@ -45,7 +45,6 @@ jobs:
           done
 
       - name: Trigger Render redeploy
-        if: github.event_name == 'workflow_dispatch'
         env:
           RENDER_DEPLOY_HOOK: ${{ secrets.RENDER_DEPLOY_HOOK }}
         run: |

--- a/.github/workflows/release-github-preview.yml
+++ b/.github/workflows/release-github-preview.yml
@@ -79,3 +79,23 @@ jobs:
       tag: dev-preview
       ref: ${{ needs.overwrite-prerelease.outputs.sha }}
     secrets: inherit
+
+  # Pull latest Hub :dev on Render after overnight-green tip (or manual preview run).
+  render-redeploy:
+    name: Trigger Render redeploy
+    needs: overwrite-prerelease
+    if: needs.overwrite-prerelease.result == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Render redeploy
+        env:
+          RENDER_DEPLOY_HOOK: ${{ secrets.RENDER_DEPLOY_HOOK }}
+        run: |
+          if [ -z "${RENDER_DEPLOY_HOOK}" ]; then
+            echo "RENDER_DEPLOY_HOOK secret not set; skipping Render redeploy"
+            exit 0
+          fi
+          echo "Triggering Render deploy hook (image tag :dev)…"
+          curl -fsS -X GET "${RENDER_DEPLOY_HOOK}"
+          echo
+          echo "Render deploy requested"


### PR DESCRIPTION
## Summary
- `hub-images-dev`: keep building/pushing Hub `:dev` on every push to `dev`, and **also** call the Render deploy hook (was manual-only).
- `release-github-preview`: after green `nightly-test` (or manual preview run), trigger Render so live pulls current Hub `:dev`.

## Why
Tip merges updated Docker Hub but not [casper-webclient.interchouette.net](https://casper-webclient.interchouette.net/) unless someone manually ran `hub-images-dev`. Nightly never hit Render either.

## Test plan
- [ ] After merge, next push to `dev` runs `hub-images-dev` with a non-skipped Render step; footer SHA on live matches the merge.
- [ ] Next green `nightly-test` → `release-github-preview` shows `render-redeploy` job success (or skip if secret unset).
- [ ] Manual Run on `hub-images-dev` still works.


Made with [Cursor](https://cursor.com)