### PR TITLE
docs: Python section below Install + refresh Todo (#9 done)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -43,27 +43,6 @@ make mcp-test-live  # against a live local node
 
 See [`mcp/README.md`](../mcp/README.md), tool inventory [`mcp/TOOLS.md`](../mcp/TOOLS.md), and Cursor sample [`mcp/mcp.json.example`](../mcp/mcp.json.example).
 
-## Casperatatui
-
-**Casperatatui** is a Casper TUI (terminal UI) based on [ratatui](https://ratatui.rs/), over the native Rust SDK. JSON-RPC and SSE only (no binary port).
-
-- Source: [`examples/desktop/casperatatui`](../examples/desktop/casperatatui)
-- Issue: [#123](https://github.com/casper-ecosystem/casper-rust-wasm-sdk/issues/123)
-- GitHub Releases / Pre-release [`dev-preview`](https://github.com/casper-ecosystem/casper-rust-wasm-sdk/releases): linux binary `casperatatui-<label>-linux-x86_64`
-
-```bash
-make run-casperatatui
-# alias
-make run-tui
-
-make run-tui TUI_ARGS='--preset testnet'
-make run-tui TUI_ARGS='--preset mainnet'
-```
-
-Writes stay off unless you pass `--enable-writes` and a secret key. Not part of the default SDK crate build or Hub images (unlike MCP).
-
-See [`examples/desktop/casperatatui/README.md`](../examples/desktop/casperatatui/README.md).
-
 ## Install
 
 <details>
@@ -389,6 +368,37 @@ print(sdk.get_rpc_address(), sdk.get_verbosity())
 Deploy APIs and binary-port are not wrapped. Transaction V1 and Runtime V1 / V2 are supported on the transaction / contract helpers.
 
 </details>
+
+## Python
+
+The workspace package [`python/`](../python/) (`casper-rust-wasm-sdk-py`) is a PyO3 / maturin extension over the same native Rust `rlib` (not a Python port).
+
+- Install / develop: see [Python Project](#python-project) under Install above, or [`python/README.md`](../python/README.md)
+- CI: path-filtered `python-bindings` (offline unit + Hub NCTL `:dev`)
+- Make: `make python-test`, `make python-test-nctl`
+
+Initial face: [#117](https://github.com/casper-ecosystem/casper-rust-wasm-sdk/pull/117). Parity waves 1–4: [#121](https://github.com/casper-ecosystem/casper-rust-wasm-sdk/pull/121) (closes [#120](https://github.com/casper-ecosystem/casper-rust-wasm-sdk/issues/120)). Epic [#9](https://github.com/casper-ecosystem/casper-rust-wasm-sdk/issues/9) is **closed**. Deploy APIs, binary-port, and PyPI publish remain out of that epic.
+
+## Casperatatui
+
+**Casperatatui** is a Casper TUI (terminal UI) based on [ratatui](https://ratatui.rs/), over the native Rust SDK. JSON-RPC and SSE only (no binary port).
+
+- Source: [`examples/desktop/casperatatui`](../examples/desktop/casperatatui)
+- Issue: [#123](https://github.com/casper-ecosystem/casper-rust-wasm-sdk/issues/123)
+- GitHub Releases / Pre-release [`dev-preview`](https://github.com/casper-ecosystem/casper-rust-wasm-sdk/releases): linux binary `casperatatui-<label>-linux-x86_64`
+
+```bash
+make run-casperatatui
+# alias
+make run-tui
+
+make run-tui TUI_ARGS='--preset testnet'
+make run-tui TUI_ARGS='--preset mainnet'
+```
+
+Writes stay off unless you pass `--enable-writes` and a secret key. Not part of the default SDK crate build or Hub images (unlike MCP).
+
+See [`examples/desktop/casperatatui/README.md`](../examples/desktop/casperatatui/README.md).
 
 ## Usage
 
@@ -2862,9 +2872,12 @@ SECRET_KEY_NCTL_PATH=/casper/casper-nctl-2-docker/assets/users/user-1/
 
 Open tracking (not a full roadmap):
 
-- [#9](https://github.com/casper-ecosystem/casper-rust-wasm-sdk/issues/9): Python / PyO3 bindings (initial face in [`python/`](../python/); expand surface)
 - [#36](https://github.com/casper-ecosystem/casper-rust-wasm-sdk/issues/36) — first crates.io publish
 - [#96](https://github.com/casper-ecosystem/casper-rust-wasm-sdk/issues/96) — explainer for node core: AE-off `entity-contract-…` vs `hash-…` on `query_global_state` (SDK remaps; permanent fix is upstream)
+- [#118](https://github.com/casper-ecosystem/casper-rust-wasm-sdk/issues/118) — C bindings (cdylib / cbindgen)
+- [#119](https://github.com/casper-ecosystem/casper-rust-wasm-sdk/issues/119) — Go bindings (cgo / native)
+
+Done (removed from this list): [#9](https://github.com/casper-ecosystem/casper-rust-wasm-sdk/issues/9) Python / PyO3 face + parity ([#117](https://github.com/casper-ecosystem/casper-rust-wasm-sdk/pull/117), [#121](https://github.com/casper-ecosystem/casper-rust-wasm-sdk/pull/121)). See [Python](#python).
 
 Mac desktop Electron build is still TODO (Windows / Linux demos ship on releases).
 


### PR DESCRIPTION
## Summary
- Move **Python** and **Casperatatui** discovery sections to sit below Install (language blocks) and above the main Usage / RPC examples.
- Add a top-level **Python** section that matches closed epic [#9](https://github.com/casper-ecosystem/casper-rust-wasm-sdk/issues/9) ([#117](https://github.com/casper-ecosystem/casper-rust-wasm-sdk/pull/117) / [#121](https://github.com/casper-ecosystem/casper-rust-wasm-sdk/pull/121)).
- Refresh **Todo**: remove stale open #9; keep #36 / #96; list open C/Go binding issues #118 / #119.

## Test plan
- [ ] Skim `docs/README.md` heading order: Try → MCP → Install → Python → Casperatatui → Usage → … → Todo
- [ ] Confirm `#python` / `#casperatatui` anchors resolve from Rust API / Electron cross-links
- [ ] Confirm Todo no longer presents #9 as unfinished work


Made with [Cursor](https://cursor.com)