### PR TITLE
feat(python): PyO3 maturin bindings (#9)

### DIFF
--- a/.github/workflows/python-bindings.yml
+++ b/.github/workflows/python-bindings.yml
@@ -1,0 +1,50 @@
+# Lightweight PyO3 / maturin smoke. Separate from ci-test (no NCTL, no Wasm).
+name: python-bindings
+
+on:
+  push:
+    branches: [dev, "feat*", "release-*"]
+    paths:
+      - "python/**"
+      - ".github/workflows/python-bindings.yml"
+  pull_request:
+    branches: [dev, "feat*", "release-*"]
+    paths:
+      - "python/**"
+      - ".github/workflows/python-bindings.yml"
+  workflow_dispatch:
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: python
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install native deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y pkg-config libssl-dev
+        working-directory: ${{ github.workspace }}
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Swatinem cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: ". -> target"
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install maturin
+        run: pip install "maturin>=1.7,<2.0"
+
+      - name: maturin develop
+        run: maturin develop
+
+      - name: Offline smoke
+        run: python tests/smoke_offline.py

--- a/.github/workflows/python-bindings.yml
+++ b/.github/workflows/python-bindings.yml
@@ -40,11 +40,14 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install maturin
-        run: pip install "maturin>=1.7,<2.0"
-
-      - name: maturin develop
-        run: maturin develop
+      - name: venv + maturin develop
+        run: |
+          python -m venv .venv
+          . .venv/bin/activate
+          pip install "maturin>=1.7,<2.0"
+          maturin develop
 
       - name: Offline smoke
-        run: python tests/smoke_offline.py
+        run: |
+          . .venv/bin/activate
+          python tests/smoke_offline.py

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -493,6 +493,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "casper_rust_wasm_sdk_py"
+version = "0.1.0"
+dependencies = [
+ "casper-rust-wasm-sdk",
+ "casper-types",
+ "pyo3",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
 name = "cc"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1589,6 +1600,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1869,6 +1889,15 @@ name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "miette"
@@ -2182,6 +2211,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
+name = "portable-atomic"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2206,6 +2241,68 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "pyo3"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8970a78afe0628a3e3430376fc5fd76b6b45c4d43360ffd6cdd40bdde72b682a"
+dependencies = [
+ "indoc",
+ "libc",
+ "memoffset",
+ "once_cell",
+ "portable-atomic",
+ "pyo3-build-config",
+ "pyo3-ffi",
+ "pyo3-macros",
+ "unindent",
+]
+
+[[package]]
+name = "pyo3-build-config"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "458eb0c55e7ece017adeba38f2248ff3ac615e53660d7c71a238d7d2a01c7598"
+dependencies = [
+ "once_cell",
+ "target-lexicon",
+]
+
+[[package]]
+name = "pyo3-ffi"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7114fe5457c61b276ab77c5055f206295b812608083644a5c5b2640c3102565c"
+dependencies = [
+ "libc",
+ "pyo3-build-config",
+]
+
+[[package]]
+name = "pyo3-macros"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8725c0a622b374d6cb051d11a0983786448f7785336139c3c94f5aa6bef7e50"
+dependencies = [
+ "proc-macro2",
+ "pyo3-macros-backend",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "pyo3-macros-backend"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4109984c22491085343c05b0dbc54ddc405c3cf7b4374fc533f5c3313a572ccc"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "pyo3-build-config",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2992,13 +3089,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "target-lexicon"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -3398,6 +3501,12 @@ name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
+name = "unindent"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1600,15 +1600,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indoc"
-version = "2.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
 name = "ipnet"
 version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1889,15 +1880,6 @@ name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
-
-[[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
-]
 
 [[package]]
 name = "miette"
@@ -2245,36 +2227,32 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.25.1"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8970a78afe0628a3e3430376fc5fd76b6b45c4d43360ffd6cdd40bdde72b682a"
+checksum = "4688ddedf473e32662b9b067670129a8afb8c18e351482c70d62ba4a88171e8b"
 dependencies = [
- "indoc",
  "libc",
- "memoffset",
  "once_cell",
  "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
- "unindent",
 ]
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.25.1"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "458eb0c55e7ece017adeba38f2248ff3ac615e53660d7c71a238d7d2a01c7598"
+checksum = "f41027e41b4bd03f6e60f9f417fe24a6341a6bb744edd62b6f709f2a52ea30e9"
 dependencies = [
- "once_cell",
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.25.1"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7114fe5457c61b276ab77c5055f206295b812608083644a5c5b2640c3102565c"
+checksum = "e591a95526fead067432c3b3a33fc74770b87b1e04e73671090d9c2055a2b327"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -2282,9 +2260,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.25.1"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8725c0a622b374d6cb051d11a0983786448f7785336139c3c94f5aa6bef7e50"
+checksum = "73225868fc1cd84eef2c3c230ddb91273bf1de46aeb8a4248da76d32a0924a1c"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -2294,13 +2272,12 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.25.1"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4109984c22491085343c05b0dbc54ddc405c3cf7b4374fc533f5c3313a572ccc"
+checksum = "571575aa3749fa6216757dd47d2a3e7ef360f329a40f0666a9fbd14889024952"
 dependencies = [
  "heck",
  "proc-macro2",
- "pyo3-build-config",
  "quote",
  "syn 2.0.119",
 ]
@@ -3501,12 +3478,6 @@ name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
-
-[[package]]
-name = "unindent"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,8 @@
 [workspace]
-members = [".", "mcp"]
+members = [".", "mcp", "python"]
+# Keep the root package as the only default member so `cargo clippy --lib` /
+# CI do not build mcp or the maturin python/ cdylib.
+default-members = ["."]
 resolver = "2"
 
 [package]
@@ -18,6 +21,8 @@ exclude = [
   "docs/api-wasm",
   "docs/images",
   "examples",
+  "mcp",
+  "python",
   "pkg",
   "pkg-nodejs",
   "tests/**",

--- a/Makefile
+++ b/Makefile
@@ -202,3 +202,17 @@ mcp-test-live:
 
 .PHONY: mcp-build mcp-http mcp-http-stop \
 	run-mcp run-mcp-http mcp-test mcp-test-live
+
+# --- Python bindings (python/ — maturin; not part of ci-test) ---
+
+python-develop:
+	cd python && \
+		(test -d .venv || uv venv .venv) && \
+		. .venv/bin/activate && \
+		uv pip install 'maturin>=1.7,<2.0' && \
+		maturin develop
+
+python-test: python-develop
+	cd python && . .venv/bin/activate && python tests/smoke_offline.py
+
+.PHONY: python-develop python-test

--- a/docs/README.md
+++ b/docs/README.md
@@ -57,7 +57,7 @@ cd python
 uv venv .venv && source .venv/bin/activate
 uv pip install maturin
 maturin develop
-python -c "import casper_rust_wasm_sdk_py as m; print(m.get_node_status('http://127.0.0.1:11101/rpc')['chainspec_name'])"
+python -c "import casper_rust_wasm_sdk_py as m; print(m.get_node_status('http://127.0.0.1:11101/rpc'))"
 ```
 
 Build is local via maturin (not part of `make pack` / CI Wasm jobs). See [`python/README.md`](../python/README.md).

--- a/docs/README.md
+++ b/docs/README.md
@@ -42,6 +42,26 @@ make mcp-test-live  # against a live local node
 
 See [`mcp/README.md`](../mcp/README.md), tool inventory [`mcp/TOOLS.md`](../mcp/TOOLS.md), and Cursor sample [`mcp/mcp.json.example`](../mcp/mcp.json.example).
 
+## Python
+
+The workspace package [`python/`](../python/) (`casper-rust-wasm-sdk-py`) exposes the same native Rust SDK as a PyO3 / maturin extension ([#9](https://github.com/casper-ecosystem/casper-rust-wasm-sdk/issues/9)). Not a Python port: one `rlib`, thin language face (same idea as Wasm and MCP).
+
+Initial surface (grow incrementally; not full Wasm/TS parity):
+
+- `get_node_status(rpc_address=None)`: JSON-RPC status dict
+- `make_signed_transfer(...)`: make + sign transfer (no put)
+- `generate_secret_key_pem()` / `public_key_hex(pem)` / `version()`
+
+```bash
+cd python
+uv venv .venv && source .venv/bin/activate
+uv pip install maturin
+maturin develop
+python -c "import casper_rust_wasm_sdk_py as m; print(m.get_node_status('http://127.0.0.1:11101/rpc')['chainspec_name'])"
+```
+
+Build is local via maturin (not part of `make pack` / CI Wasm jobs). See [`python/README.md`](../python/README.md).
+
 ## Install
 
 <details>
@@ -2551,6 +2571,10 @@ High-level install / entrypoint / dictionary / key query helpers on `SDK` (see r
 
 Not part of the Rust crate root: sibling package [`mcp/`](../mcp/) wraps the same SDK as MCP tools. See [MCP](#mcp) above and [`mcp/TOOLS.md`](../mcp/TOOLS.md).
 
+### Python
+
+Not part of the Rust crate root: sibling package [`python/`](../python/) wraps the same SDK as a PyO3 extension. See [Python](#python) above and [`python/README.md`](../python/README.md).
+
 ## Typescript API
 
 Published typedoc: [index](https://casper-ecosystem.github.io/casper-rust-wasm-sdk/api-wasm/index.html)
@@ -2660,7 +2684,7 @@ SECRET_KEY_NCTL_PATH=/casper/casper-nctl-2-docker/assets/users/user-1/
 
 Open tracking (not a full roadmap):
 
-- [#9](https://github.com/casper-ecosystem/casper-rust-wasm-sdk/issues/9) — Python / PyO3 bindings
+- [#9](https://github.com/casper-ecosystem/casper-rust-wasm-sdk/issues/9): Python / PyO3 bindings (initial face in [`python/`](../python/); expand surface)
 - [#36](https://github.com/casper-ecosystem/casper-rust-wasm-sdk/issues/36) — first crates.io publish
 - [#96](https://github.com/casper-ecosystem/casper-rust-wasm-sdk/issues/96) — explainer for node core: AE-off `entity-contract-…` vs `hash-…` on `query_global_state` (SDK remaps; permanent fix is upstream)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -60,7 +60,7 @@ maturin develop
 python -c "import casper_rust_wasm_sdk_py as m; print(m.get_node_status('http://127.0.0.1:11101/rpc'))"
 ```
 
-Build is local via maturin (not part of `make pack` / CI Wasm jobs). See [`python/README.md`](../python/README.md).
+Build is local via maturin (`make python-test` for an offline smoke). Separate Actions workflow `python-bindings` (not part of `ci-test` / `make pack`). See [`python/README.md`](../python/README.md).
 
 ## Install
 

--- a/python/.gitignore
+++ b/python/.gitignore
@@ -1,0 +1,9 @@
+/.venv/
+/target/
+*.so
+*.dylib
+*.pyd
+__pycache__/
+*.egg-info/
+dist/
+.wheels/

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -16,7 +16,7 @@ casper-rust-wasm-sdk = { path = "..", default-features = false, features = [
   "helpers",
 ] }
 casper-types = { version = "7.1.1", default-features = false }
-pyo3 = { version = "0.25", features = ["extension-module"] }
+pyo3 = { version = "0.29", features = ["extension-module"] }
 serde_json = "1"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "casper_rust_wasm_sdk_py"
+version = "0.1.0"
+edition = "2021"
+description = "PyO3 bindings for casper-rust-wasm-sdk"
+license = "Apache-2.0"
+publish = false
+
+[lib]
+name = "casper_rust_wasm_sdk_py"
+crate-type = ["cdylib"]
+
+[dependencies]
+casper-rust-wasm-sdk = { path = "..", default-features = false, features = [
+  "transaction",
+  "helpers",
+] }
+casper-types = { version = "7.1.1", default-features = false }
+pyo3 = { version = "0.25", features = ["extension-module"] }
+serde_json = "1"
+tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
+
+[package.metadata.maturin]
+name = "casper_rust_wasm_sdk_py"

--- a/python/README.md
+++ b/python/README.md
@@ -1,0 +1,60 @@
+# casper-rust-wasm-sdk-py
+
+PyO3 + maturin bindings over [`casper-rust-wasm-sdk`](../) for [#9](https://github.com/casper-ecosystem/casper-rust-wasm-sdk/issues/9).
+
+Not a port of the SDK into Python. Same Rust `rlib`, thin Python face (like Wasm / MCP). Initial surface only; expand incrementally.
+
+## Surface
+
+| Function | Behavior |
+| --- | --- |
+| `get_node_status(rpc_address=None)` | JSON-RPC `info_get_status` → dict (`chainspec_name`, `build_version`, `api_version`, `json`) |
+| `make_signed_transfer(...)` | Make + sign a native transfer (no put) → transaction JSON |
+| `generate_secret_key_pem()` / `public_key_hex(pem)` | Local key helpers |
+| `version()` | Extension package version |
+
+Async SDK calls use an owned tokio multi-thread runtime and `block_on` inside the pyfunction.
+
+## Isolation
+
+- Package lives under [`python/`](./); path-depends on the repo root crate with `default-features = false` and `transaction` + `helpers` only.
+- Not part of the default Cargo build / CI clippy matrix for the Wasm SDK (build via maturin in this directory).
+- No change to default features or Wasm packs.
+
+## Build (local)
+
+Requires a CPython 3.10+ venv, Rust toolchain, and (for the status smoke) a reachable JSON-RPC node.
+
+```bash
+cd python
+uv venv .venv
+source .venv/bin/activate
+uv pip install maturin
+maturin develop
+python -c "import casper_rust_wasm_sdk_py as m; print(m.get_node_status('http://127.0.0.1:11101/rpc')['chainspec_name'])"
+```
+
+Use the venv interpreter (`python` after `source .venv/bin/activate`, or `.venv/bin/python`). System `python3` will not see the wheel.
+
+## Example
+
+```python
+import casper_rust_wasm_sdk_py as casper
+
+RPC = "http://127.0.0.1:11101/rpc"
+
+status = casper.get_node_status(RPC)
+print(status["chainspec_name"], status["build_version"])
+
+pem = casper.generate_secret_key_pem()
+sender = casper.public_key_hex(pem)
+tx_json = casper.make_signed_transfer(
+    target=sender,
+    amount="2500000000",
+    chain_name=status["chainspec_name"],
+    secret_key_pem=pem,
+    payment_amount="100000000",
+    rpc_address=RPC,
+)
+print(tx_json[:120], "...")
+```

--- a/python/README.md
+++ b/python/README.md
@@ -6,12 +6,12 @@ Not a port of the SDK into Python. Same Rust `rlib`, thin Python face (like Wasm
 
 ## Surface
 
-| Function | Behavior |
-| --- | --- |
-| `get_node_status(rpc_address=None)` | JSON-RPC `info_get_status` → dict (`chainspec_name`, `build_version`, `api_version`, `json`) |
-| `make_signed_transfer(...)` | Make + sign a native transfer (no put) → transaction JSON |
-| `generate_secret_key_pem()` / `public_key_hex(pem)` | Local key helpers |
-| `version()` | Extension package version |
+| Function                                            | Behavior                                                                                     |
+| --------------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| `get_node_status(rpc_address=None)`                 | JSON-RPC `info_get_status` → dict (`chainspec_name`, `build_version`, `api_version`, `json`) |
+| `make_signed_transfer(...)`                         | Make + sign a native transfer (no put) → transaction JSON                                    |
+| `generate_secret_key_pem()` / `public_key_hex(pem)` | Local key helpers                                                                            |
+| `version()`                                         | Extension package version                                                                    |
 
 Async SDK calls use an owned tokio multi-thread runtime and `block_on` inside the pyfunction.
 
@@ -31,8 +31,10 @@ uv venv .venv
 source .venv/bin/activate
 uv pip install maturin
 maturin develop
-python -c "import casper_rust_wasm_sdk_py as m; print(m.get_node_status('http://127.0.0.1:11101/rpc')['chainspec_name'])"
+python -c "import casper_rust_wasm_sdk_py as m; print(m.get_node_status('http://127.0.0.1:11101/rpc'))"
 ```
+
+Returns a dict (`chainspec_name`, `build_version`, `api_version`, `json`). Print the whole dict for a smoke check; pick fields only when you need them (e.g. `chain_name` for a transfer).
 
 Use the venv interpreter (`python` after `source .venv/bin/activate`, or `.venv/bin/python`). System `python3` will not see the wheel.
 
@@ -44,7 +46,8 @@ import casper_rust_wasm_sdk_py as casper
 RPC = "http://127.0.0.1:11101/rpc"
 
 status = casper.get_node_status(RPC)
-print(status["chainspec_name"], status["build_version"])
+print(status)  # full status dict
+# optional fields: status["chainspec_name"], status["build_version"], status["json"]
 
 pem = casper.generate_secret_key_pem()
 sender = casper.public_key_hex(pem)

--- a/python/README.md
+++ b/python/README.md
@@ -20,6 +20,7 @@ Async SDK calls use an owned tokio multi-thread runtime and `block_on` inside th
 - Package lives under [`python/`](./); path-depends on the repo root crate with `default-features = false` and `transaction` + `helpers` only.
 - Not part of the default Cargo build / CI clippy matrix for the Wasm SDK (build via maturin in this directory).
 - No change to default features or Wasm packs.
+- CI: separate workflow [`python-bindings`](../.github/workflows/python-bindings.yml) (path-filtered on `python/**`). Does not run inside `ci-test`. Offline smoke only (no NCTL).
 
 ## Build (local)
 
@@ -37,6 +38,12 @@ python -c "import casper_rust_wasm_sdk_py as m; print(m.get_node_status('http://
 Returns a dict (`chainspec_name`, `build_version`, `api_version`, `json`). Print the whole dict for a smoke check; pick fields only when you need them (e.g. `chain_name` for a transfer).
 
 Use the venv interpreter (`python` after `source .venv/bin/activate`, or `.venv/bin/python`). System `python3` will not see the wheel.
+
+From the repo root (same offline smoke as CI):
+
+```bash
+make python-test
+```
 
 ## Example
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,0 +1,19 @@
+[build-system]
+requires = ["maturin>=1.7,<2.0"]
+build-backend = "maturin"
+
+[project]
+name = "casper-rust-wasm-sdk-py"
+version = "0.1.0"
+description = "PyO3 bindings for casper-rust-wasm-sdk"
+requires-python = ">=3.10"
+license = { text = "Apache-2.0" }
+classifiers = [
+  "Programming Language :: Rust",
+  "Programming Language :: Python :: Implementation :: CPython",
+]
+
+[tool.maturin]
+manifest-path = "Cargo.toml"
+module-name = "casper_rust_wasm_sdk_py"
+features = ["pyo3/extension-module"]

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -1,0 +1,109 @@
+//! Thin PyO3 face over `casper-rust-wasm-sdk` (native cdylib).
+//!
+//! Surface: `get_node_status` RPC read; make + sign transfer (no put).
+
+use casper_rust_wasm_sdk::{
+    helpers::{public_key_from_secret_key, secret_key_generate},
+    types::{
+        transaction::Transaction, transaction_params::transaction_str_params::TransactionStrParams,
+    },
+    SDK,
+};
+use casper_types::SecretKey;
+use pyo3::exceptions::PyRuntimeError;
+use pyo3::prelude::*;
+use pyo3::types::PyDict;
+
+fn runtime() -> Result<tokio::runtime::Runtime, PyErr> {
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .map_err(|e| PyRuntimeError::new_err(format!("tokio runtime: {e}")))
+}
+
+fn py_err(err: impl std::fmt::Display) -> PyErr {
+    PyRuntimeError::new_err(err.to_string())
+}
+
+fn secret_key_to_pem(secret_key: &SecretKey) -> Result<String, PyErr> {
+    secret_key
+        .to_pem()
+        .map_err(|e| py_err(format!("secret key to pem: {e}")))
+}
+
+/// Call `info_get_status`. Returns chainspec name, build version, and full result JSON.
+#[pyfunction]
+#[pyo3(signature = (rpc_address=None))]
+fn get_node_status(py: Python<'_>, rpc_address: Option<String>) -> PyResult<Bound<'_, PyDict>> {
+    let rt = runtime()?;
+    let sdk = SDK::new(rpc_address.clone(), None, None);
+    let response = rt
+        .block_on(sdk.get_node_status(None, rpc_address))
+        .map_err(py_err)?;
+
+    let result = response.result;
+    let dict = PyDict::new(py);
+    dict.set_item("chainspec_name", result.chainspec_name.clone())?;
+    dict.set_item("build_version", result.build_version.clone())?;
+    dict.set_item(
+        "api_version",
+        serde_json::to_string(&result.api_version).map_err(py_err)?,
+    )?;
+    dict.set_item("json", serde_json::to_string(&result).map_err(py_err)?)?;
+    Ok(dict)
+}
+
+/// Generate an ed25519 secret key PEM (Casper format).
+#[pyfunction]
+fn generate_secret_key_pem() -> PyResult<String> {
+    let sk = secret_key_generate().map_err(py_err)?;
+    secret_key_to_pem(&sk)
+}
+
+/// Public key hex for a Casper secret key PEM.
+#[pyfunction]
+fn public_key_hex(secret_key_pem: String) -> PyResult<String> {
+    public_key_from_secret_key(&secret_key_pem).map_err(py_err)
+}
+
+/// Build and sign a native transfer transaction (does not submit).
+///
+/// Returns JSON for the signed `Transaction`.
+#[pyfunction]
+#[pyo3(signature = (target, amount, chain_name, secret_key_pem, payment_amount, rpc_address=None))]
+fn make_signed_transfer(
+    target: String,
+    amount: String,
+    chain_name: String,
+    secret_key_pem: String,
+    payment_amount: String,
+    rpc_address: Option<String>,
+) -> PyResult<String> {
+    let sdk = SDK::new(rpc_address, None, None);
+    let params = TransactionStrParams::default();
+    params.set_secret_key(&secret_key_pem);
+    params.set_chain_name(&chain_name);
+    params.set_payment_amount(&payment_amount);
+
+    let tx: Transaction = sdk
+        .make_transfer_transaction(None, &target, &amount, params, None)
+        .map_err(py_err)?;
+    let signed = sdk.sign_transaction(tx, &secret_key_pem);
+    signed.to_json_string().map_err(py_err)
+}
+
+/// Extension package version (`CARGO_PKG_VERSION`).
+#[pyfunction]
+fn version() -> &'static str {
+    env!("CARGO_PKG_VERSION")
+}
+
+#[pymodule]
+fn casper_rust_wasm_sdk_py(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add_function(wrap_pyfunction!(get_node_status, m)?)?;
+    m.add_function(wrap_pyfunction!(make_signed_transfer, m)?)?;
+    m.add_function(wrap_pyfunction!(generate_secret_key_pem, m)?)?;
+    m.add_function(wrap_pyfunction!(public_key_hex, m)?)?;
+    m.add_function(wrap_pyfunction!(version, m)?)?;
+    Ok(())
+}

--- a/python/tests/smoke_offline.py
+++ b/python/tests/smoke_offline.py
@@ -1,0 +1,31 @@
+"""Offline smoke for casper_rust_wasm_sdk_py (no JSON-RPC / NCTL)."""
+
+from __future__ import annotations
+
+import casper_rust_wasm_sdk_py as casper
+
+
+def main() -> None:
+    ver = casper.version()
+    assert ver, "version() empty"
+
+    pem = casper.generate_secret_key_pem()
+    assert "BEGIN" in pem and "PRIVATE KEY" in pem, "unexpected PEM"
+
+    pk = casper.public_key_hex(pem)
+    assert pk.startswith(("01", "02")), f"unexpected public key prefix: {pk[:8]}"
+
+    tx_json = casper.make_signed_transfer(
+        target=pk,
+        amount="2500000000",
+        chain_name="casper-net-1",
+        secret_key_pem=pem,
+        payment_amount="100000000",
+    )
+    assert "hash" in tx_json and len(tx_json) > 100, "signed transfer JSON too small"
+
+    print("OK", ver, pk[:18] + "...", "tx_len=", len(tx_json))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Add workspace package [`python/`](python/) (`casper-rust-wasm-sdk-py`): thin **PyO3 + maturin** face over the existing Rust `rlib` for [#9](https://github.com/casper-ecosystem/casper-rust-wasm-sdk/issues/9) (bindings, not a Python port).
- Initial surface: `get_node_status`, `make_signed_transfer` (make+sign, no put), key helpers, `version()`.
- Isolation: `default-members = ["."]` so default `cargo clippy --lib` / CI do not build the Python cdylib; path-dep uses `transaction` + `helpers` only; `python` (and `mcp`) excluded from the crates.io crate tarball; local build via `maturin develop` in a venv.
- Docs: `## Python` section in `docs/README.md` (same style as MCP) + `python/README.md`.

## Isolation / SDK impact

- No Wasm feature or `src/` API changes.
- `make check-lint` green on the root package (stable).
- `cargo build --lib --all-targets` does not compile `casper_rust_wasm_sdk_py`.
- Smoke (venv): `get_node_status('http://127.0.0.1:11101/rpc')` → `casper-net-1`.

## Test plan

- [ ] `RUSTUP_TOOLCHAIN=stable make check-lint`
- [ ] `cd python && uv venv .venv && source .venv/bin/activate && uv pip install maturin && maturin develop`
- [ ] `.venv/bin/python -c "import casper_rust_wasm_sdk_py as m; print(m.get_node_status('http://127.0.0.1:11101/rpc')['chainspec_name'])"` against local NCTL
- [ ] Confirm CI does not require Python/maturin for existing jobs


Made with [Cursor](https://cursor.com)