### PR TITLE
fix(docker): COPY tauri member for MCP/Hub image builds

### DIFF
--- a/docker/Dockerfile.cicd
+++ b/docker/Dockerfile.cicd
@@ -14,11 +14,13 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /src
-# Workspace members: ., mcp, casperatatui (+ sdk_tests path-dep). Do not COPY python/.
+# Workspace members: ., mcp, casperatatui, tauri/src-tauri (+ sdk_tests path-dep).
+# Do not COPY python/.
 COPY Cargo.toml Cargo.lock ./
 COPY src ./src
 COPY mcp ./mcp
 COPY examples/desktop/casperatatui ./examples/desktop/casperatatui
+COPY examples/desktop/tauri/src-tauri ./examples/desktop/tauri/src-tauri
 COPY tests/integration/rust ./tests/integration/rust
 
 RUN cargo build -p casper-rust-wasm-sdk-mcp --release \

--- a/mcp/Dockerfile
+++ b/mcp/Dockerfile
@@ -18,11 +18,13 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /src
-# Workspace members: ., mcp, casperatatui (+ sdk_tests path-dep). Do not COPY python/.
+# Workspace members: ., mcp, casperatatui, tauri/src-tauri (+ sdk_tests path-dep).
+# Do not COPY python/.
 COPY Cargo.toml Cargo.lock ./
 COPY src ./src
 COPY mcp ./mcp
 COPY examples/desktop/casperatatui ./examples/desktop/casperatatui
+COPY examples/desktop/tauri/src-tauri ./examples/desktop/tauri/src-tauri
 COPY tests/integration/rust ./tests/integration/rust
 
 RUN cargo build -p casper-rust-wasm-sdk-mcp --release \


### PR DESCRIPTION
## Summary
Fixes Hub / webclient MCP Docker builds after [#129](https://github.com/casper-ecosystem/casper-rust-wasm-sdk/pull/129): workspace lists `examples/desktop/tauri/src-tauri`, but `mcp/Dockerfile` and `docker/Dockerfile.cicd` only copied casperatatui.

Closes nothing new; unblocks `hub-images-dev` (cargo: missing workspace member Cargo.toml).

## Test plan
- [ ] `docker build -f mcp/Dockerfile -t casper-rust-wasm-sdk-mcp:local .` gets past workspace load (or Hub workflow green)
- [ ] Confirm `docker/Dockerfile.cicd` mcp-builder stage same


Made with [Cursor](https://cursor.com)