### PR TITLE
feat: gate wasm-bindgen behind Cargo feature js

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -102,12 +102,15 @@ jobs:
       - name: Lint
         run: make check-lint
 
-      - name: Feature matrix (read-only + transaction-without-deploy)
+      - name: Feature matrix (js on/off, ceps shape, packs)
         run: |
           cargo check --lib --no-default-features
           cargo check --lib --no-default-features --features transaction,helpers,watcher
-          cargo check --lib --no-default-features --features transaction,helpers,SSE
+          cargo check --lib --no-default-features --features transaction,helpers,watcher,SSE
           cargo check --lib --target wasm32-unknown-unknown --no-default-features
+          cargo check --lib --target wasm32-unknown-unknown --no-default-features --features transaction,helpers,watcher,SSE
+          cargo check --lib --target wasm32-unknown-unknown --no-default-features --features js
+          cargo check --lib --target wasm32-unknown-unknown --no-default-features --features transaction,helpers,watcher,js
           cargo check --lib --target wasm32-unknown-unknown
 
       - name: Unit Tests

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,8 +37,9 @@ exclude = [
 ]
 
 [features]
-default = ["full"]
+default = ["full", "js"]
 # Convenience bundle (not a product gate). Includes `watcher`, not full `SSE`.
+# Domain slice only: `js` is intentionally not part of `full`.
 full = [
   "transaction",
   "deploy",
@@ -46,6 +47,13 @@ full = [
   "binary-port",
   "watcher",
   "helpers",
+]
+# wasm-bindgen / js-sys surface for SDK packs. Omit for Rust-only consumers.
+js = [
+  "dep:wasm-bindgen",
+  "dep:wasm-bindgen-futures",
+  "dep:js-sys",
+  "dep:gloo-utils",
 ]
 transaction = []
 deploy = []
@@ -67,13 +75,13 @@ casper-binary-port-access = { version = "0.1.0", optional = true }
 rand = { version = "0.9.2", default-features = false, features = [
   "thread_rng",
 ] }
-getrandom = { version = "0.3.3", default-features = false, features = [
-  "wasm_js",
+getrandom = { version = "0.3.3", default-features = false }
+wasm-bindgen = { version = "0.2.104", optional = true }
+wasm-bindgen-futures = { version = "*", optional = true }
+js-sys = { version = "*", optional = true }
+gloo-utils = { version = "0.2", optional = true, default-features = false, features = [
+  "serde",
 ] }
-wasm-bindgen = "0.2.104"
-wasm-bindgen-futures = "*"
-js-sys = "*"
-gloo-utils = { version = "0.2", default-features = false, features = ["serde"] }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_json = "1.0"
 once_cell = { version = "1", default-features = false }
@@ -91,6 +99,11 @@ reqwest = { version = "0.12.12", default-features = false, features = [
 ] }
 futures-util = "*"
 async-trait = "0.1"
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+getrandom = { version = "0.3.3", default-features = false, features = [
+  "wasm_js",
+] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio = { version = "1", default-features = false, features = ["time"] }

--- a/Makefile
+++ b/Makefile
@@ -7,11 +7,11 @@ CURRENT_DIR = .
 WEB_OUT_DIR = pkg
 NODEJS_OUT_DIR = pkg-nodejs
 
-# web-full / nodejs-full: default features plus SSE (SSEClient + CESParser).
-# Cargo `full` stays watcher-only for crate consumers; packs express the full SDK.
+# web-full / nodejs-full: default features (includes `js`) plus SSE.
+# Cargo `full` stays domain-only (no `js`) for Rust consumers; packs keep `js` on.
 WASM_FEATURES_FULL = --features SSE
-WASM_FEATURES_READ_ONLY = --no-default-features
-WASM_FEATURES_TRANSACTION = --no-default-features --features transaction,helpers,watcher
+WASM_FEATURES_READ_ONLY = --no-default-features --features js
+WASM_FEATURES_TRANSACTION = --no-default-features --features transaction,helpers,watcher,js
 
 # Pin Binaryen so wasm-pack does not fall back to its vendored 117 download.
 BINARYEN_VERSION := 130
@@ -115,8 +115,13 @@ lint: format clippy
 clippy:
 	cargo clippy --target wasm32-unknown-unknown --bins --fix --allow-dirty --allow-staged -- -D warnings
 	cargo clippy --lib -- -D warnings
+	cargo clippy --target wasm32-unknown-unknown --lib -- -D warnings
 	cargo clippy --no-default-features --lib -- -D warnings
+	cargo clippy --target wasm32-unknown-unknown --no-default-features --lib -- -D warnings
+	cargo clippy --target wasm32-unknown-unknown --no-default-features --features transaction,helpers,watcher,SSE --lib -- -D warnings
+	cargo clippy --target wasm32-unknown-unknown --no-default-features --features js --lib -- -D warnings
 	cargo clippy --no-default-features --features transaction,helpers --lib -- -D warnings
+	cargo clippy --target wasm32-unknown-unknown --no-default-features --features transaction,helpers,watcher,js --lib -- -D warnings
 
 check-lint: clippy
 	cargo fmt -- --check

--- a/docs/README.md
+++ b/docs/README.md
@@ -101,17 +101,17 @@ This will create a `pkg` and `pkg-nodejs` containing the Typescript interfaces. 
 
 ### Cargo features
 
-Default is `full` (today's API) for both the wasm package and the Rust `rlib`. Slim builds drop optional surfaces:
+Default is `full` + `js` (today's JS/wasm API) for both the wasm package and the Rust `rlib`. Slim builds drop optional surfaces. Omit `js` for Rust-only consumers so wasm-bindgen exports are not linked into a foreign pack.
 
-| Profile                 | Make target                | Cargo flags                                                    |
-| ----------------------- | -------------------------- | -------------------------------------------------------------- |
-| full + SSE (wasm packs) | `make web` / `make nodejs` | default features + `--features SSE` (SSEClient + CESParser)    |
-| read-only               | `make web-read-only`       | `--no-default-features`                                        |
-| transaction (no deploy) | `make web-transaction`     | `--no-default-features --features transaction,helpers,watcher` |
+| Profile                 | Make target                | Cargo flags                                                              |
+| ----------------------- | -------------------------- | ------------------------------------------------------------------------ |
+| full + SSE (wasm packs) | `make web` / `make nodejs` | default features + `--features SSE` (SSEClient + CESParser; `js` on)     |
+| read-only               | `make web-read-only`       | `--no-default-features --features js`                                    |
+| transaction (no deploy) | `make web-transaction`     | `--no-default-features --features transaction,helpers,watcher,js`        |
 
-Optional features: `transaction`, `deploy`, `contract`, `binary-port`, `watcher` (wait/watch), `SSE` (node SSE client + CES; enables `watcher`), `helpers`. Core JSON-RPC reads stay available without them. `binary-port` pulls optional `casper-binary-port*` crates.
+Optional features: `js` (wasm-bindgen / js-sys surface; default on), `transaction`, `deploy`, `contract`, `binary-port`, `watcher` (wait/watch), `SSE` (node SSE client + CES; enables `watcher`), `helpers`. Core JSON-RPC reads stay available without them. `binary-port` pulls optional `casper-binary-port*` crates. Domain feature `full` does not include `js`.
 
-Cargo crate `default`/`full` includes `watcher` only. Browser `pkg` and Node `pkg-nodejs` packs from `make web` / `make nodejs` also enable `SSE` so demos and e2e harnesses get the full SDK surface.
+Cargo crate `default` includes `full` and `js`. Browser `pkg` and Node `pkg-nodejs` packs from `make web` / `make nodejs` also enable `SSE` so demos and e2e harnesses get the full SDK surface. A dependent crate's own wasm-pack must not enable this SDK's `js` feature if it wants a private export surface (no SDK `SDK` / `Key` / `Transaction` classes in its `.d.ts`).
 
 This folder contains a Wasm binary, a JS wrapper file, Typescript types definitions, and a package.json file that you can load in your project.
 

--- a/src/helpers/mod.rs
+++ b/src/helpers/mod.rs
@@ -15,12 +15,12 @@ use casper_types::{
     TimeDiff, Timestamp,
 };
 use chrono::{DateTime, SecondsFormat, Utc};
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use gloo_utils::format::JsValueSerdeExt;
 use serde::Serialize;
 use serde_json::Value;
 use std::str::FromStr;
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use wasm_bindgen::{JsCast, JsValue};
 
 pub const BLAKE2B_DIGEST_LENGTH: usize = 32;
@@ -468,7 +468,7 @@ where
 /// # Returns
 ///
 /// The modified `RuntimeArgs` map.
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 pub fn insert_js_value_arg(
     args: &mut RuntimeArgs,
     js_value_arg: JsValue,

--- a/src/js/externs.rs
+++ b/src/js/externs.rs
@@ -1,4 +1,6 @@
+#[cfg(feature = "js")]
 use js_sys::Promise;
+#[cfg(feature = "js")]
 use wasm_bindgen::prelude::*;
 
 /// Logs a message, prefixing it with "log wasm" and sends it to the console in JavaScript when running in a WebAssembly environment.
@@ -13,7 +15,7 @@ extern "C" {
 /// When running outside WebAssembly, it prints the message to the standard output.
 pub fn log(s: &str) {
     let prefixed_s = format!("log wasm {s}");
-    #[cfg(target_arch = "wasm32")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
     log_with_prefix(&prefixed_s);
     #[cfg(not(target_arch = "wasm32"))]
     println!("{prefixed_s}");
@@ -31,7 +33,7 @@ extern "C" {
 /// When running outside WebAssembly, it prints the error message to the standard output.
 pub fn error(s: &str) {
     let prefixed_s = format!("error wasm {s}");
-    #[cfg(target_arch = "wasm32")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
     error_with_prefix(&prefixed_s);
     #[cfg(not(target_arch = "wasm32"))]
     println!("{prefixed_s}");

--- a/src/js/interns.rs
+++ b/src/js/interns.rs
@@ -10,7 +10,9 @@ use crate::{
     types::verbosity::Verbosity,
 };
 use casper_types::U256;
+#[cfg(feature = "js")]
 use gloo_utils::format::JsValueSerdeExt;
+#[cfg(feature = "js")]
 use wasm_bindgen::prelude::*;
 
 /// Converts a hexadecimal string to a regular string.

--- a/src/js/mod.rs
+++ b/src/js/mod.rs
@@ -1,5 +1,5 @@
 pub mod externs;
-#[cfg(all(target_arch = "wasm32", feature = "helpers"))]
+#[cfg(all(feature = "js", target_arch = "wasm32", feature = "helpers"))]
 pub mod interns;
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 pub mod wallet;

--- a/src/js/wallet.rs
+++ b/src/js/wallet.rs
@@ -5,8 +5,11 @@ use crate::{
         wallet::signature_response::SignatureResponse,
     },
 };
+#[cfg(feature = "js")]
 use gloo_utils::format::JsValueSerdeExt;
+#[cfg(feature = "js")]
 use wasm_bindgen::prelude::*;
+#[cfg(feature = "js")]
 use wasm_bindgen_futures::JsFuture;
 
 #[wasm_bindgen]
@@ -358,6 +361,7 @@ impl CasperWallet {
         Ok(true)
     }
 
+    #[cfg(feature = "js")]
     async fn get_public_or_active_key(
         &self,
         provided_public_key: Option<String>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,5 +4,19 @@ pub mod types;
 pub(crate) mod sdk;
 pub use sdk::*;
 
+#[cfg(feature = "js")]
 pub(crate) mod js;
+#[cfg(feature = "js")]
 pub use js::externs as debug;
+
+/// Native log/error when the `js` feature (and `js::externs`) is off.
+#[cfg(not(feature = "js"))]
+pub(crate) mod debug {
+    pub fn log(s: &str) {
+        println!("log wasm {s}");
+    }
+
+    pub fn error(s: &str) {
+        println!("error wasm {s}");
+    }
+}

--- a/src/sdk/binary_port/mod.rs
+++ b/src/sdk/binary_port/mod.rs
@@ -22,6 +22,7 @@ use casper_types::{
     Transaction, TransactionHash,
 };
 
+#[cfg(feature = "js")]
 pub mod wasm32;
 
 impl SDK {

--- a/src/sdk/binary_port/wasm32.rs
+++ b/src/sdk/binary_port/wasm32.rs
@@ -1,4 +1,4 @@
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use crate::{
     types::{
         digest::Digest,
@@ -12,15 +12,19 @@ use crate::{
     },
     SDK,
 };
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use gloo_utils::format::JsValueSerdeExt;
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use wasm_bindgen::prelude::*;
 
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl SDK {
-    #[wasm_bindgen(js_name = "get_binary_latest_switch_block_header")]
+    #[cfg_attr(
+        feature = "js",
+        wasm_bindgen(js_name = "get_binary_latest_switch_block_header")
+    )]
+    #[cfg(feature = "js")]
     pub async fn get_binary_latest_switch_block_header_js_alias(
         &self,
         node_address: Option<String>,
@@ -34,7 +38,11 @@ impl SDK {
             .map_err(|err| JsError::new(&format!("Error occurred: {err:?}")))
     }
 
-    #[wasm_bindgen(js_name = "get_binary_latest_block_header")]
+    #[cfg_attr(
+        feature = "js",
+        wasm_bindgen(js_name = "get_binary_latest_block_header")
+    )]
+    #[cfg(feature = "js")]
     pub async fn get_binary_latest_block_header_js_alias(
         &self,
         node_address: Option<String>,
@@ -45,7 +53,11 @@ impl SDK {
             .map_err(|err| JsError::new(&format!("Error occurred: {err:?}")))
     }
 
-    #[wasm_bindgen(js_name = "get_binary_block_header_by_height")]
+    #[cfg_attr(
+        feature = "js",
+        wasm_bindgen(js_name = "get_binary_block_header_by_height")
+    )]
+    #[cfg(feature = "js")]
     pub async fn get_binary_block_header_by_height_js_alias(
         &self,
         height: u64,
@@ -59,7 +71,11 @@ impl SDK {
             .map_err(|err| JsError::new(&format!("Error occurred: {err:?}")))
     }
 
-    #[wasm_bindgen(js_name = "get_binary_block_header_by_hash")]
+    #[cfg_attr(
+        feature = "js",
+        wasm_bindgen(js_name = "get_binary_block_header_by_hash")
+    )]
+    #[cfg(feature = "js")]
     pub async fn get_binary_block_header_by_hash_js_alias(
         &self,
         block_hash: BlockHash,
@@ -73,7 +89,11 @@ impl SDK {
             .map_err(|err| JsError::new(&format!("Error occurred: {err:?}")))
     }
 
-    #[wasm_bindgen(js_name = "get_binary_latest_block_with_signatures")]
+    #[cfg_attr(
+        feature = "js",
+        wasm_bindgen(js_name = "get_binary_latest_block_with_signatures")
+    )]
+    #[cfg(feature = "js")]
     pub async fn get_binary_latest_block_with_signatures_js_alias(
         &self,
         node_address: Option<String>,
@@ -86,7 +106,11 @@ impl SDK {
             .map_err(|err| JsError::new(&format!("Error occurred: {err:?}")))
     }
 
-    #[wasm_bindgen(js_name = "get_binary_block_with_signatures_by_height")]
+    #[cfg_attr(
+        feature = "js",
+        wasm_bindgen(js_name = "get_binary_block_with_signatures_by_height")
+    )]
+    #[cfg(feature = "js")]
     pub async fn get_binary_block_with_signatures_by_height_js_alias(
         &self,
         height: u64,
@@ -100,7 +124,11 @@ impl SDK {
             .map_err(|err| JsError::new(&format!("Error occurred: {err:?}")))
     }
 
-    #[wasm_bindgen(js_name = "get_binary_block_with_signatures_by_hash")]
+    #[cfg_attr(
+        feature = "js",
+        wasm_bindgen(js_name = "get_binary_block_with_signatures_by_hash")
+    )]
+    #[cfg(feature = "js")]
     pub async fn get_binary_block_with_signatures_by_hash_js_alias(
         &self,
         block_hash: BlockHash,
@@ -114,7 +142,11 @@ impl SDK {
             .map_err(|err| JsError::new(&format!("Error occurred: {err:?}")))
     }
 
-    #[wasm_bindgen(js_name = "get_binary_transaction_by_hash")]
+    #[cfg_attr(
+        feature = "js",
+        wasm_bindgen(js_name = "get_binary_transaction_by_hash")
+    )]
+    #[cfg(feature = "js")]
     pub async fn get_binary_transaction_by_hash_js_alias(
         &self,
         hash: TransactionHash,
@@ -129,7 +161,8 @@ impl SDK {
             .map_err(|err| JsError::new(&format!("Error occurred: {err:?}")))
     }
 
-    #[wasm_bindgen(js_name = "get_binary_peers")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "get_binary_peers"))]
+    #[cfg(feature = "js")]
     pub async fn get_binary_peers_js_alias(
         &self,
         node_address: Option<String>,
@@ -140,7 +173,8 @@ impl SDK {
             .map_err(|err| JsError::new(&format!("Error occurred: {err:?}")))
     }
 
-    #[wasm_bindgen(js_name = "get_binary_uptime")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "get_binary_uptime"))]
+    #[cfg(feature = "js")]
     pub async fn get_binary_uptime_js_alias(
         &self,
         node_address: Option<String>,
@@ -151,7 +185,8 @@ impl SDK {
             .map_err(|err| JsError::new(&format!("Error occurred: {err:?}")))
     }
 
-    #[wasm_bindgen(js_name = "get_binary_last_progress")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "get_binary_last_progress"))]
+    #[cfg(feature = "js")]
     pub async fn get_binary_last_progress_js_alias(
         &self,
         node_address: Option<String>,
@@ -162,7 +197,8 @@ impl SDK {
             .map_err(|err| JsError::new(&format!("Error occurred: {err:?}")))
     }
 
-    #[wasm_bindgen(js_name = "get_binary_reactor_state")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "get_binary_reactor_state"))]
+    #[cfg(feature = "js")]
     pub async fn get_binary_reactor_state_js_alias(
         &self,
         node_address: Option<String>,
@@ -173,7 +209,8 @@ impl SDK {
             .map_err(|err| JsError::new(&format!("Error occurred: {err:?}")))
     }
 
-    #[wasm_bindgen(js_name = "get_binary_network_name")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "get_binary_network_name"))]
+    #[cfg(feature = "js")]
     pub async fn get_binary_network_name_js_alias(
         &self,
         node_address: Option<String>,
@@ -184,7 +221,11 @@ impl SDK {
             .map_err(|err| JsError::new(&format!("Error occurred: {err:?}")))
     }
 
-    #[wasm_bindgen(js_name = "get_binary_consensus_validator_changes")]
+    #[cfg_attr(
+        feature = "js",
+        wasm_bindgen(js_name = "get_binary_consensus_validator_changes")
+    )]
+    #[cfg(feature = "js")]
     pub async fn get_binary_consensus_validator_changes_js_alias(
         &self,
         node_address: Option<String>,
@@ -197,7 +238,11 @@ impl SDK {
             .map_err(|err| JsError::new(&format!("Error occurred: {err:?}")))
     }
 
-    #[wasm_bindgen(js_name = "get_binary_block_synchronizer_status")]
+    #[cfg_attr(
+        feature = "js",
+        wasm_bindgen(js_name = "get_binary_block_synchronizer_status")
+    )]
+    #[cfg(feature = "js")]
     pub async fn get_binary_block_synchronizer_status_js_alias(
         &self,
         node_address: Option<String>,
@@ -210,7 +255,11 @@ impl SDK {
             .map_err(|err| JsError::new(&format!("Error occurred: {err:?}")))
     }
 
-    #[wasm_bindgen(js_name = "get_binary_available_block_range")]
+    #[cfg_attr(
+        feature = "js",
+        wasm_bindgen(js_name = "get_binary_available_block_range")
+    )]
+    #[cfg(feature = "js")]
     pub async fn get_binary_available_block_range_js_alias(
         &self,
         node_address: Option<String>,
@@ -221,7 +270,8 @@ impl SDK {
             .map_err(|err| JsError::new(&format!("Error occurred: {err:?}")))
     }
 
-    #[wasm_bindgen(js_name = "get_binary_next_upgrade")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "get_binary_next_upgrade"))]
+    #[cfg(feature = "js")]
     pub async fn get_binary_next_upgrade_js_alias(
         &self,
         node_address: Option<String>,
@@ -232,7 +282,8 @@ impl SDK {
             .map_err(|err| JsError::new(&format!("Error occurred: {err:?}")))
     }
 
-    #[wasm_bindgen(js_name = "get_binary_consensus_status")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "get_binary_consensus_status"))]
+    #[cfg(feature = "js")]
     pub async fn get_binary_consensus_status_js_alias(
         &self,
         node_address: Option<String>,
@@ -243,7 +294,11 @@ impl SDK {
             .map_err(|err| JsError::new(&format!("Error occurred: {err:?}")))
     }
 
-    #[wasm_bindgen(js_name = "get_binary_chainspec_raw_bytes")]
+    #[cfg_attr(
+        feature = "js",
+        wasm_bindgen(js_name = "get_binary_chainspec_raw_bytes")
+    )]
+    #[cfg(feature = "js")]
     pub async fn get_binary_chainspec_raw_bytes_js_alias(
         &self,
         node_address: Option<String>,
@@ -254,7 +309,8 @@ impl SDK {
             .map_err(|err| JsError::new(&format!("Error occurred: {err:?}")))
     }
 
-    #[wasm_bindgen(js_name = "get_binary_node_status")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "get_binary_node_status"))]
+    #[cfg(feature = "js")]
     pub async fn get_binary_node_status_js_alias(
         &self,
         node_address: Option<String>,
@@ -265,7 +321,11 @@ impl SDK {
             .map_err(|err| JsError::new(&format!("Error occurred: {err:?}")))
     }
 
-    #[wasm_bindgen(js_name = "get_binary_validator_reward_by_era")]
+    #[cfg_attr(
+        feature = "js",
+        wasm_bindgen(js_name = "get_binary_validator_reward_by_era")
+    )]
+    #[cfg(feature = "js")]
     pub async fn get_binary_validator_reward_by_era_js_alias(
         &self,
         validator_key: PublicKey,
@@ -280,7 +340,11 @@ impl SDK {
             .map_err(|err| JsError::new(&format!("Error occurred: {err:?}")))
     }
 
-    #[wasm_bindgen(js_name = "get_binary_validator_reward_by_block_height")]
+    #[cfg_attr(
+        feature = "js",
+        wasm_bindgen(js_name = "get_binary_validator_reward_by_block_height")
+    )]
+    #[cfg(feature = "js")]
     pub async fn get_binary_validator_reward_by_block_height_js_alias(
         &self,
         validator_key: PublicKey,
@@ -299,7 +363,11 @@ impl SDK {
             .map_err(|err| JsError::new(&format!("Error occurred: {err:?}")))
     }
 
-    #[wasm_bindgen(js_name = "get_binary_validator_reward_by_block_hash")]
+    #[cfg_attr(
+        feature = "js",
+        wasm_bindgen(js_name = "get_binary_validator_reward_by_block_hash")
+    )]
+    #[cfg(feature = "js")]
     pub async fn get_binary_validator_reward_by_block_hash_js_alias(
         &self,
         validator_key: PublicKey,
@@ -318,7 +386,11 @@ impl SDK {
             .map_err(|err| JsError::new(&format!("Error occurred: {err:?}")))
     }
 
-    #[wasm_bindgen(js_name = "get_binary_delegator_reward_by_era")]
+    #[cfg_attr(
+        feature = "js",
+        wasm_bindgen(js_name = "get_binary_delegator_reward_by_era")
+    )]
+    #[cfg(feature = "js")]
     pub async fn get_binary_delegator_reward_by_era_js_alias(
         &self,
         validator_key: PublicKey,
@@ -339,7 +411,11 @@ impl SDK {
             .map_err(|err| JsError::new(&format!("Error occurred: {err:?}")))
     }
 
-    #[wasm_bindgen(js_name = "get_binary_delegator_reward_by_block_height")]
+    #[cfg_attr(
+        feature = "js",
+        wasm_bindgen(js_name = "get_binary_delegator_reward_by_block_height")
+    )]
+    #[cfg(feature = "js")]
     pub async fn get_binary_delegator_reward_by_block_height_js_alias(
         &self,
         validator_key: PublicKey,
@@ -360,7 +436,11 @@ impl SDK {
             .map_err(|err| JsError::new(&format!("Error occurred: {err:?}")))
     }
 
-    #[wasm_bindgen(js_name = "get_binary_delegator_reward_by_block_hash")]
+    #[cfg_attr(
+        feature = "js",
+        wasm_bindgen(js_name = "get_binary_delegator_reward_by_block_hash")
+    )]
+    #[cfg(feature = "js")]
     pub async fn get_binary_delegator_reward_by_block_hash_js_alias(
         &self,
         validator_key: PublicKey,
@@ -381,7 +461,8 @@ impl SDK {
             .map_err(|err| JsError::new(&format!("Error occurred: {err:?}")))
     }
 
-    #[wasm_bindgen(js_name = "get_binary_read_record")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "get_binary_read_record"))]
+    #[cfg(feature = "js")]
     pub async fn get_binary_read_record_js_alias(
         &self,
         record_id: RecordId,
@@ -396,7 +477,8 @@ impl SDK {
             .map_err(|err| JsError::new(&format!("Error occurred: {err:?}")))
     }
 
-    #[wasm_bindgen(js_name = "get_binary_global_state_item")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "get_binary_global_state_item"))]
+    #[cfg(feature = "js")]
     pub async fn get_binary_global_state_item_js_alias(
         &self,
         key: Key,
@@ -411,7 +493,11 @@ impl SDK {
             .map_err(|err| JsError::new(&format!("Error occurred: {err:?}")))
     }
 
-    #[wasm_bindgen(js_name = "get_binary_global_state_item_by_state_root_hash")]
+    #[cfg_attr(
+        feature = "js",
+        wasm_bindgen(js_name = "get_binary_global_state_item_by_state_root_hash")
+    )]
+    #[cfg(feature = "js")]
     pub async fn get_binary_global_state_item_by_state_root_hash_js_alias(
         &self,
         state_root_hash: Digest,
@@ -432,7 +518,11 @@ impl SDK {
             .map_err(|err| JsError::new(&format!("Error occurred: {err:?}")))
     }
 
-    #[wasm_bindgen(js_name = "get_binary_global_state_item_by_block_hash")]
+    #[cfg_attr(
+        feature = "js",
+        wasm_bindgen(js_name = "get_binary_global_state_item_by_block_hash")
+    )]
+    #[cfg(feature = "js")]
     pub async fn get_binary_global_state_item_by_block_hash_js_alias(
         &self,
         block_hash: BlockHash,
@@ -453,7 +543,11 @@ impl SDK {
             .map_err(|err| JsError::new(&format!("Error occurred: {err:?}")))
     }
 
-    #[wasm_bindgen(js_name = "get_binary_global_state_item_by_block_height")]
+    #[cfg_attr(
+        feature = "js",
+        wasm_bindgen(js_name = "get_binary_global_state_item_by_block_height")
+    )]
+    #[cfg(feature = "js")]
     pub async fn get_binary_global_state_item_by_block_height_js_alias(
         &self,
         block_height: u64,
@@ -474,7 +568,11 @@ impl SDK {
             .map_err(|err| JsError::new(&format!("Error occurred: {err:?}")))
     }
 
-    #[wasm_bindgen(js_name = "get_binary_try_accept_transaction")]
+    #[cfg_attr(
+        feature = "js",
+        wasm_bindgen(js_name = "get_binary_try_accept_transaction")
+    )]
+    #[cfg(feature = "js")]
     pub async fn get_binary_try_accept_transaction_js_alias(
         &self,
         transaction: Transaction,
@@ -490,7 +588,11 @@ impl SDK {
         }
     }
 
-    #[wasm_bindgen(js_name = "get_binary_try_speculative_execution")]
+    #[cfg_attr(
+        feature = "js",
+        wasm_bindgen(js_name = "get_binary_try_speculative_execution")
+    )]
+    #[cfg(feature = "js")]
     pub async fn get_binary_try_speculative_execution_js_alias(
         &self,
         transaction: Transaction,
@@ -504,7 +606,8 @@ impl SDK {
             .map_err(|err| JsError::new(&format!("Error occurred: {err:?}")))
     }
 
-    #[wasm_bindgen(js_name = "get_binary_protocol_version")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "get_binary_protocol_version"))]
+    #[cfg(feature = "js")]
     pub async fn get_binary_protocol_version_js_alias(
         &self,
         node_address: Option<String>,

--- a/src/sdk/contract/call_entrypoint.rs
+++ b/src/sdk/contract/call_entrypoint.rs
@@ -1,4 +1,4 @@
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use crate::transaction::transaction::PutTransactionResult;
 use crate::{
     types::{
@@ -13,12 +13,12 @@ use crate::{
 use casper_client::{
     rpcs::results::PutTransactionResult as _PutTransactionResult, SuccessResponse,
 };
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use wasm_bindgen::prelude::*;
 
 /// A set of functions for working with smart contract entry points.
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl SDK {
     /// Calls a smart contract entry point with the specified parameters and returns the result.
     ///
@@ -35,7 +35,8 @@ impl SDK {
     /// # Errors
     ///
     /// Returns a `JsError` if there is an error during the call.
-    #[wasm_bindgen(js_name = "call_entrypoint")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "call_entrypoint"))]
+    #[cfg(feature = "js")]
     pub async fn call_entrypoint_js_alias(
         &self,
         builder_params: TransactionBuilderParams,

--- a/src/sdk/contract/call_entrypoint_deploy.rs
+++ b/src/sdk/contract/call_entrypoint_deploy.rs
@@ -1,6 +1,6 @@
 #![allow(deprecated)]
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use crate::deploy::deploy::PutDeployResult;
 use crate::types::deploy_params::{
     deploy_str_params::{deploy_str_params_to_casper_client, DeployStrParams},
@@ -11,12 +11,12 @@ use crate::{types::sdk_error::SdkError, SDK};
 use casper_client::{
     cli::deploy::make_deploy, rpcs::results::PutDeployResult as _PutDeployResult, SuccessResponse,
 };
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use wasm_bindgen::prelude::*;
 
 /// A set of functions for working with smart contract entry points.
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl SDK {
     /// Calls a smart contract entry point with the specified parameters and returns the result.
     ///
@@ -34,9 +34,10 @@ impl SDK {
     /// # Errors
     ///
     /// Returns a `JsError` if there is an error during the call.
-    #[wasm_bindgen(js_name = "call_entrypoint_deploy")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "call_entrypoint_deploy"))]
     #[deprecated(note = "prefer 'call_entrypoint' with transaction")]
     #[allow(deprecated)]
+    #[cfg(feature = "js")]
     pub async fn call_entrypoint_deploy_js_alias(
         &self,
         deploy_params: DeployStrParams,

--- a/src/sdk/contract/install.rs
+++ b/src/sdk/contract/install.rs
@@ -1,4 +1,4 @@
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use crate::transaction::transaction::PutTransactionResult;
 use crate::{
     types::{
@@ -14,12 +14,12 @@ use crate::{
 use casper_client::{
     rpcs::results::PutTransactionResult as _PutTransactionResult, SuccessResponse,
 };
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use wasm_bindgen::prelude::*;
 
 /// A set of functions for installing smart contracts on the blockchain.
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl SDK {
     /// Installs a smart contract with the specified parameters and returns the result.
     ///
@@ -36,7 +36,8 @@ impl SDK {
     /// # Errors
     ///
     /// Returns a `JsError` if there is an error during the installation.
-    #[wasm_bindgen(js_name = "install")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "install"))]
+    #[cfg(feature = "js")]
     pub async fn install_js_alias(
         &self,
         transaction_params: TransactionStrParams,

--- a/src/sdk/contract/install_deploy.rs
+++ b/src/sdk/contract/install_deploy.rs
@@ -1,6 +1,6 @@
 #![allow(deprecated)]
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use crate::deploy::deploy::PutDeployResult;
 use crate::types::deploy_params::{
     deploy_str_params::{deploy_str_params_to_casper_client, DeployStrParams},
@@ -11,12 +11,12 @@ use crate::{types::sdk_error::SdkError, SDK};
 use casper_client::{
     cli::deploy::make_deploy, rpcs::results::PutDeployResult as _PutDeployResult, SuccessResponse,
 };
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use wasm_bindgen::prelude::*;
 
 /// A set of functions for installing smart contracts on the blockchain.
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl SDK {
     /// Installs a smart contract with the specified parameters and returns the result.
     ///
@@ -34,9 +34,10 @@ impl SDK {
     /// # Errors
     ///
     /// Returns a `JsError` if there is an error during the installation.
-    #[wasm_bindgen(js_name = "install_deploy")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "install_deploy"))]
     #[deprecated(note = "prefer 'install' with transaction")]
     #[allow(deprecated)]
+    #[cfg(feature = "js")]
     pub async fn install_deploy_js_alias(
         &self,
         deploy_params: DeployStrParams,

--- a/src/sdk/contract/query_contract_dict.rs
+++ b/src/sdk/contract/query_contract_dict.rs
@@ -1,8 +1,8 @@
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use crate::rpcs::get_dictionary_item::GetDictionaryItemResult;
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use crate::types::digest::Digest;
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use crate::types::{
     deploy_params::dictionary_item_str_params::DictionaryItemStrParams,
     identifier::dictionary_item_identifier::DictionaryItemIdentifier,
@@ -15,16 +15,19 @@ use crate::{types::sdk_error::SdkError, SDK};
 use casper_client::{
     rpcs::results::GetDictionaryItemResult as _GetDictionaryItemResult, SuccessResponse,
 };
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use gloo_utils::format::JsValueSerdeExt;
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use serde::{Deserialize, Serialize};
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use wasm_bindgen::prelude::*;
 
 #[derive(Default, Debug, Deserialize, Clone, Serialize)]
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen(js_name = "queryContractDictOptions", getter_with_clone)]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
+#[cfg_attr(
+    feature = "js",
+    wasm_bindgen(js_name = "queryContractDictOptions", getter_with_clone)
+)]
 pub struct QueryContractDictOptions {
     // Not supported by get_dictionary_item
     // pub global_state_identifier: Option<GlobalStateIdentifier>,
@@ -36,11 +39,12 @@ pub struct QueryContractDictOptions {
     pub verbosity: Option<Verbosity>,
 }
 
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl SDK {
     /// Deserialize query_contract_dict_options from a JavaScript object.
-    #[wasm_bindgen(js_name = "query_contract_dict_options")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "query_contract_dict_options"))]
+    #[cfg(feature = "js")]
     pub fn query_contract_dict_state_options(
         &self,
         options: JsValue,
@@ -51,7 +55,8 @@ impl SDK {
     }
 
     /// JavaScript function for query_contract_dict with deserialized options.
-    #[wasm_bindgen(js_name = "query_contract_dict")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "query_contract_dict"))]
+    #[cfg(feature = "js")]
     pub async fn query_contract_dict_js_alias(
         &self,
         options: Option<QueryContractDictOptions>,

--- a/src/sdk/contract/query_contract_key.rs
+++ b/src/sdk/contract/query_contract_key.rs
@@ -1,6 +1,6 @@
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use crate::types::identifier::block_identifier::BlockIdentifier;
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use crate::{rpcs::query_global_state::QueryGlobalStateResult, types::path::Path};
 use crate::{
     rpcs::query_global_state::{KeyIdentifierInput, PathIdentifierInput, QueryGlobalStateParams},
@@ -14,16 +14,19 @@ use crate::{
 use casper_client::{
     rpcs::results::QueryGlobalStateResult as _QueryGlobalStateResult, SuccessResponse,
 };
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use gloo_utils::format::JsValueSerdeExt;
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use serde::{Deserialize, Serialize};
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use wasm_bindgen::prelude::*;
 
 #[derive(Deserialize, Default, Serialize)]
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen(js_name = "queryContractKeyOptions", getter_with_clone)]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
+#[cfg_attr(
+    feature = "js",
+    wasm_bindgen(js_name = "queryContractKeyOptions", getter_with_clone)
+)]
 pub struct QueryContractKeyOptions {
     pub entity_identifier: Option<EntityIdentifier>,
     pub entity_identifier_as_string: Option<String>,
@@ -35,11 +38,12 @@ pub struct QueryContractKeyOptions {
     pub verbosity: Option<Verbosity>,
 }
 
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl SDK {
     /// Deserialize query_contract_key_options from a JavaScript object.
-    #[wasm_bindgen(js_name = "query_contract_key_options")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "query_contract_key_options"))]
+    #[cfg(feature = "js")]
     pub fn query_contract_key_state_options(
         &self,
         options: JsValue,
@@ -50,7 +54,8 @@ impl SDK {
     }
 
     /// JavaScript function for query_contract_key with deserialized options.
-    #[wasm_bindgen(js_name = "query_contract_key")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "query_contract_key"))]
+    #[cfg(feature = "js")]
     pub async fn query_contract_key_js_alias(
         &self,
         options: Option<QueryContractKeyOptions>,

--- a/src/sdk/deploy/deploy.rs
+++ b/src/sdk/deploy/deploy.rs
@@ -1,4 +1,4 @@
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use crate::types::hash::deploy_hash::DeployHash;
 use crate::{
     types::{
@@ -15,27 +15,27 @@ use crate::{
 use casper_client::{
     cli::deploy::make_deploy, rpcs::results::PutDeployResult as _PutDeployResult, SuccessResponse,
 };
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use gloo_utils::format::JsValueSerdeExt;
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use serde::{Deserialize, Serialize};
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use wasm_bindgen::prelude::*;
 
 // Define a struct to wrap the result of a deploy.
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 #[derive(Debug, Deserialize, Clone, Serialize)]
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 pub struct PutDeployResult(_PutDeployResult);
 
 /// Implement conversions between PutDeployResult and _PutDeployResult.
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 impl From<PutDeployResult> for _PutDeployResult {
     fn from(result: PutDeployResult) -> Self {
         result.0
     }
 }
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 impl From<_PutDeployResult> for PutDeployResult {
     fn from(result: _PutDeployResult) -> Self {
         PutDeployResult(result)
@@ -43,30 +43,32 @@ impl From<_PutDeployResult> for PutDeployResult {
 }
 
 /// Implement JavaScript bindings for PutDeployResult.
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl PutDeployResult {
     /// Gets the API version as a JavaScript value.
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
+    #[cfg(feature = "js")]
     pub fn api_version(&self) -> JsValue {
         JsValue::from_serde(&self.0.api_version).unwrap()
     }
 
     /// Gets the deploy hash associated with this result.
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
     pub fn deploy_hash(&self) -> DeployHash {
         self.0.deploy_hash.into()
     }
 
     /// Converts PutDeployResult to a JavaScript object.
-    #[wasm_bindgen(js_name = "toJson")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "toJson"))]
+    #[cfg(feature = "js")]
     pub fn to_json(&self) -> JsValue {
         JsValue::from_serde(&self.0).unwrap_or(JsValue::null())
     }
 }
 
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl SDK {
     /// JavaScript function for deploying with deserialized parameters.
     ///
@@ -81,7 +83,8 @@ impl SDK {
     /// # Returns
     ///
     /// A result containing PutDeployResult or a JsError.
-    #[wasm_bindgen(js_name = "deploy")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "deploy"))]
+    #[cfg(feature = "js")]
     pub async fn deploy_js_alias(
         &self,
         deploy_params: DeployStrParams,

--- a/src/sdk/deploy/speculative_deploy.rs
+++ b/src/sdk/deploy/speculative_deploy.rs
@@ -1,4 +1,4 @@
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use crate::rpcs::speculative_exec_deploy::SpeculativeExecResult;
 use crate::{
     types::{
@@ -16,11 +16,11 @@ use casper_client::{
     cli::deploy::make_deploy, rpcs::results::SpeculativeExecResult as _SpeculativeExecResult,
     SuccessResponse,
 };
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use wasm_bindgen::prelude::*;
 
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl SDK {
     /// This function allows executing a deploy speculatively.
     ///
@@ -35,9 +35,10 @@ impl SDK {
     /// # Returns
     ///
     /// A `Result` containing either a `SpeculativeExecResult` or a `JsError` in case of an error.
-    #[wasm_bindgen(js_name = "speculative_deploy")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "speculative_deploy"))]
     #[allow(clippy::too_many_arguments, deprecated)]
     #[deprecated(note = "prefer speculative_transaction")]
+    #[cfg(feature = "js")]
     pub async fn speculative_deploy_js_alias(
         &self,
         deploy_params: DeployStrParams,

--- a/src/sdk/deploy/speculative_transfer.rs
+++ b/src/sdk/deploy/speculative_transfer.rs
@@ -1,4 +1,4 @@
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use crate::rpcs::speculative_exec_deploy::SpeculativeExecResult;
 use crate::{
     types::{
@@ -16,11 +16,11 @@ use casper_client::{
     SuccessResponse,
 };
 use rand::Rng;
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use wasm_bindgen::prelude::*;
 
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl SDK {
     /// JS function for speculative transfer.
     ///
@@ -37,9 +37,10 @@ impl SDK {
     /// # Returns
     ///
     /// A `Result` containing the result of the speculative transfer or a `JsError` in case of an error.
-    #[wasm_bindgen(js_name = "speculative_transfer")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "speculative_transfer"))]
     #[allow(clippy::too_many_arguments, deprecated)]
     #[deprecated(note = "prefer speculative_transfer_transaction")]
+    #[cfg(feature = "js")]
     pub async fn speculative_transfer_js_alias(
         &self,
         amount: &str,

--- a/src/sdk/deploy/transfer.rs
+++ b/src/sdk/deploy/transfer.rs
@@ -1,4 +1,4 @@
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use crate::deploy::deploy::PutDeployResult;
 use crate::{
     types::{
@@ -15,11 +15,11 @@ use casper_client::{
     cli::deploy::make_transfer, rpcs::results::PutDeployResult as _PutDeployResult, SuccessResponse,
 };
 use rand::Rng;
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use wasm_bindgen::prelude::*;
 
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl SDK {
     /// JS function for transferring funds.
     ///
@@ -36,9 +36,10 @@ impl SDK {
     /// # Returns
     ///
     /// A `Result` containing the result of the transfer or a `JsError` in case of an error.
-    #[wasm_bindgen(js_name = "transfer")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "transfer"))]
     #[deprecated(note = "prefer transfer_transaction")]
     #[allow(clippy::too_many_arguments, deprecated)]
+    #[cfg(feature = "js")]
     pub async fn transfer_js_alias(
         &self,
         amount: &str,

--- a/src/sdk/deploy_utils/make_deploy.rs
+++ b/src/sdk/deploy_utils/make_deploy.rs
@@ -11,12 +11,12 @@ use crate::{
     SDK,
 };
 use casper_client::cli::deploy::make_deploy as client_make_deploy;
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use wasm_bindgen::prelude::*;
 
 /// Exposes the `make_deploy` function to JavaScript with an alias.
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl SDK {
     /// JS function for `make_deploy`.
     ///
@@ -29,9 +29,10 @@ impl SDK {
     /// # Returns
     ///
     /// A `Result` containing the created `Deploy` or a `JsError` in case of an error.
-    #[wasm_bindgen(js_name = "make_deploy")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "make_deploy"))]
     #[deprecated(note = "prefer 'make_transaction'")]
     #[allow(deprecated)]
+    #[cfg(feature = "js")]
     pub fn make_deploy_js_alias(
         &self,
         deploy_params: DeployStrParams,

--- a/src/sdk/deploy_utils/make_transfer.rs
+++ b/src/sdk/deploy_utils/make_transfer.rs
@@ -11,12 +11,12 @@ use crate::{
 };
 use casper_client::cli::deploy::make_transfer as client_make_transfer;
 use rand::Rng;
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use wasm_bindgen::prelude::*;
 
 /// Exposes the `make_transfer` function to JavaScript with an alias.
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl SDK {
     /// JS function for `make_transfer`.
     ///
@@ -31,9 +31,10 @@ impl SDK {
     /// # Returns
     ///
     /// A `Result` containing the created `Deploy` or a `JsError` in case of an error.
-    #[wasm_bindgen(js_name = "make_transfer")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "make_transfer"))]
     #[deprecated(note = "prefer 'make_transfer_transaction'")]
     #[allow(deprecated)]
+    #[cfg(feature = "js")]
     pub fn make_transfer_js_alias(
         &self,
         amount: &str,

--- a/src/sdk/deploy_utils/sign_deploy.rs
+++ b/src/sdk/deploy_utils/sign_deploy.rs
@@ -1,10 +1,10 @@
 use crate::{types::deploy::Deploy, SDK};
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use wasm_bindgen::prelude::*;
 
 /// Exposes the `sign_deploy` function to JavaScript with an alias.
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl SDK {
     /// JS function for `sign_deploy`.
     ///
@@ -18,7 +18,7 @@ impl SDK {
     /// The signed `Deploy`.
     #[deprecated(note = "prefer sign_transaction")]
     #[allow(deprecated)]
-    #[wasm_bindgen(js_name = "sign_deploy")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "sign_deploy"))]
     pub fn sign_deploy_js_alias(&self, deploy: Deploy, secret_key: &str) -> Deploy {
         sign_deploy(deploy, secret_key)
     }

--- a/src/sdk/mod.rs
+++ b/src/sdk/mod.rs
@@ -50,11 +50,12 @@ pub(crate) mod contract;
 #[cfg(feature = "contract")]
 pub use contract::*;
 
+#[cfg(feature = "js")]
 use wasm_bindgen::prelude::*;
 
 use crate::types::verbosity::Verbosity;
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 pub struct SDK {
     rpc_address: Option<String>,
     node_address: Option<String>,
@@ -67,9 +68,9 @@ impl Default for SDK {
     }
 }
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl SDK {
-    #[wasm_bindgen(constructor)]
+    #[cfg_attr(feature = "js", wasm_bindgen(constructor))]
     pub fn new(
         rpc_address: Option<String>,
         node_address: Option<String>,
@@ -82,7 +83,7 @@ impl SDK {
         }
     }
 
-    #[wasm_bindgen(js_name = "getRPCAddress")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "getRPCAddress"))]
     pub fn get_rpc_address(&self, rpc_address: Option<String>) -> String {
         rpc_address
             .as_ref()
@@ -91,13 +92,13 @@ impl SDK {
             .unwrap_or_default()
     }
 
-    #[wasm_bindgen(js_name = "setRPCAddress")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "setRPCAddress"))]
     pub fn set_rpc_address(&mut self, rpc_address: Option<String>) -> Result<(), String> {
         self.rpc_address = rpc_address;
         Ok(())
     }
 
-    #[wasm_bindgen(js_name = "getNodeAddress")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "getNodeAddress"))]
     pub fn get_node_address(&self, node_address: Option<String>) -> String {
         node_address
             .as_ref()
@@ -106,18 +107,18 @@ impl SDK {
             .unwrap_or_default()
     }
 
-    #[wasm_bindgen(js_name = "setNodeAddress")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "setNodeAddress"))]
     pub fn set_node_address(&mut self, node_address: Option<String>) -> Result<(), String> {
         self.node_address = node_address;
         Ok(())
     }
 
-    #[wasm_bindgen(js_name = "getVerbosity")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "getVerbosity"))]
     pub fn get_verbosity(&self, verbosity: Option<Verbosity>) -> Verbosity {
         verbosity.unwrap_or(self.verbosity.unwrap_or(Verbosity::Low))
     }
 
-    #[wasm_bindgen(js_name = "setVerbosity")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "setVerbosity"))]
     pub fn set_verbosity(&mut self, verbosity: Option<Verbosity>) -> Result<(), String> {
         self.verbosity = verbosity;
         Ok(())

--- a/src/sdk/rpcs/get_account.rs
+++ b/src/sdk/rpcs/get_account.rs
@@ -1,4 +1,4 @@
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use crate::types::identifier::block_identifier::BlockIdentifier;
 use crate::{
     types::{
@@ -16,15 +16,16 @@ use casper_client::{
     cli::get_account as get_account_cli, get_account as get_account_lib,
     rpcs::results::GetAccountResult as _GetAccountResult, JsonRpcId, SuccessResponse,
 };
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use gloo_utils::format::JsValueSerdeExt;
 use rand::Rng;
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "js")]
 use wasm_bindgen::prelude::*;
 
 /// Wrapper around Casper Client `GetAccountResult`.
 #[derive(Debug, Deserialize, Clone, Serialize)]
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 pub struct GetAccountResult(_GetAccountResult);
 
 impl From<GetAccountResult> for _GetAccountResult {
@@ -46,31 +47,34 @@ impl GetAccountResult {
     }
 }
 
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl GetAccountResult {
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
+    #[cfg(feature = "js")]
     pub fn api_version(&self) -> JsValue {
         JsValue::from_serde(&self.0.api_version).unwrap()
     }
 
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
+    #[cfg(feature = "js")]
     pub fn account(&self) -> JsValue {
         JsValue::from_serde(&self.0.account).unwrap()
     }
 
     /// Gets the typed account wrapper.
-    #[wasm_bindgen(js_name = "accountTyped")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "accountTyped"))]
     pub fn account_typed_js(&self) -> Account {
         self.account_typed()
     }
 
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
     pub fn merkle_proof(&self) -> String {
         self.0.merkle_proof.clone()
     }
 
-    #[wasm_bindgen(js_name = "toJson")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "toJson"))]
+    #[cfg(feature = "js")]
     pub fn to_json(&self) -> JsValue {
         JsValue::from_serde(&self.0).unwrap_or(JsValue::null())
     }
@@ -78,8 +82,11 @@ impl GetAccountResult {
 
 // Define options for the `get_account` function
 #[derive(Debug, Deserialize, Clone, Default, Serialize)]
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen(js_name = "getAccountOptions", getter_with_clone)]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
+#[cfg_attr(
+    feature = "js",
+    wasm_bindgen(js_name = "getAccountOptions", getter_with_clone)
+)]
 pub struct GetAccountOptions {
     pub account_identifier: Option<AccountIdentifier>,
     pub account_identifier_as_string: Option<String>,
@@ -89,12 +96,13 @@ pub struct GetAccountOptions {
     pub verbosity: Option<Verbosity>,
 }
 
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl SDK {
     // Deserialize options for `get_account` from a JavaScript object
     #[deprecated(note = "prefer 'get_entity_options'")]
     #[allow(deprecated)]
+    #[cfg(feature = "js")]
     pub fn get_account_options(&self, options: JsValue) -> Result<GetAccountOptions, JsError> {
         options
             .into_serde::<GetAccountOptions>()
@@ -123,9 +131,10 @@ impl SDK {
     ///
     /// Returns a `JsError` if there is an error during the retrieval process, such as issues with the provided options or network errors.
     /// ```
-    #[wasm_bindgen(js_name = "get_account")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "get_account"))]
     #[deprecated(note = "prefer 'get_entity'")]
     #[allow(deprecated)]
+    #[cfg(feature = "js")]
     pub async fn get_account_js_alias(
         &self,
         options: Option<GetAccountOptions>,
@@ -166,9 +175,10 @@ impl SDK {
     }
 
     // JavaScript alias for `get_account`
-    #[wasm_bindgen(js_name = "state_get_account_info")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "state_get_account_info"))]
     #[deprecated(note = "prefer 'get_entity'")]
     #[allow(deprecated)]
+    #[cfg(feature = "js")]
     pub async fn state_get_account_info(
         &self,
         options: Option<GetAccountOptions>,

--- a/src/sdk/rpcs/get_auction_info.rs
+++ b/src/sdk/rpcs/get_auction_info.rs
@@ -1,4 +1,4 @@
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use crate::types::identifier::block_identifier::BlockIdentifier;
 use crate::{
     types::{
@@ -11,51 +11,54 @@ use casper_client::{
     cli::get_auction_info as get_auction_info_cli, get_auction_info as get_auction_info_lib,
     rpcs::results::GetAuctionInfoResult as _GetAuctionInfoResult, JsonRpcId, SuccessResponse,
 };
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use gloo_utils::format::JsValueSerdeExt;
 use rand::Rng;
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use serde::{Deserialize, Serialize};
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use wasm_bindgen::prelude::*;
 
 // Define a struct to wrap the GetAuctionInfoResult
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 #[derive(Debug, Deserialize, Clone, Serialize)]
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 pub struct GetAuctionInfoResult(_GetAuctionInfoResult);
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 impl From<GetAuctionInfoResult> for _GetAuctionInfoResult {
     fn from(result: GetAuctionInfoResult) -> Self {
         result.0
     }
 }
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 impl From<_GetAuctionInfoResult> for GetAuctionInfoResult {
     fn from(result: _GetAuctionInfoResult) -> Self {
         GetAuctionInfoResult(result)
     }
 }
 
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl GetAuctionInfoResult {
     /// Gets the API version as a JsValue.
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
+    #[cfg(feature = "js")]
     pub fn api_version(&self) -> JsValue {
         JsValue::from_serde(&self.0.api_version).unwrap()
     }
 
     /// Gets the auction state as a JsValue.
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
+    #[cfg(feature = "js")]
     pub fn auction_state(&self) -> JsValue {
         JsValue::from_serde(&self.0.auction_state).unwrap()
     }
 
     /// Converts the GetAuctionInfoResult to a JsValue.
-    #[wasm_bindgen(js_name = "toJson")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "toJson"))]
+    #[cfg(feature = "js")]
     pub fn to_json(&self) -> JsValue {
         JsValue::from_serde(&self.0).unwrap_or(JsValue::null())
     }
@@ -63,8 +66,11 @@ impl GetAuctionInfoResult {
 
 /// Options for the `get_auction_info` method.
 #[derive(Debug, Deserialize, Clone, Default, Serialize)]
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen(js_name = "getAuctionInfoOptions", getter_with_clone)]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
+#[cfg_attr(
+    feature = "js",
+    wasm_bindgen(js_name = "getAuctionInfoOptions", getter_with_clone)
+)]
 pub struct GetAuctionInfoOptions {
     pub maybe_block_id_as_string: Option<String>,
     pub maybe_block_identifier: Option<BlockIdentifier>,
@@ -72,8 +78,8 @@ pub struct GetAuctionInfoOptions {
     pub verbosity: Option<Verbosity>,
 }
 
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl SDK {
     /// Parses auction info options from a JsValue.
     ///
@@ -85,6 +91,7 @@ impl SDK {
     ///
     /// Result containing parsed auction info options as a `GetAuctionInfoOptions` struct,
     /// or a `JsError` if deserialization fails.
+    #[cfg(feature = "js")]
     pub fn get_auction_info_options(
         &self,
         options: JsValue,
@@ -107,7 +114,8 @@ impl SDK {
     /// # Errors
     ///
     /// Returns a `JsError` if there is an error during the retrieval process.
-    #[wasm_bindgen(js_name = "get_auction_info")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "get_auction_info"))]
+    #[cfg(feature = "js")]
     pub async fn get_auction_info_js_alias(
         &self,
         options: Option<GetAuctionInfoOptions>,
@@ -140,7 +148,11 @@ impl SDK {
     }
 
     // JavaScript alias for `get_auction_info`
-    #[wasm_bindgen(js_name = "state_get_auction_info_js_alias")]
+    #[cfg_attr(
+        feature = "js",
+        wasm_bindgen(js_name = "state_get_auction_info_js_alias")
+    )]
+    #[cfg(feature = "js")]
     pub async fn state_get_auction_info(
         &self,
         options: Option<GetAuctionInfoOptions>,

--- a/src/sdk/rpcs/get_balance.rs
+++ b/src/sdk/rpcs/get_balance.rs
@@ -11,57 +11,60 @@ use casper_client::{
     cli::get_balance as get_balance_cli, get_balance as get_balance_lib,
     rpcs::results::GetBalanceResult as _GetBalanceResult, JsonRpcId, SuccessResponse,
 };
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use gloo_utils::format::JsValueSerdeExt;
 use rand::Rng;
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use serde::{Deserialize, Serialize};
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use wasm_bindgen::prelude::*;
 
 // Define a struct to wrap the GetBalanceResult
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 #[derive(Debug, Deserialize, Clone, Serialize)]
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 pub struct GetBalanceResult(_GetBalanceResult);
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 impl From<GetBalanceResult> for _GetBalanceResult {
     fn from(result: GetBalanceResult) -> Self {
         result.0
     }
 }
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 impl From<_GetBalanceResult> for GetBalanceResult {
     fn from(result: _GetBalanceResult) -> Self {
         GetBalanceResult(result)
     }
 }
 
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl GetBalanceResult {
     /// Gets the API version as a JsValue.
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
+    #[cfg(feature = "js")]
     pub fn api_version(&self) -> JsValue {
         JsValue::from_serde(&self.0.api_version).unwrap()
     }
 
     /// Gets the balance value as a JsValue.
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
+    #[cfg(feature = "js")]
     pub fn balance_value(&self) -> JsValue {
         JsValue::from_serde(&self.0.balance_value).unwrap()
     }
 
     /// Gets the Merkle proof as a string.
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
     pub fn merkle_proof(&self) -> String {
         self.0.merkle_proof.clone()
     }
 
     /// Converts the GetBalanceResult to a JsValue.
-    #[wasm_bindgen(js_name = "toJson")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "toJson"))]
+    #[cfg(feature = "js")]
     pub fn to_json(&self) -> JsValue {
         JsValue::from_serde(&self.0).unwrap_or(JsValue::null())
     }
@@ -69,8 +72,11 @@ impl GetBalanceResult {
 
 /// Options for the `get_balance` method.
 #[derive(Default, Debug, Deserialize, Clone, Serialize)]
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen(js_name = "getBalanceOptions", getter_with_clone)]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
+#[cfg_attr(
+    feature = "js",
+    wasm_bindgen(js_name = "getBalanceOptions", getter_with_clone)
+)]
 pub struct GetBalanceOptions {
     pub state_root_hash_as_string: Option<String>,
     pub state_root_hash: Option<Digest>,
@@ -80,8 +86,8 @@ pub struct GetBalanceOptions {
     pub verbosity: Option<Verbosity>,
 }
 
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl SDK {
     /// Parses balance options from a JsValue.
     ///
@@ -92,6 +98,7 @@ impl SDK {
     /// # Returns
     ///
     /// Parsed balance options as a `GetBalanceOptions` struct.
+    #[cfg(feature = "js")]
     pub fn get_balance_options(&self, options: JsValue) -> Result<GetBalanceOptions, JsError> {
         options
             .into_serde::<GetBalanceOptions>()
@@ -111,7 +118,8 @@ impl SDK {
     /// # Errors
     ///
     /// Returns a `JsError` if there is an error during the retrieval process.
-    #[wasm_bindgen(js_name = "get_balance")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "get_balance"))]
+    #[cfg(feature = "js")]
     pub async fn get_balance_js_alias(
         &self,
         options: Option<GetBalanceOptions>,
@@ -171,9 +179,10 @@ impl SDK {
     /// # Returns
     ///
     /// A `Result` containing either a `GetBalanceResult` or a `JsError` in case of an error.
-    #[wasm_bindgen(js_name = "state_get_balance")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "state_get_balance"))]
     #[deprecated(note = "This function is an alias. Please use `get_balance` instead.")]
     #[allow(deprecated)]
+    #[cfg(feature = "js")]
     pub async fn state_get_balance(
         &self,
         options: Option<GetBalanceOptions>,

--- a/src/sdk/rpcs/get_block.rs
+++ b/src/sdk/rpcs/get_block.rs
@@ -1,4 +1,4 @@
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use crate::types::identifier::block_identifier::BlockIdentifier;
 use crate::{
     types::{
@@ -11,46 +11,48 @@ use casper_client::{
     cli::get_block as get_block_cli, get_block as get_block_lib,
     rpcs::results::GetBlockResult as _GetBlockResult, JsonRpcId, SuccessResponse,
 };
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use casper_types::Block;
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use gloo_utils::format::JsValueSerdeExt;
 use rand::Rng;
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use serde::{Deserialize, Serialize};
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use wasm_bindgen::prelude::*;
 
 // Define a struct to wrap the GetBlockResult
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 #[derive(Debug, Deserialize, Serialize)]
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 pub struct GetBlockResult(_GetBlockResult);
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 impl From<GetBlockResult> for _GetBlockResult {
     fn from(result: GetBlockResult) -> Self {
         result.0
     }
 }
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 impl From<_GetBlockResult> for GetBlockResult {
     fn from(result: _GetBlockResult) -> Self {
         GetBlockResult(result)
     }
 }
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl GetBlockResult {
     /// Gets the API version as a JsValue.
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
+    #[cfg(feature = "js")]
     pub fn api_version(&self) -> JsValue {
         JsValue::from_serde(&self.0.api_version).unwrap()
     }
 
     /// Gets the block information as a JsValue.
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
+    #[cfg(feature = "js")]
     pub fn block(&self) -> JsValue {
         let block = self.0.block_with_signatures.clone().unwrap().block;
 
@@ -61,7 +63,8 @@ impl GetBlockResult {
     }
 
     /// Converts the GetBlockResult to a JsValue.
-    #[wasm_bindgen(js_name = "toJson")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "toJson"))]
+    #[cfg(feature = "js")]
     pub fn to_json(&self) -> JsValue {
         JsValue::from_serde(&self.0).unwrap_or(JsValue::null())
     }
@@ -69,8 +72,11 @@ impl GetBlockResult {
 
 /// Options for the `get_block` method.
 #[derive(Debug, Deserialize, Default, Serialize)]
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen(js_name = "getBlockOptions", getter_with_clone)]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
+#[cfg_attr(
+    feature = "js",
+    wasm_bindgen(js_name = "getBlockOptions", getter_with_clone)
+)]
 pub struct GetBlockOptions {
     pub maybe_block_id_as_string: Option<String>,
     pub maybe_block_identifier: Option<BlockIdentifier>,
@@ -78,8 +84,8 @@ pub struct GetBlockOptions {
     pub verbosity: Option<Verbosity>,
 }
 
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl SDK {
     /// Parses block options from a JsValue.
     ///
@@ -90,6 +96,7 @@ impl SDK {
     /// # Returns
     ///
     /// Parsed block options as a `GetBlockOptions` struct.
+    #[cfg(feature = "js")]
     pub fn get_block_options(&self, options: JsValue) -> Result<GetBlockOptions, JsError> {
         options
             .into_serde::<GetBlockOptions>()
@@ -109,7 +116,8 @@ impl SDK {
     /// # Errors
     ///
     /// Returns a `JsError` if there is an error during the retrieval process.
-    #[wasm_bindgen(js_name = "get_block")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "get_block"))]
+    #[cfg(feature = "js")]
     pub async fn get_block_js_alias(
         &self,
         options: Option<GetBlockOptions>,
@@ -156,6 +164,7 @@ impl SDK {
     /// Returns a `JsError` if there is an error during the retrieval process.
     #[deprecated(note = "This function is an alias. Please use `get_block` instead.")]
     #[allow(deprecated)]
+    #[cfg(feature = "js")]
     pub async fn chain_get_block(
         &self,
         options: Option<GetBlockOptions>,

--- a/src/sdk/rpcs/get_block_transfers.rs
+++ b/src/sdk/rpcs/get_block_transfers.rs
@@ -1,6 +1,6 @@
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use crate::types::hash::block_hash::BlockHash;
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use crate::types::identifier::block_identifier::BlockIdentifier;
 use crate::{
     types::{
@@ -14,57 +14,60 @@ use casper_client::{
     get_block_transfers as get_block_transfers_lib,
     rpcs::results::GetBlockTransfersResult as _GetBlockTransfersResult, JsonRpcId, SuccessResponse,
 };
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use gloo_utils::format::JsValueSerdeExt;
 use rand::Rng;
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use serde::{Deserialize, Serialize};
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use wasm_bindgen::prelude::*;
 
 // Define a struct to wrap the GetBlockTransfersResult
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 #[derive(Debug, Deserialize, Clone, Serialize)]
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 pub struct GetBlockTransfersResult(_GetBlockTransfersResult);
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 impl From<GetBlockTransfersResult> for _GetBlockTransfersResult {
     fn from(result: GetBlockTransfersResult) -> Self {
         result.0
     }
 }
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 impl From<_GetBlockTransfersResult> for GetBlockTransfersResult {
     fn from(result: _GetBlockTransfersResult) -> Self {
         GetBlockTransfersResult(result)
     }
 }
 
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl GetBlockTransfersResult {
     /// Gets the API version as a JsValue.
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
+    #[cfg(feature = "js")]
     pub fn api_version(&self) -> JsValue {
         JsValue::from_serde(&self.0.api_version).unwrap()
     }
 
     /// Gets the block hash as an Option<BlockHash>.
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
     pub fn block_hash(&self) -> Option<BlockHash> {
         self.0.block_hash.map(Into::into)
     }
 
     /// Gets the transfers as a JsValue.
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
+    #[cfg(feature = "js")]
     pub fn transfers(&self) -> JsValue {
         JsValue::from_serde(&self.0.transfers).unwrap()
     }
 
     /// Converts the GetBlockTransfersResult to a JsValue.
-    #[wasm_bindgen(js_name = "toJson")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "toJson"))]
+    #[cfg(feature = "js")]
     pub fn to_json(&self) -> JsValue {
         JsValue::from_serde(&self.0).unwrap_or(JsValue::null())
     }
@@ -72,8 +75,11 @@ impl GetBlockTransfersResult {
 
 /// Options for the `get_block_transfers` method.
 #[derive(Debug, Deserialize, Clone, Default, Serialize)]
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen(js_name = "getBlockTransfersOptions", getter_with_clone)]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
+#[cfg_attr(
+    feature = "js",
+    wasm_bindgen(js_name = "getBlockTransfersOptions", getter_with_clone)
+)]
 pub struct GetBlockTransfersOptions {
     pub maybe_block_id_as_string: Option<String>,
     pub maybe_block_identifier: Option<BlockIdentifier>,
@@ -81,8 +87,8 @@ pub struct GetBlockTransfersOptions {
     pub rpc_address: Option<String>,
 }
 
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl SDK {
     /// Parses block transfers options from a JsValue.
     ///
@@ -93,6 +99,7 @@ impl SDK {
     /// # Returns
     ///
     /// Parsed block transfers options as a `GetBlockTransfersOptions` struct.
+    #[cfg(feature = "js")]
     pub fn get_block_transfers_options(
         &self,
         options: JsValue,
@@ -115,7 +122,8 @@ impl SDK {
     /// # Errors
     ///
     /// Returns a `JsError` if there is an error during the retrieval process.
-    #[wasm_bindgen(js_name = "get_block_transfers")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "get_block_transfers"))]
+    #[cfg(feature = "js")]
     pub async fn get_block_transfers_js_alias(
         &self,
         options: Option<GetBlockTransfersOptions>,
@@ -148,9 +156,10 @@ impl SDK {
     }
 
     // JavaScript alias for `get_block_transfers`.
-    #[wasm_bindgen(js_name = "chain_get_block_transfers")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "chain_get_block_transfers"))]
     #[deprecated(note = "This function is an alias. Please use `get_block_transfers` instead.")]
     #[allow(deprecated)]
+    #[cfg(feature = "js")]
     pub async fn chain_get_block_transfers(
         &self,
         options: Option<GetBlockTransfersOptions>,

--- a/src/sdk/rpcs/get_chainspec.rs
+++ b/src/sdk/rpcs/get_chainspec.rs
@@ -3,28 +3,28 @@ use casper_client::{
     get_chainspec, rpcs::results::GetChainspecResult as _GetChainspecResult, Error, JsonRpcId,
     SuccessResponse,
 };
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use gloo_utils::format::JsValueSerdeExt;
 use rand::Rng;
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use serde::{Deserialize, Serialize};
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use wasm_bindgen::prelude::*;
 
 /// A struct representing the result of the `get_chainspec` function.
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 #[derive(Debug, Deserialize, Clone, Serialize)]
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 pub struct GetChainspecResult(_GetChainspecResult);
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 impl From<GetChainspecResult> for _GetChainspecResult {
     fn from(result: GetChainspecResult) -> Self {
         result.0
     }
 }
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 impl From<_GetChainspecResult> for GetChainspecResult {
     fn from(result: _GetChainspecResult) -> Self {
         GetChainspecResult(result)
@@ -32,31 +32,34 @@ impl From<_GetChainspecResult> for GetChainspecResult {
 }
 
 /// Implementations for the `GetChainspecResult` struct.
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl GetChainspecResult {
     /// Gets the API version as a JsValue.
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
+    #[cfg(feature = "js")]
     pub fn api_version(&self) -> JsValue {
         JsValue::from_serde(&self.0.api_version).unwrap()
     }
 
     /// Gets the chainspec bytes as a JsValue.
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
+    #[cfg(feature = "js")]
     pub fn chainspec_bytes(&self) -> JsValue {
         JsValue::from_serde(&self.0.chainspec_bytes).unwrap()
     }
 
     /// Converts the `GetChainspecResult` to a JsValue.
-    #[wasm_bindgen(js_name = "toJson")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "toJson"))]
+    #[cfg(feature = "js")]
     pub fn to_json(&self) -> JsValue {
         JsValue::from_serde(&self.0).unwrap_or(JsValue::null())
     }
 }
 
 /// Implementations for the `SDK` struct.
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl SDK {
     /// Asynchronously retrieves the chainspec.
     ///
@@ -68,7 +71,8 @@ impl SDK {
     /// # Returns
     ///
     /// A `Result` containing either a `GetChainspecResult` or a `JsError` in case of an error.
-    #[wasm_bindgen(js_name = "get_chainspec")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "get_chainspec"))]
+    #[cfg(feature = "js")]
     pub async fn get_chainspec_js_alias(
         &self,
         verbosity: Option<Verbosity>,
@@ -87,6 +91,7 @@ impl SDK {
     // JavaScript alias for `get_chainspec`.
     #[deprecated(note = "This function is an alias. Please use `get_chainspec` instead.")]
     #[allow(deprecated)]
+    #[cfg(feature = "js")]
     pub async fn info_get_chainspec(
         &self,
         verbosity: Option<Verbosity>,

--- a/src/sdk/rpcs/get_deploy.rs
+++ b/src/sdk/rpcs/get_deploy.rs
@@ -1,4 +1,4 @@
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use crate::types::deploy::Deploy;
 use crate::types::hash::deploy_hash::DeployHash;
 use crate::{types::verbosity::Verbosity, SDK};
@@ -6,56 +6,59 @@ use casper_client::{
     get_deploy, rpcs::results::GetDeployResult as _GetDeployResult, Error, JsonRpcId,
     SuccessResponse,
 };
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use gloo_utils::format::JsValueSerdeExt;
 use rand::Rng;
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use serde::{Deserialize, Serialize};
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use wasm_bindgen::prelude::*;
 
 // Define a struct to wrap the GetDeployResult
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 #[derive(Debug, Deserialize, Clone, Serialize)]
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 pub struct GetDeployResult(_GetDeployResult);
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 impl From<GetDeployResult> for _GetDeployResult {
     fn from(result: GetDeployResult) -> Self {
         result.0
     }
 }
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 impl From<_GetDeployResult> for GetDeployResult {
     fn from(result: _GetDeployResult) -> Self {
         GetDeployResult(result)
     }
 }
 
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl GetDeployResult {
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
     /// Gets the API version as a JavaScript value.
+    #[cfg(feature = "js")]
     pub fn api_version(&self) -> JsValue {
         JsValue::from_serde(&self.0.api_version).unwrap()
     }
 
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
     /// Gets the deploy information.
     pub fn deploy(&self) -> Deploy {
         self.0.deploy.clone().into()
     }
 
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
     /// Gets the execution info as a JavaScript value.
+    #[cfg(feature = "js")]
     pub fn execution_info(&self) -> JsValue {
         JsValue::from_serde(&self.0.execution_info).unwrap()
     }
 
-    #[wasm_bindgen(js_name = "toJson")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "toJson"))]
     /// Converts the result to a JSON JavaScript value.
+    #[cfg(feature = "js")]
     pub fn to_json(&self) -> JsValue {
         JsValue::from_serde(&self.0).unwrap_or(JsValue::null())
     }
@@ -63,8 +66,11 @@ impl GetDeployResult {
 
 /// Options for the `get_deploy` method.
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen(js_name = "getDeployOptions", getter_with_clone)]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
+#[cfg_attr(
+    feature = "js",
+    wasm_bindgen(js_name = "getDeployOptions", getter_with_clone)
+)]
 pub struct GetDeployOptions {
     pub deploy_hash_as_string: Option<String>,
     pub deploy_hash: Option<DeployHash>,
@@ -73,8 +79,8 @@ pub struct GetDeployOptions {
     pub verbosity: Option<Verbosity>,
 }
 
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl SDK {
     /// Parses deploy options from a JsValue.
     ///
@@ -87,6 +93,7 @@ impl SDK {
     /// Parsed deploy options as a `GetDeployOptions` struct.
     #[deprecated(note = "prefer 'get_transaction_options'")]
     #[allow(deprecated)]
+    #[cfg(feature = "js")]
     pub fn get_deploy_options(&self, options: JsValue) -> Result<GetDeployOptions, JsError> {
         let mut options: GetDeployOptions = options.into_serde()?;
 
@@ -110,7 +117,8 @@ impl SDK {
     /// A `Result` containing either a `GetDeployResult` or an error.
     #[deprecated(note = "prefer 'get_transaction'")]
     #[allow(deprecated)]
-    #[wasm_bindgen(js_name = "get_deploy")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "get_deploy"))]
+    #[cfg(feature = "js")]
     pub async fn get_deploy_js_alias(
         &self,
         options: Option<GetDeployOptions>,
@@ -148,6 +156,7 @@ impl SDK {
     /// Retrieves deploy information using the provided options, alias for `get_deploy`.
     #[deprecated(note = "This function is an alias. Please use `get_transaction` instead.")]
     #[allow(deprecated)]
+    #[cfg(feature = "js")]
     pub async fn info_get_deploy(
         &self,
         options: Option<GetDeployOptions>,

--- a/src/sdk/rpcs/get_dictionary_item.rs
+++ b/src/sdk/rpcs/get_dictionary_item.rs
@@ -17,15 +17,16 @@ use casper_client::{
     get_dictionary_item as get_dictionary_item_lib,
     rpcs::results::GetDictionaryItemResult as _GetDictionaryItemResult, JsonRpcId, SuccessResponse,
 };
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use gloo_utils::format::JsValueSerdeExt;
 use rand::Rng;
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "js")]
 use wasm_bindgen::prelude::*;
 
 // Define a struct to wrap the GetDictionaryItemResult
 #[derive(Debug, Deserialize, Clone, Serialize)]
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 pub struct GetDictionaryItemResult(_GetDictionaryItemResult);
 
 impl From<GetDictionaryItemResult> for _GetDictionaryItemResult {
@@ -46,41 +47,44 @@ impl GetDictionaryItemResult {
     }
 }
 
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl GetDictionaryItemResult {
     /// Gets the API version as a JsValue.
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
+    #[cfg(feature = "js")]
     pub fn api_version(&self) -> JsValue {
         JsValue::from_serde(&self.0.api_version).unwrap()
     }
 
     /// Gets the dictionary key as a String.
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
     pub fn dictionary_key(&self) -> String {
         self.0.dictionary_key.clone()
     }
 
     /// Gets the stored value as a JsValue.
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
+    #[cfg(feature = "js")]
     pub fn stored_value(&self) -> JsValue {
         JsValue::from_serde(&self.0.stored_value).unwrap()
     }
 
     /// Gets the typed stored value wrapper.
-    #[wasm_bindgen(js_name = "storedValueTyped")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "storedValueTyped"))]
     pub fn stored_value_typed_js(&self) -> StoredValue {
         self.stored_value_typed()
     }
 
     /// Gets the merkle proof as a String.
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
     pub fn merkle_proof(&self) -> String {
         self.0.merkle_proof.clone()
     }
 
     /// Converts the GetDictionaryItemResult to a JsValue.
-    #[wasm_bindgen(js_name = "toJson")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "toJson"))]
+    #[cfg(feature = "js")]
     pub fn to_json(&self) -> JsValue {
         JsValue::from_serde(&self.0).unwrap_or(JsValue::null())
     }
@@ -88,8 +92,11 @@ impl GetDictionaryItemResult {
 
 /// Options for the `get_dictionary_item` method.
 #[derive(Default, Debug, Deserialize, Clone, Serialize)]
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen(js_name = "getDictionaryItemOptions", getter_with_clone)]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
+#[cfg_attr(
+    feature = "js",
+    wasm_bindgen(js_name = "getDictionaryItemOptions", getter_with_clone)
+)]
 pub struct GetDictionaryItemOptions {
     pub state_root_hash_as_string: Option<String>,
     pub state_root_hash: Option<Digest>,
@@ -99,8 +106,8 @@ pub struct GetDictionaryItemOptions {
     pub verbosity: Option<Verbosity>,
 }
 
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl SDK {
     /// Parses dictionary item options from a JsValue.
     ///
@@ -111,6 +118,7 @@ impl SDK {
     /// # Returns
     ///
     /// Parsed dictionary item options as a `GetDictionaryItemOptions` struct.
+    #[cfg(feature = "js")]
     pub fn get_dictionary_item_options(
         &self,
         options: JsValue,
@@ -133,7 +141,8 @@ impl SDK {
     /// # Errors
     ///
     /// Returns a `JsError` if there is an error during the retrieval process.
-    #[wasm_bindgen(js_name = "get_dictionary_item")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "get_dictionary_item"))]
+    #[cfg(feature = "js")]
     pub async fn get_dictionary_item_js_alias(
         &self,
         options: Option<GetDictionaryItemOptions>,
@@ -179,6 +188,7 @@ impl SDK {
     /// JavaScript Alias for `get_dictionary_item`
     #[deprecated(note = "This function is an alias. Please use `get_dictionary_item` instead.")]
     #[allow(deprecated)]
+    #[cfg(feature = "js")]
     pub async fn state_get_dictionary_item(
         &self,
         options: Option<GetDictionaryItemOptions>,

--- a/src/sdk/rpcs/get_entity.rs
+++ b/src/sdk/rpcs/get_entity.rs
@@ -1,4 +1,4 @@
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use crate::types::identifier::block_identifier::BlockIdentifier;
 use crate::{
     types::{
@@ -15,15 +15,16 @@ use casper_client::{
     rpcs::results::GetAddressableEntityResult as _GetAddressableEntityResult,
     JsonRpcId, SuccessResponse,
 };
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use gloo_utils::format::JsValueSerdeExt;
 use rand::Rng;
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "js")]
 use wasm_bindgen::prelude::*;
 
 /// Wrapper around Casper Client `GetAddressableEntityResult`.
 #[derive(Debug, Deserialize, Clone, Serialize)]
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 pub struct GetAddressableEntityResult(_GetAddressableEntityResult);
 
 impl From<GetAddressableEntityResult> for _GetAddressableEntityResult {
@@ -45,31 +46,34 @@ impl GetAddressableEntityResult {
     }
 }
 
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl GetAddressableEntityResult {
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
+    #[cfg(feature = "js")]
     pub fn api_version(&self) -> JsValue {
         JsValue::from_serde(&self.0.api_version).unwrap()
     }
 
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
+    #[cfg(feature = "js")]
     pub fn entity_result(&self) -> JsValue {
         JsValue::from_serde(&self.0.entity_result).unwrap()
     }
 
     /// Typed `entity_result` (`AddressableEntity` or legacy `Account`).
-    #[wasm_bindgen(js_name = "entityResultTyped")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "entityResultTyped"))]
     pub fn entity_result_typed_js(&self) -> EntityOrAccount {
         self.entity_result_typed()
     }
 
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
     pub fn merkle_proof(&self) -> String {
         self.0.merkle_proof.clone()
     }
 
-    #[wasm_bindgen(js_name = "toJson")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "toJson"))]
+    #[cfg(feature = "js")]
     pub fn to_json(&self) -> JsValue {
         JsValue::from_serde(&self.0).unwrap_or(JsValue::null())
     }
@@ -77,8 +81,11 @@ impl GetAddressableEntityResult {
 
 // Define options for the `get_entity` function
 #[derive(Debug, Deserialize, Clone, Default, Serialize)]
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen(js_name = "getEntityOptions", getter_with_clone)]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
+#[cfg_attr(
+    feature = "js",
+    wasm_bindgen(js_name = "getEntityOptions", getter_with_clone)
+)]
 pub struct GetEntityOptions {
     pub entity_identifier: Option<EntityIdentifier>,
     pub entity_identifier_as_string: Option<String>,
@@ -88,10 +95,11 @@ pub struct GetEntityOptions {
     pub verbosity: Option<Verbosity>,
 }
 
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl SDK {
     // Deserialize options for `get_entity` from a JavaScript object
+    #[cfg(feature = "js")]
     pub fn get_entity_options(&self, options: JsValue) -> Result<GetEntityOptions, JsError> {
         options
             .into_serde::<GetEntityOptions>()
@@ -120,7 +128,8 @@ impl SDK {
     ///
     /// Returns a `JsError` if there is an error during the retrieval process, such as issues with the provided options or network errors.
     /// ```
-    #[wasm_bindgen(js_name = "get_entity")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "get_entity"))]
+    #[cfg(feature = "js")]
     pub async fn get_entity_js_alias(
         &self,
         options: Option<GetEntityOptions>,
@@ -161,7 +170,8 @@ impl SDK {
     }
 
     // JavaScript alias for `get_entity`
-    #[wasm_bindgen(js_name = "state_get_entity")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "state_get_entity"))]
+    #[cfg(feature = "js")]
     pub async fn state_get_entity(
         &self,
         options: Option<GetEntityOptions>,

--- a/src/sdk/rpcs/get_era_info.rs
+++ b/src/sdk/rpcs/get_era_info.rs
@@ -1,4 +1,4 @@
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use crate::types::identifier::block_identifier::BlockIdentifier;
 use crate::{
     types::{
@@ -12,54 +12,60 @@ use casper_client::{
     cli::get_era_info as get_era_info_cli, get_era_info as get_era_info_lib,
     rpcs::results::GetEraInfoResult as _GetEraInfoResult, JsonRpcId, SuccessResponse,
 };
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use gloo_utils::format::JsValueSerdeExt;
 use rand::Rng;
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use serde::{Deserialize, Serialize};
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use wasm_bindgen::prelude::*;
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 #[derive(Debug, Deserialize, Clone, Serialize)]
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 pub struct GetEraInfoResult(_GetEraInfoResult);
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 impl From<GetEraInfoResult> for _GetEraInfoResult {
     fn from(result: GetEraInfoResult) -> Self {
         result.0
     }
 }
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 impl From<_GetEraInfoResult> for GetEraInfoResult {
     fn from(result: _GetEraInfoResult) -> Self {
         GetEraInfoResult(result)
     }
 }
 
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl GetEraInfoResult {
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
+    #[cfg(feature = "js")]
     pub fn api_version(&self) -> JsValue {
         JsValue::from_serde(&self.0.api_version).unwrap()
     }
 
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
+    #[cfg(feature = "js")]
     pub fn era_summary(&self) -> JsValue {
         JsValue::from_serde(&self.0.era_summary).unwrap()
     }
 
-    #[wasm_bindgen(js_name = "toJson")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "toJson"))]
+    #[cfg(feature = "js")]
     pub fn to_json(&self) -> JsValue {
         JsValue::from_serde(&self.0).unwrap_or(JsValue::null())
     }
 }
 
 #[derive(Debug, Deserialize, Clone, Default, Serialize)]
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen(js_name = "getEraInfoOptions", getter_with_clone)]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
+#[cfg_attr(
+    feature = "js",
+    wasm_bindgen(js_name = "getEraInfoOptions", getter_with_clone)
+)]
 pub struct GetEraInfoOptions {
     pub maybe_block_id_as_string: Option<String>,
     pub maybe_block_identifier: Option<BlockIdentifier>,
@@ -67,11 +73,12 @@ pub struct GetEraInfoOptions {
     pub verbosity: Option<Verbosity>,
 }
 
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl SDK {
     #[deprecated(note = "prefer 'get_era_summary' as it doesn't require a switch block")]
     #[allow(deprecated)]
+    #[cfg(feature = "js")]
     pub fn get_era_info_options(&self, options: JsValue) -> Result<GetEraInfoOptions, JsError> {
         options
             .into_serde::<GetEraInfoOptions>()
@@ -80,7 +87,8 @@ impl SDK {
 
     #[deprecated(note = "prefer 'get_era_summary' as it doesn't require a switch block")]
     #[allow(deprecated)]
-    #[wasm_bindgen(js_name = "get_era_info")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "get_era_info"))]
+    #[cfg(feature = "js")]
     pub async fn get_era_info_js_alias(
         &self,
         options: Option<GetEraInfoOptions>,
@@ -115,6 +123,7 @@ impl SDK {
     // JavaScript alias for `get_era_summary`
     #[deprecated(note = "This function is an alias. Please use `get_era_info` instead.")]
     #[allow(deprecated)]
+    #[cfg(feature = "js")]
     pub async fn chain_get_era_info_by_switch_block(
         &self,
         options: Option<GetEraInfoOptions>,

--- a/src/sdk/rpcs/get_era_summary.rs
+++ b/src/sdk/rpcs/get_era_summary.rs
@@ -1,4 +1,4 @@
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use crate::types::identifier::block_identifier::BlockIdentifier;
 use crate::{
     types::{
@@ -11,51 +11,54 @@ use casper_client::{
     cli::get_era_summary as get_era_summary_cli, get_era_summary as get_era_summary_lib,
     rpcs::results::GetEraSummaryResult as _GetEraSummaryResult, JsonRpcId, SuccessResponse,
 };
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use gloo_utils::format::JsValueSerdeExt;
 use rand::Rng;
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use serde::{Deserialize, Serialize};
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use wasm_bindgen::prelude::*;
 
 /// Wrapper struct for the `GetEraSummaryResult` from casper_client.
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 #[derive(Debug, Deserialize, Clone, Serialize)]
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 pub struct GetEraSummaryResult(_GetEraSummaryResult);
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 impl From<GetEraSummaryResult> for _GetEraSummaryResult {
     fn from(result: GetEraSummaryResult) -> Self {
         result.0
     }
 }
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 impl From<_GetEraSummaryResult> for GetEraSummaryResult {
     fn from(result: _GetEraSummaryResult) -> Self {
         GetEraSummaryResult(result)
     }
 }
 
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl GetEraSummaryResult {
     /// Gets the API version as a JsValue.
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
+    #[cfg(feature = "js")]
     pub fn api_version(&self) -> JsValue {
         JsValue::from_serde(&self.0.api_version).unwrap()
     }
 
     /// Gets the era summary as a JsValue.
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
+    #[cfg(feature = "js")]
     pub fn era_summary(&self) -> JsValue {
         JsValue::from_serde(&self.0.era_summary).unwrap()
     }
 
     /// Converts the GetEraSummaryResult to a JsValue.
-    #[wasm_bindgen(js_name = "toJson")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "toJson"))]
+    #[cfg(feature = "js")]
     pub fn to_json(&self) -> JsValue {
         JsValue::from_serde(&self.0).unwrap_or(JsValue::null())
     }
@@ -63,8 +66,11 @@ impl GetEraSummaryResult {
 
 /// Options for the `get_era_summary` method.
 #[derive(Debug, Deserialize, Clone, Default, Serialize)]
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen(js_name = "getEraSummaryOptions", getter_with_clone)]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
+#[cfg_attr(
+    feature = "js",
+    wasm_bindgen(js_name = "getEraSummaryOptions", getter_with_clone)
+)]
 pub struct GetEraSummaryOptions {
     pub maybe_block_id_as_string: Option<String>,
     pub maybe_block_identifier: Option<BlockIdentifier>,
@@ -72,8 +78,8 @@ pub struct GetEraSummaryOptions {
     pub verbosity: Option<Verbosity>,
 }
 
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl SDK {
     /// Parses era summary options from a JsValue.
     ///
@@ -84,6 +90,7 @@ impl SDK {
     /// # Returns
     ///
     /// Parsed era summary options as a `GetEraSummaryOptions` struct.
+    #[cfg(feature = "js")]
     pub fn get_era_summary_options(
         &self,
         options: JsValue,
@@ -106,7 +113,8 @@ impl SDK {
     /// # Errors
     ///
     /// Returns a `JsError` if there is an error during the retrieval process.
-    #[wasm_bindgen(js_name = "get_era_summary")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "get_era_summary"))]
+    #[cfg(feature = "js")]
     pub async fn get_era_summary_js_alias(
         &self,
         options: Option<GetEraSummaryOptions>,
@@ -139,9 +147,10 @@ impl SDK {
     }
 
     // JavaScript alias for `get_era_summary`
-    #[wasm_bindgen(js_name = "chain_get_era_summary")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "chain_get_era_summary"))]
     #[deprecated(note = "This function is an alias. Please use `get_era_summary` instead.")]
     #[allow(deprecated)]
+    #[cfg(feature = "js")]
     pub async fn chain_get_era_summary(
         &self,
         options: Option<GetEraSummaryOptions>,

--- a/src/sdk/rpcs/get_node_status.rs
+++ b/src/sdk/rpcs/get_node_status.rs
@@ -1,136 +1,147 @@
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use crate::types::{digest::Digest, public_key::PublicKey};
 use crate::{types::verbosity::Verbosity, SDK};
 use casper_client::{
     get_node_status, rpcs::results::GetNodeStatusResult as _GetNodeStatusResult, Error, JsonRpcId,
     SuccessResponse,
 };
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use gloo_utils::format::JsValueSerdeExt;
 use rand::Rng;
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use serde::{Deserialize, Serialize};
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use wasm_bindgen::prelude::*;
 
 /// Wrapper struct for the `GetNodeStatusResult` from casper_client.
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 #[derive(Debug, Deserialize, Clone, Serialize)]
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 pub struct GetNodeStatusResult(_GetNodeStatusResult);
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 impl From<GetNodeStatusResult> for _GetNodeStatusResult {
     fn from(result: GetNodeStatusResult) -> Self {
         result.0
     }
 }
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 impl From<_GetNodeStatusResult> for GetNodeStatusResult {
     fn from(result: _GetNodeStatusResult) -> Self {
         GetNodeStatusResult(result)
     }
 }
 
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl GetNodeStatusResult {
     /// Gets the API version as a JsValue.
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
+    #[cfg(feature = "js")]
     pub fn api_version(&self) -> JsValue {
         JsValue::from_serde(&self.0.api_version).unwrap()
     }
 
     /// Gets the chainspec name as a String.
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
     pub fn chainspec_name(&self) -> String {
         self.0.chainspec_name.clone()
     }
 
     /// Gets the starting state root hash as a Digest.
     #[allow(deprecated)]
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
     pub fn starting_state_root_hash(&self) -> Digest {
         self.0.starting_state_root_hash.into()
     }
 
     /// Gets the list of peers as a JsValue.
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
+    #[cfg(feature = "js")]
     pub fn peers(&self) -> JsValue {
         JsValue::from_serde(&self.0.peers).unwrap()
     }
 
     /// Gets information about the last added block as a JsValue.
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
+    #[cfg(feature = "js")]
     pub fn last_added_block_info(&self) -> JsValue {
         JsValue::from_serde(&self.0.last_added_block_info).unwrap()
     }
 
     /// Gets the public signing key as an Option<PublicKey>.
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
     pub fn our_public_signing_key(&self) -> Option<PublicKey> {
         self.0.our_public_signing_key.clone().map(Into::into)
     }
 
     /// Gets the round length as a JsValue.
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
+    #[cfg(feature = "js")]
     pub fn round_length(&self) -> JsValue {
         JsValue::from_serde(&self.0.round_length).unwrap()
     }
 
     /// Gets information about the next upgrade as a JsValue.
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
+    #[cfg(feature = "js")]
     pub fn next_upgrade(&self) -> JsValue {
         JsValue::from_serde(&self.0.next_upgrade).unwrap()
     }
 
     /// Gets the build version as a String.
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
     pub fn build_version(&self) -> String {
         self.0.build_version.clone()
     }
 
     /// Gets the uptime information as a JsValue.
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
+    #[cfg(feature = "js")]
     pub fn uptime(&self) -> JsValue {
         JsValue::from_serde(&self.0.uptime).unwrap()
     }
 
     /// Gets the reactor state information as a JsValue.
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
+    #[cfg(feature = "js")]
     pub fn reactor_state(&self) -> JsValue {
         JsValue::from_serde(&self.0.reactor_state).unwrap()
     }
 
     /// Gets the last progress information as a JsValue.
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
+    #[cfg(feature = "js")]
     pub fn last_progress(&self) -> JsValue {
         JsValue::from_serde(&self.0.last_progress).unwrap()
     }
 
     /// Gets the available block range as a JsValue.
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
+    #[cfg(feature = "js")]
     pub fn available_block_range(&self) -> JsValue {
         JsValue::from_serde(&self.0.available_block_range).unwrap()
     }
 
     /// Gets the block sync information as a JsValue.
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
+    #[cfg(feature = "js")]
     pub fn block_sync(&self) -> JsValue {
         JsValue::from_serde(&self.0.block_sync).unwrap()
     }
 
     /// Converts the GetNodeStatusResult to a JsValue.
-    #[wasm_bindgen(js_name = "toJson")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "toJson"))]
+    #[cfg(feature = "js")]
     pub fn to_json(&self) -> JsValue {
         JsValue::from_serde(&self.0).unwrap_or(JsValue::null())
     }
 }
 
 /// SDK methods related to retrieving node status information.
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl SDK {
     /// Retrieves node status information using the provided options.
     ///
@@ -146,7 +157,8 @@ impl SDK {
     /// # Errors
     ///
     /// Returns a `JsError` if there is an error during the retrieval process.
-    #[wasm_bindgen(js_name = "get_node_status")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "get_node_status"))]
+    #[cfg(feature = "js")]
     pub async fn get_node_status_js_alias(
         &self,
         verbosity: Option<Verbosity>,
@@ -165,6 +177,7 @@ impl SDK {
     // JavaScript alias for `get_node_status`
     #[deprecated(note = "This function is an alias. Please use `get_node_status` instead.")]
     #[allow(deprecated)]
+    #[cfg(feature = "js")]
     pub async fn info_get_status(
         &self,
         verbosity: Option<Verbosity>,

--- a/src/sdk/rpcs/get_peers.rs
+++ b/src/sdk/rpcs/get_peers.rs
@@ -2,58 +2,61 @@ use crate::{types::verbosity::Verbosity, SDK};
 use casper_client::{
     get_peers, rpcs::results::GetPeersResult as _GetPeersResult, Error, JsonRpcId, SuccessResponse,
 };
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use gloo_utils::format::JsValueSerdeExt;
 use rand::Rng;
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use serde::{Deserialize, Serialize};
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use wasm_bindgen::prelude::*;
 
 /// A wrapper for the `GetPeersResult` type from the Casper client.
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 #[derive(Debug, Deserialize, Clone, Serialize)]
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 pub struct GetPeersResult(_GetPeersResult);
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 impl From<GetPeersResult> for _GetPeersResult {
     fn from(result: GetPeersResult) -> Self {
         result.0
     }
 }
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 impl From<_GetPeersResult> for GetPeersResult {
     fn from(result: _GetPeersResult) -> Self {
         GetPeersResult(result)
     }
 }
 
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl GetPeersResult {
     /// Gets the API version as a JSON value.
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
+    #[cfg(feature = "js")]
     pub fn api_version(&self) -> JsValue {
         JsValue::from_serde(&self.0.api_version).unwrap()
     }
 
     /// Gets the peers as a JSON value.
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
+    #[cfg(feature = "js")]
     pub fn peers(&self) -> JsValue {
         JsValue::from_serde(&self.0.peers).unwrap()
     }
 
     /// Converts the result to JSON format as a JavaScript value.
-    #[wasm_bindgen(js_name = "toJson")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "toJson"))]
+    #[cfg(feature = "js")]
     pub fn to_json(&self) -> JsValue {
         JsValue::from_serde(&self.0).unwrap_or(JsValue::null())
     }
 }
 
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl SDK {
     /// Retrieves peers asynchronously.
     ///
@@ -65,7 +68,8 @@ impl SDK {
     /// # Returns
     ///
     /// A `Result` containing `GetPeersResult` or a `JsError` if an error occurs.
-    #[wasm_bindgen(js_name = "get_peers")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "get_peers"))]
+    #[cfg(feature = "js")]
     pub async fn get_peers_js_alias(
         &self,
         verbosity: Option<Verbosity>,
@@ -84,6 +88,7 @@ impl SDK {
     // JavaScript alias for `get_peers`
     #[deprecated(note = "This function is an alias. Please use `get_peers` instead.")]
     #[allow(deprecated)]
+    #[cfg(feature = "js")]
     pub async fn info_get_peers(
         &self,
         verbosity: Option<Verbosity>,

--- a/src/sdk/rpcs/get_reward.rs
+++ b/src/sdk/rpcs/get_reward.rs
@@ -1,4 +1,4 @@
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use crate::types::identifier::block_identifier::BlockIdentifier;
 use crate::{
     types::{public_key::PublicKey, sdk_error::SdkError, verbosity::Verbosity},
@@ -9,71 +9,76 @@ use casper_client::{
     rpcs::results::GetRewardResult as _GetRewardResult, rpcs::EraIdentifier, JsonRpcId,
     SuccessResponse,
 };
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use casper_types::EraId;
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use gloo_utils::format::JsValueSerdeExt;
 use rand::Rng;
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use serde::{Deserialize, Serialize};
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use wasm_bindgen::prelude::*;
 
 /// Wrapper struct for the `GetRewardResult` from casper_client.
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 #[derive(Debug, Deserialize, Serialize)]
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 pub struct GetRewardResult(_GetRewardResult);
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 impl From<GetRewardResult> for _GetRewardResult {
     fn from(result: GetRewardResult) -> Self {
         result.0
     }
 }
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 impl From<_GetRewardResult> for GetRewardResult {
     fn from(result: _GetRewardResult) -> Self {
         GetRewardResult(result)
     }
 }
 
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl GetRewardResult {
     /// Gets the API version as a JsValue.
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
+    #[cfg(feature = "js")]
     pub fn api_version(&self) -> JsValue {
         JsValue::from_serde(&self.0.api_version).unwrap()
     }
 
     /// Gets the reward amount as a JsValue.
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
+    #[cfg(feature = "js")]
     pub fn reward_amount(&self) -> JsValue {
         JsValue::from_serde(&self.0.reward_amount).unwrap()
     }
 
     /// Gets the era id as a JsValue.
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
+    #[cfg(feature = "js")]
     pub fn era_id(&self) -> JsValue {
         JsValue::from_serde(&self.0.era_id).unwrap()
     }
 
     /// Gets the delegation rate.
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
     pub fn delegation_rate(&self) -> u8 {
         self.0.delegation_rate
     }
 
     /// Gets the switch block hash as a JsValue.
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
+    #[cfg(feature = "js")]
     pub fn switch_block_hash(&self) -> JsValue {
         JsValue::from_serde(&self.0.switch_block_hash).unwrap()
     }
 
     /// Converts the GetRewardResult to a JsValue.
-    #[wasm_bindgen(js_name = "toJson")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "toJson"))]
+    #[cfg(feature = "js")]
     pub fn to_json(&self) -> JsValue {
         JsValue::from_serde(&self.0).unwrap_or(JsValue::null())
     }
@@ -81,8 +86,11 @@ impl GetRewardResult {
 
 /// Options for the `get_reward` method.
 #[derive(Debug, Deserialize, Clone, Default, Serialize)]
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen(js_name = "getRewardOptions", getter_with_clone)]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
+#[cfg_attr(
+    feature = "js",
+    wasm_bindgen(js_name = "getRewardOptions", getter_with_clone)
+)]
 pub struct GetRewardOptions {
     pub validator_public_key: Option<PublicKey>,
     pub validator_public_key_as_string: Option<String>,
@@ -95,10 +103,11 @@ pub struct GetRewardOptions {
     pub verbosity: Option<Verbosity>,
 }
 
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl SDK {
     /// Parses reward options from a JsValue.
+    #[cfg(feature = "js")]
     pub fn get_reward_options(&self, options: JsValue) -> Result<GetRewardOptions, JsError> {
         options
             .into_serde::<GetRewardOptions>()
@@ -106,7 +115,8 @@ impl SDK {
     }
 
     /// Retrieves validator/delegator reward via JSON-RPC `info_get_reward`.
-    #[wasm_bindgen(js_name = "get_reward")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "get_reward"))]
+    #[cfg(feature = "js")]
     pub async fn get_reward_js_alias(
         &self,
         options: Option<GetRewardOptions>,
@@ -175,9 +185,10 @@ impl SDK {
     }
 
     /// JavaScript alias for `get_reward`.
-    #[wasm_bindgen(js_name = "info_get_reward")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "info_get_reward"))]
     #[deprecated(note = "This function is an alias. Please use `get_reward` instead.")]
     #[allow(deprecated)]
+    #[cfg(feature = "js")]
     pub async fn info_get_reward(
         &self,
         options: Option<GetRewardOptions>,

--- a/src/sdk/rpcs/get_state_root_hash.rs
+++ b/src/sdk/rpcs/get_state_root_hash.rs
@@ -1,6 +1,6 @@
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use crate::types::digest::Digest;
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use crate::types::identifier::block_identifier::BlockIdentifier;
 use crate::{
     types::{
@@ -14,51 +14,52 @@ use casper_client::{
     get_state_root_hash as get_state_root_hash_lib,
     rpcs::results::GetStateRootHashResult as _GetStateRootHashResult, JsonRpcId, SuccessResponse,
 };
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use gloo_utils::format::JsValueSerdeExt;
 use rand::Rng;
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use serde::{Deserialize, Serialize};
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use wasm_bindgen::prelude::*;
 
 /// Wrapper struct for the `GetStateRootHashResult` from casper_client.
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 #[derive(Debug, Deserialize, Clone, Serialize)]
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 pub struct GetStateRootHashResult(_GetStateRootHashResult);
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 impl From<GetStateRootHashResult> for _GetStateRootHashResult {
     fn from(result: GetStateRootHashResult) -> Self {
         result.0
     }
 }
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 impl From<_GetStateRootHashResult> for GetStateRootHashResult {
     fn from(result: _GetStateRootHashResult) -> Self {
         GetStateRootHashResult(result)
     }
 }
 
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl GetStateRootHashResult {
     /// Gets the API version as a JsValue.
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
+    #[cfg(feature = "js")]
     pub fn api_version(&self) -> JsValue {
         JsValue::from_serde(&self.0.api_version).unwrap()
     }
 
     /// Gets the state root hash as an Option<Digest>.
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
     pub fn state_root_hash(&self) -> Option<Digest> {
         self.0.state_root_hash.map(Into::into)
     }
 
     /// Gets the state root hash as a String.
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
     pub fn state_root_hash_as_string(&self) -> String {
         self.0
             .state_root_hash
@@ -68,14 +69,15 @@ impl GetStateRootHashResult {
     }
 
     /// Alias for state_root_hash_as_string
-    #[wasm_bindgen(js_name = "toString")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "toString"))]
     pub fn to_string_js_alias(&self) -> String {
         // You can still use to_string method for compatibility
         self.state_root_hash_as_string()
     }
 
     /// Converts the GetStateRootHashResult to a JsValue.
-    #[wasm_bindgen(js_name = "toJson")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "toJson"))]
+    #[cfg(feature = "js")]
     pub fn to_json(&self) -> JsValue {
         JsValue::from_serde(&self.0).unwrap_or(JsValue::null())
     }
@@ -83,8 +85,11 @@ impl GetStateRootHashResult {
 
 /// Options for the `get_state_root_hash` method.
 #[derive(Debug, Deserialize, Clone, Default, Serialize)]
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen(js_name = "getStateRootHashOptions", getter_with_clone)]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
+#[cfg_attr(
+    feature = "js",
+    wasm_bindgen(js_name = "getStateRootHashOptions", getter_with_clone)
+)]
 pub struct GetStateRootHashOptions {
     pub maybe_block_id_as_string: Option<String>,
     pub maybe_block_identifier: Option<BlockIdentifier>,
@@ -92,8 +97,8 @@ pub struct GetStateRootHashOptions {
     pub verbosity: Option<Verbosity>,
 }
 
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl SDK {
     /// Parses state root hash options from a JsValue.
     ///
@@ -104,6 +109,7 @@ impl SDK {
     /// # Returns
     ///
     /// Parsed state root hash options as a `GetStateRootHashOptions` struct.
+    #[cfg(feature = "js")]
     pub fn get_state_root_hash_options(
         &self,
         options: JsValue,
@@ -126,7 +132,8 @@ impl SDK {
     /// # Errors
     ///
     /// Returns a `JsError` if there is an error during the retrieval process.
-    #[wasm_bindgen(js_name = "get_state_root_hash")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "get_state_root_hash"))]
+    #[cfg(feature = "js")]
     pub async fn get_state_root_hash_js_alias(
         &self,
         options: Option<GetStateRootHashOptions>,
@@ -173,6 +180,7 @@ impl SDK {
     /// Returns a `JsError` if there is an error during the retrieval process.
     #[deprecated(note = "This function is an alias. Please use `get_state_root_hash` instead.")]
     #[allow(deprecated)]
+    #[cfg(feature = "js")]
     pub async fn chain_get_state_root_hash(
         &self,
         options: Option<GetStateRootHashOptions>,

--- a/src/sdk/rpcs/get_transaction.rs
+++ b/src/sdk/rpcs/get_transaction.rs
@@ -1,60 +1,64 @@
 use crate::types::hash::transaction_hash::TransactionHash;
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use crate::types::transaction::Transaction;
 use crate::{types::verbosity::Verbosity, SDK};
 use casper_client::{
     get_transaction, rpcs::results::GetTransactionResult as _GetTransactionResult, Error,
     JsonRpcId, SuccessResponse,
 };
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use gloo_utils::format::JsValueSerdeExt;
 use rand::Rng;
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "js")]
 use wasm_bindgen::prelude::*;
 
 // Define a struct to wrap the GetTransactionResult
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 #[derive(Debug, Deserialize, Clone, Serialize)]
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 pub struct GetTransactionResult(_GetTransactionResult);
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 impl From<GetTransactionResult> for _GetTransactionResult {
     fn from(result: GetTransactionResult) -> Self {
         result.0
     }
 }
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 impl From<_GetTransactionResult> for GetTransactionResult {
     fn from(result: _GetTransactionResult) -> Self {
         GetTransactionResult(result)
     }
 }
 
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl GetTransactionResult {
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
     /// Gets the API version as a JavaScript value.
+    #[cfg(feature = "js")]
     pub fn api_version(&self) -> JsValue {
         JsValue::from_serde(&self.0.api_version).unwrap()
     }
 
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
     /// Gets the transaction information.
     pub fn transaction(&self) -> Transaction {
         self.0.transaction.clone().into()
     }
 
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
     /// Gets the execution info as a JavaScript value.
+    #[cfg(feature = "js")]
     pub fn execution_info(&self) -> JsValue {
         JsValue::from_serde(&self.0.execution_info).unwrap()
     }
 
-    #[wasm_bindgen(js_name = "toJson")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "toJson"))]
     /// Converts the result to a JSON JavaScript value.
+    #[cfg(feature = "js")]
     pub fn to_json(&self) -> JsValue {
         JsValue::from_serde(&self.0).unwrap_or(JsValue::null())
     }
@@ -62,8 +66,11 @@ impl GetTransactionResult {
 
 /// Options for the `get_transaction` method.
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen(js_name = "getTransactionOptions", getter_with_clone)]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
+#[cfg_attr(
+    feature = "js",
+    wasm_bindgen(js_name = "getTransactionOptions", getter_with_clone)
+)]
 pub struct GetTransactionOptions {
     pub transaction_hash_as_string: Option<String>,
     pub transaction_hash: Option<TransactionHash>,
@@ -72,7 +79,7 @@ pub struct GetTransactionOptions {
     pub verbosity: Option<Verbosity>,
 }
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl SDK {
     /// Parses transaction options from a JsValue.
     ///
@@ -83,7 +90,7 @@ impl SDK {
     /// # Returns
     ///
     /// Parsed transaction options as a `GetTransactionOptions` struct.
-    #[cfg(target_arch = "wasm32")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
     pub fn get_transaction_options(
         &self,
         options: JsValue,
@@ -112,8 +119,8 @@ impl SDK {
     /// # Returns
     ///
     /// A `Result` containing either a `GetTransactionResult` or an error.
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(js_name = "get_transaction")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "get_transaction"))]
     pub async fn get_transaction_js_alias(
         &self,
         options: Option<GetTransactionOptions>,
@@ -156,7 +163,7 @@ impl SDK {
     }
 
     /// Retrieves transaction information using the provided options, alias for `get_transaction`.
-    #[cfg(target_arch = "wasm32")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
     #[deprecated(note = "This function is an alias. Please use `get_transaction` instead.")]
     #[allow(deprecated)]
     pub async fn info_get_transaction(

--- a/src/sdk/rpcs/get_validator_changes.rs
+++ b/src/sdk/rpcs/get_validator_changes.rs
@@ -3,59 +3,62 @@ use casper_client::{
     get_validator_changes, rpcs::results::GetValidatorChangesResult as _GetValidatorChangesResult,
     Error, JsonRpcId, SuccessResponse,
 };
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use gloo_utils::format::JsValueSerdeExt;
 use rand::Rng;
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use serde::{Deserialize, Serialize};
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use wasm_bindgen::prelude::*;
 
 /// Wrapper struct for the `GetValidatorChangesResult` from casper_client.
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 #[derive(Debug, Deserialize, Clone, Serialize)]
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 pub struct GetValidatorChangesResult(_GetValidatorChangesResult);
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 impl From<GetValidatorChangesResult> for _GetValidatorChangesResult {
     fn from(result: GetValidatorChangesResult) -> Self {
         result.0
     }
 }
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 impl From<_GetValidatorChangesResult> for GetValidatorChangesResult {
     fn from(result: _GetValidatorChangesResult) -> Self {
         GetValidatorChangesResult(result)
     }
 }
 
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl GetValidatorChangesResult {
     /// Gets the API version as a JsValue.
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
+    #[cfg(feature = "js")]
     pub fn api_version(&self) -> JsValue {
         JsValue::from_serde(&self.0.api_version).unwrap()
     }
 
     /// Gets the validator changes as a JsValue.
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
+    #[cfg(feature = "js")]
     pub fn changes(&self) -> JsValue {
         JsValue::from_serde(&self.0.changes).unwrap()
     }
 
     /// Converts the GetValidatorChangesResult to a JsValue.
-    #[wasm_bindgen(js_name = "toJson")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "toJson"))]
+    #[cfg(feature = "js")]
     pub fn to_json(&self) -> JsValue {
         JsValue::from_serde(&self.0).unwrap_or(JsValue::null())
     }
 }
 
 /// SDK methods for working with validator changes.
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl SDK {
     /// Retrieves validator changes using the provided options.
     ///
@@ -71,7 +74,8 @@ impl SDK {
     /// # Errors
     ///
     /// Returns a `JsError` if there is an error during the retrieval process.
-    #[wasm_bindgen(js_name = "get_validator_changes")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "get_validator_changes"))]
+    #[cfg(feature = "js")]
     pub async fn get_validator_changes_js_alias(
         &self,
         verbosity: Option<Verbosity>,
@@ -90,6 +94,7 @@ impl SDK {
     // JavaScript alias for `get_validator_changes`
     #[deprecated(note = "This function is an alias. Please use `get_validator_changes` instead.")]
     #[allow(deprecated)]
+    #[cfg(feature = "js")]
     pub async fn info_get_validator_change(
         &self,
         verbosity: Option<Verbosity>,

--- a/src/sdk/rpcs/list_rpcs.rs
+++ b/src/sdk/rpcs/list_rpcs.rs
@@ -2,65 +2,68 @@ use crate::{types::verbosity::Verbosity, SDK};
 use casper_client::{
     list_rpcs, rpcs::results::ListRpcsResult as _ListRpcsResult, Error, JsonRpcId, SuccessResponse,
 };
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use gloo_utils::format::JsValueSerdeExt;
 use rand::Rng;
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use serde::{Deserialize, Serialize};
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use wasm_bindgen::prelude::*;
 
 /// Wrapper struct for the `ListRpcsResult` from casper_client.
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 #[derive(Debug, Deserialize, Clone, Serialize)]
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 pub struct ListRpcsResult(_ListRpcsResult);
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 impl From<ListRpcsResult> for _ListRpcsResult {
     fn from(result: ListRpcsResult) -> Self {
         result.0
     }
 }
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 impl From<_ListRpcsResult> for ListRpcsResult {
     fn from(result: _ListRpcsResult) -> Self {
         ListRpcsResult(result)
     }
 }
 
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl ListRpcsResult {
     /// Gets the API version as a JsValue.
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
+    #[cfg(feature = "js")]
     pub fn api_version(&self) -> JsValue {
         JsValue::from_serde(&self.0.api_version).unwrap()
     }
 
     /// Gets the name of the RPC.
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
     pub fn name(&self) -> String {
         self.0.name.clone()
     }
 
     /// Gets the schema of the RPC as a JsValue.
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
+    #[cfg(feature = "js")]
     pub fn schema(&self) -> JsValue {
         JsValue::from_serde(&self.0.schema).unwrap()
     }
 
     /// Converts the ListRpcsResult to a JsValue.
-    #[wasm_bindgen(js_name = "toJson")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "toJson"))]
+    #[cfg(feature = "js")]
     pub fn to_json(&self) -> JsValue {
         JsValue::from_serde(&self.0).unwrap_or(JsValue::null())
     }
 }
 
 /// SDK methods for listing available RPCs.
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl SDK {
     /// Lists available RPCs using the provided options.
     ///
@@ -76,7 +79,8 @@ impl SDK {
     /// # Errors
     ///
     /// Returns a `JsError` if there is an error during the listing process.
-    #[wasm_bindgen(js_name = "list_rpcs")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "list_rpcs"))]
+    #[cfg(feature = "js")]
     pub async fn list_rpcs_js_alias(
         &self,
         verbosity: Option<Verbosity>,

--- a/src/sdk/rpcs/put_deploy.rs
+++ b/src/sdk/rpcs/put_deploy.rs
@@ -1,4 +1,4 @@
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use crate::deploy::deploy::PutDeployResult;
 use crate::types::deploy::Deploy;
 use crate::{types::verbosity::Verbosity, SDK};
@@ -8,12 +8,12 @@ use casper_client::{
     SuccessResponse,
 };
 use rand::Rng;
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use wasm_bindgen::prelude::*;
 
 /// SDK methods for putting a deploy.
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl SDK {
     /// Puts a deploy using the provided options.
     ///
@@ -30,8 +30,9 @@ impl SDK {
     /// # Errors
     ///
     /// Returns a `JsError` if there is an error during the deploy process.
-    #[wasm_bindgen(js_name = "put_deploy")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "put_deploy"))]
     #[allow(deprecated)]
+    #[cfg(feature = "js")]
     pub async fn put_deploy_js_alias(
         &self,
         deploy: Deploy,
@@ -51,6 +52,7 @@ impl SDK {
     /// JavaScript Alias for `put_deploy`.
     #[deprecated(note = "This function is an alias. Please use `put_deploy` instead.")]
     #[allow(deprecated)]
+    #[cfg(feature = "js")]
     pub async fn account_put_deploy(
         &self,
         deploy: Deploy,

--- a/src/sdk/rpcs/put_transaction.rs
+++ b/src/sdk/rpcs/put_transaction.rs
@@ -1,4 +1,4 @@
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use crate::transaction::transaction::PutTransactionResult;
 use crate::{
     types::{transaction::Transaction, verbosity::Verbosity},
@@ -9,12 +9,12 @@ use casper_client::{
     JsonRpcId, SuccessResponse,
 };
 use rand::Rng;
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use wasm_bindgen::prelude::*;
 
 /// SDK methods for putting a transaction.
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl SDK {
     /// Puts a transaction using the provided options.
     ///
@@ -31,7 +31,8 @@ impl SDK {
     /// # Errors
     ///
     /// Returns a `JsError` if there is an error during the transaction process.
-    #[wasm_bindgen(js_name = "put_transaction")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "put_transaction"))]
+    #[cfg(feature = "js")]
     pub async fn put_transaction_js_alias(
         &self,
         transaction: Transaction,
@@ -53,6 +54,7 @@ impl SDK {
     /// JavaScript Alias for `put_transaction`.
     #[deprecated(note = "This function is an alias. Please use `put_transaction` instead.")]
     #[allow(deprecated)]
+    #[cfg(feature = "js")]
     pub async fn account_put_transaction(
         &self,
         transaction: Transaction,

--- a/src/sdk/rpcs/query_balance.rs
+++ b/src/sdk/rpcs/query_balance.rs
@@ -1,4 +1,4 @@
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use crate::types::digest::Digest;
 use crate::{
     types::{
@@ -16,51 +16,54 @@ use casper_client::{
     rpcs::results::QueryBalanceResult as _QueryBalanceResult,
     JsonRpcId, SuccessResponse,
 };
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use gloo_utils::format::JsValueSerdeExt;
 use rand::Rng;
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use serde::{Deserialize, Serialize};
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use wasm_bindgen::prelude::*;
 
 // Define a struct to wrap the QueryBalanceResult
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 #[derive(Debug, Deserialize, Clone, Serialize)]
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 pub struct QueryBalanceResult(_QueryBalanceResult);
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 impl From<QueryBalanceResult> for _QueryBalanceResult {
     fn from(result: QueryBalanceResult) -> Self {
         result.0
     }
 }
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 impl From<_QueryBalanceResult> for QueryBalanceResult {
     fn from(result: _QueryBalanceResult) -> Self {
         QueryBalanceResult(result)
     }
 }
 
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl QueryBalanceResult {
     /// Gets the API version as a JsValue.
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
+    #[cfg(feature = "js")]
     pub fn api_version(&self) -> JsValue {
         JsValue::from_serde(&self.0.api_version).unwrap()
     }
 
     /// Gets the balance as a JsValue.
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
+    #[cfg(feature = "js")]
     pub fn balance(&self) -> JsValue {
         JsValue::from_serde(&self.0.balance).unwrap()
     }
 
     /// Converts the QueryBalanceResult to a JsValue.
-    #[wasm_bindgen(js_name = "toJson")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "toJson"))]
+    #[cfg(feature = "js")]
     pub fn to_json(&self) -> JsValue {
         JsValue::from_serde(&self.0).unwrap_or(JsValue::null())
     }
@@ -68,8 +71,11 @@ impl QueryBalanceResult {
 
 /// Options for the `query_balance` method.
 #[derive(Debug, Deserialize, Clone, Default, Serialize)]
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen(js_name = "queryBalanceOptions", getter_with_clone)]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
+#[cfg_attr(
+    feature = "js",
+    wasm_bindgen(js_name = "queryBalanceOptions", getter_with_clone)
+)]
 pub struct QueryBalanceOptions {
     pub purse_identifier_as_string: Option<String>,
     pub purse_identifier: Option<PurseIdentifier>,
@@ -81,8 +87,8 @@ pub struct QueryBalanceOptions {
     pub verbosity: Option<Verbosity>,
 }
 
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl SDK {
     /// Parses query balance options from a JsValue.
     ///
@@ -93,6 +99,7 @@ impl SDK {
     /// # Returns
     ///
     /// Parsed query balance options as a `QueryBalanceOptions` struct.
+    #[cfg(feature = "js")]
     pub fn query_balance_options(&self, options: JsValue) -> Result<QueryBalanceOptions, JsError> {
         options
             .into_serde::<QueryBalanceOptions>()
@@ -112,7 +119,8 @@ impl SDK {
     /// # Errors
     ///
     /// Returns a `JsError` if there is an error during the retrieval process.
-    #[wasm_bindgen(js_name = "query_balance")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "query_balance"))]
+    #[cfg(feature = "js")]
     pub async fn query_balance_js_alias(
         &self,
         options: Option<QueryBalanceOptions>,

--- a/src/sdk/rpcs/query_balance_details.rs
+++ b/src/sdk/rpcs/query_balance_details.rs
@@ -1,4 +1,4 @@
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use crate::types::digest::Digest;
 use crate::{
     types::{
@@ -17,65 +17,71 @@ use casper_client::{
     rpcs::results::QueryBalanceDetailsResult as _QueryBalanceDetailsResult, JsonRpcId,
     SuccessResponse,
 };
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use gloo_utils::format::JsValueSerdeExt;
 use rand::Rng;
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use serde::{Deserialize, Serialize};
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use wasm_bindgen::prelude::*;
 
 // Define a struct to wrap the QueryBalanceDetailsResult
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 #[derive(Debug, Deserialize, Clone, Serialize)]
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 pub struct QueryBalanceDetailsResult(_QueryBalanceDetailsResult);
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 impl From<QueryBalanceDetailsResult> for _QueryBalanceDetailsResult {
     fn from(result: QueryBalanceDetailsResult) -> Self {
         result.0
     }
 }
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 impl From<_QueryBalanceDetailsResult> for QueryBalanceDetailsResult {
     fn from(result: _QueryBalanceDetailsResult) -> Self {
         QueryBalanceDetailsResult(result)
     }
 }
 
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl QueryBalanceDetailsResult {
     /// Gets the API version as a JsValue.
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
+    #[cfg(feature = "js")]
     pub fn api_version(&self) -> JsValue {
         JsValue::from_serde(&self.0.api_version).unwrap()
     }
 
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
+    #[cfg(feature = "js")]
     pub fn total_balance(&self) -> JsValue {
         JsValue::from_serde(&self.0.total_balance).unwrap()
     }
 
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
+    #[cfg(feature = "js")]
     pub fn available_balance(&self) -> JsValue {
         JsValue::from_serde(&self.0.available_balance).unwrap()
     }
 
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
+    #[cfg(feature = "js")]
     pub fn total_balance_proof(&self) -> JsValue {
         JsValue::from_serde(&self.0.total_balance_proof).unwrap()
     }
 
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
+    #[cfg(feature = "js")]
     pub fn holds(&self) -> JsValue {
         JsValue::from_serde(&self.0.holds).unwrap()
     }
 
     /// Converts the QueryBalanceDetailsResult to a JsValue.
-    #[wasm_bindgen(js_name = "toJson")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "toJson"))]
+    #[cfg(feature = "js")]
     pub fn to_json(&self) -> JsValue {
         JsValue::from_serde(&self.0).unwrap_or(JsValue::null())
     }
@@ -83,8 +89,11 @@ impl QueryBalanceDetailsResult {
 
 /// Options for the `query_balance` method.
 #[derive(Debug, Deserialize, Clone, Default, Serialize)]
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen(js_name = "queryBalanceDetailsOptions", getter_with_clone)]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
+#[cfg_attr(
+    feature = "js",
+    wasm_bindgen(js_name = "queryBalanceDetailsOptions", getter_with_clone)
+)]
 pub struct QueryBalanceDetailsOptions {
     pub purse_identifier_as_string: Option<String>,
     pub purse_identifier: Option<PurseIdentifier>,
@@ -96,8 +105,8 @@ pub struct QueryBalanceDetailsOptions {
     pub verbosity: Option<Verbosity>,
 }
 
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl SDK {
     /// Parses query balance options from a JsValue.
     ///
@@ -108,6 +117,7 @@ impl SDK {
     /// # Returns
     ///
     /// Parsed query balance options as a `QueryBalanceDetailsOptions` struct.
+    #[cfg(feature = "js")]
     pub fn query_balance_details_options(
         &self,
         options: JsValue,
@@ -130,7 +140,8 @@ impl SDK {
     /// # Errors
     ///
     /// Returns a `JsError` if there is an error during the retrieval process.
-    #[wasm_bindgen(js_name = "query_balance_details")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "query_balance_details"))]
+    #[cfg(feature = "js")]
     pub async fn query_balance_details_js_alias(
         &self,
         options: Option<QueryBalanceDetailsOptions>,

--- a/src/sdk/rpcs/query_global_state.rs
+++ b/src/sdk/rpcs/query_global_state.rs
@@ -10,15 +10,16 @@ use casper_client::{
     query_global_state as query_global_state_lib,
     rpcs::results::QueryGlobalStateResult as _QueryGlobalStateResult, JsonRpcId, SuccessResponse,
 };
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use gloo_utils::format::JsValueSerdeExt;
 use rand::Rng;
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "js")]
 use wasm_bindgen::prelude::*;
 
 // Define a struct to wrap the QueryGlobalStateResult
 #[derive(Debug, Deserialize, Clone, Serialize)]
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 pub struct QueryGlobalStateResult(_QueryGlobalStateResult);
 
 impl From<QueryGlobalStateResult> for _QueryGlobalStateResult {
@@ -40,41 +41,45 @@ impl QueryGlobalStateResult {
     }
 }
 
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl QueryGlobalStateResult {
     /// Gets the API version as a JsValue.
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
+    #[cfg(feature = "js")]
     pub fn api_version(&self) -> JsValue {
         JsValue::from_serde(&self.0.api_version).unwrap()
     }
 
     /// Gets the block header as a JsValue.
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
+    #[cfg(feature = "js")]
     pub fn block_header(&self) -> JsValue {
         JsValue::from_serde(&self.0.block_header).unwrap()
     }
 
     /// Gets the stored value as a JsValue.
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
+    #[cfg(feature = "js")]
     pub fn stored_value(&self) -> JsValue {
         JsValue::from_serde(&self.0.stored_value).unwrap()
     }
 
     /// Gets the typed stored value wrapper.
-    #[wasm_bindgen(js_name = "storedValueTyped")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "storedValueTyped"))]
     pub fn stored_value_typed_js(&self) -> StoredValue {
         self.stored_value_typed()
     }
 
     /// Gets the Merkle proof as a string.
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
     pub fn merkle_proof(&self) -> String {
         self.0.merkle_proof.clone()
     }
 
     /// Converts the QueryGlobalStateResult to a JsValue.
-    #[wasm_bindgen(js_name = "toJson")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "toJson"))]
+    #[cfg(feature = "js")]
     pub fn to_json(&self) -> JsValue {
         JsValue::from_serde(&self.0).unwrap_or(JsValue::null())
     }
@@ -82,7 +87,10 @@ impl QueryGlobalStateResult {
 
 /// Options for the `query_global_state` method.
 #[derive(Debug, Deserialize, Clone, Default, Serialize)]
-#[wasm_bindgen(js_name = "queryGlobalStateOptions", getter_with_clone)]
+#[cfg_attr(
+    feature = "js",
+    wasm_bindgen(js_name = "queryGlobalStateOptions", getter_with_clone)
+)]
 pub struct QueryGlobalStateOptions {
     pub global_state_identifier: Option<GlobalStateIdentifier>,
     pub state_root_hash_as_string: Option<String>,
@@ -96,8 +104,8 @@ pub struct QueryGlobalStateOptions {
     pub verbosity: Option<Verbosity>,
 }
 
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl SDK {
     /// Parses query global state options from a JsValue.
     ///
@@ -108,6 +116,7 @@ impl SDK {
     /// # Returns
     ///
     /// Parsed query global state options as a `QueryGlobalStateOptions` struct.
+    #[cfg(feature = "js")]
     pub fn query_global_state_options(
         &self,
         options: JsValue,
@@ -130,7 +139,8 @@ impl SDK {
     /// # Errors
     ///
     /// Returns a `JsError` if there is an error during the retrieval process.
-    #[wasm_bindgen(js_name = "query_global_state")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "query_global_state"))]
+    #[cfg(feature = "js")]
     pub async fn query_global_state_js_alias(
         &self,
         options: Option<QueryGlobalStateOptions>,
@@ -154,7 +164,7 @@ impl SDK {
     }
 }
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 impl SDK {
     /// Builds parameters for querying global state based on the provided options.
     ///

--- a/src/sdk/rpcs/speculative_exec.rs
+++ b/src/sdk/rpcs/speculative_exec.rs
@@ -1,4 +1,4 @@
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use crate::types::hash::block_hash::BlockHash;
 use crate::types::transaction::Transaction;
 use crate::{
@@ -9,57 +9,60 @@ use casper_client::{
     rpcs::results::SpeculativeExecTxnResult as _SpeculativeExecTxnResult,
     speculative_exec_txn as speculative_exec_lib, JsonRpcId, SuccessResponse,
 };
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use gloo_utils::format::JsValueSerdeExt;
 use rand::Rng;
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use serde::{Deserialize, Serialize};
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use wasm_bindgen::prelude::*;
 
 // Define a struct to wrap the result of a speculative execution.
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 #[derive(Debug, Deserialize, Clone, Serialize)]
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 pub struct SpeculativeExecTxnResult(_SpeculativeExecTxnResult);
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 impl From<SpeculativeExecTxnResult> for _SpeculativeExecTxnResult {
     fn from(result: SpeculativeExecTxnResult) -> Self {
         result.0
     }
 }
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 impl From<_SpeculativeExecTxnResult> for SpeculativeExecTxnResult {
     fn from(result: _SpeculativeExecTxnResult) -> Self {
         SpeculativeExecTxnResult(result)
     }
 }
 
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl SpeculativeExecTxnResult {
     /// Get the API version of the result.
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
+    #[cfg(feature = "js")]
     pub fn api_version(&self) -> JsValue {
         JsValue::from_serde(&self.0.api_version).unwrap()
     }
 
     /// Get the block hash.
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
     pub fn block_hash(&self) -> BlockHash {
         self.0.execution_result.block_hash.into()
     }
 
     /// Get the execution result.
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
+    #[cfg(feature = "js")]
     pub fn execution_result(&self) -> JsValue {
         JsValue::from_serde(&self.0.execution_result).unwrap()
     }
 
     /// Convert the result to JSON format.
-    #[wasm_bindgen(js_name = "toJson")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "toJson"))]
+    #[cfg(feature = "js")]
     pub fn to_json(&self) -> JsValue {
         JsValue::from_serde(&self.0).unwrap_or(JsValue::null())
     }
@@ -67,8 +70,11 @@ impl SpeculativeExecTxnResult {
 
 /// Options for speculative execution.
 #[derive(Debug, Deserialize, Clone, Default, Serialize)]
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen(js_name = "getSpeculativeExecTxnOptions", getter_with_clone)]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
+#[cfg_attr(
+    feature = "js",
+    wasm_bindgen(js_name = "getSpeculativeExecTxnOptions", getter_with_clone)
+)]
 pub struct GetSpeculativeExecTxnOptions {
     /// The transaction as a JSON string.
     pub transaction_as_string: Option<String>,
@@ -83,10 +89,11 @@ pub struct GetSpeculativeExecTxnOptions {
     pub verbosity: Option<Verbosity>,
 }
 
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl SDK {
     /// Get options for speculative execution from a JavaScript value.
+    #[cfg(feature = "js")]
     pub fn get_speculative_exec_options(
         &self,
         options: JsValue,
@@ -105,7 +112,8 @@ impl SDK {
     /// # Returns
     ///
     /// A `Result` containing the result of the speculative execution or a `JsError` in case of an error.
-    #[wasm_bindgen(js_name = "speculative_exec")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "speculative_exec"))]
+    #[cfg(feature = "js")]
     pub async fn speculative_exec_js_alias(
         &self,
         options: Option<GetSpeculativeExecTxnOptions>,

--- a/src/sdk/rpcs/speculative_exec_deploy.rs
+++ b/src/sdk/rpcs/speculative_exec_deploy.rs
@@ -1,5 +1,5 @@
 use crate::types::deploy::Deploy;
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use crate::types::hash::block_hash::BlockHash;
 use crate::{
     types::{sdk_error::SdkError, verbosity::Verbosity},
@@ -10,57 +10,60 @@ use casper_client::{
     rpcs::results::SpeculativeExecResult as _SpeculativeExecResult,
     speculative_exec as speculative_exec_deploy_lib, JsonRpcId, SuccessResponse,
 };
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use gloo_utils::format::JsValueSerdeExt;
 use rand::Rng;
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use serde::{Deserialize, Serialize};
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use wasm_bindgen::prelude::*;
 
 // Define a struct to wrap the result of a speculative execution.
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 #[derive(Debug, Deserialize, Clone, Serialize)]
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 pub struct SpeculativeExecResult(_SpeculativeExecResult);
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 impl From<SpeculativeExecResult> for _SpeculativeExecResult {
     fn from(result: SpeculativeExecResult) -> Self {
         result.0
     }
 }
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 impl From<_SpeculativeExecResult> for SpeculativeExecResult {
     fn from(result: _SpeculativeExecResult) -> Self {
         SpeculativeExecResult(result)
     }
 }
 
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl SpeculativeExecResult {
     /// Get the API version of the result.
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
+    #[cfg(feature = "js")]
     pub fn api_version(&self) -> JsValue {
         JsValue::from_serde(&self.0.api_version).unwrap()
     }
 
     /// Get the block hash.
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
     pub fn block_hash(&self) -> BlockHash {
         self.0.execution_result.block_hash.into()
     }
 
     /// Get the execution result.
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
+    #[cfg(feature = "js")]
     pub fn execution_result(&self) -> JsValue {
         JsValue::from_serde(&self.0.execution_result).unwrap()
     }
 
     /// Convert the result to JSON format.
-    #[wasm_bindgen(js_name = "toJson")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "toJson"))]
+    #[cfg(feature = "js")]
     pub fn to_json(&self) -> JsValue {
         JsValue::from_serde(&self.0).unwrap_or(JsValue::null())
     }
@@ -68,8 +71,11 @@ impl SpeculativeExecResult {
 
 /// Options for speculative execution.
 #[derive(Debug, Deserialize, Clone, Default, Serialize)]
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen(js_name = "getSpeculativeExecDeployOptions", getter_with_clone)]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
+#[cfg_attr(
+    feature = "js",
+    wasm_bindgen(js_name = "getSpeculativeExecDeployOptions", getter_with_clone)
+)]
 pub struct GetSpeculativeExecDeployOptions {
     /// The deploy as a JSON string.
     pub deploy_as_string: Option<String>,
@@ -84,12 +90,13 @@ pub struct GetSpeculativeExecDeployOptions {
     pub verbosity: Option<Verbosity>,
 }
 
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl SDK {
     /// Get options for speculative execution from a JavaScript value.
     #[deprecated(note = "prefer speculative_exec_transaction_options")]
     #[allow(deprecated)]
+    #[cfg(feature = "js")]
     pub fn get_speculative_exec_deploy_options(
         &self,
         options: JsValue,
@@ -110,7 +117,8 @@ impl SDK {
     /// A `Result` containing the result of the speculative execution or a `JsError` in case of an error.
     #[deprecated(note = "prefer speculative_exec_transaction")]
     #[allow(deprecated)]
-    #[wasm_bindgen(js_name = "speculative_exec_deploy")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "speculative_exec_deploy"))]
+    #[cfg(feature = "js")]
     pub async fn speculative_exec_deploy_js_alias(
         &self,
         options: Option<GetSpeculativeExecDeployOptions>,

--- a/src/sdk/sse/ces/event.rs
+++ b/src/sdk/sse/ces/event.rs
@@ -2,27 +2,45 @@
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use wasm_bindgen::prelude::*;
 
 pub const EVENT_PREFIX: &str = "event_";
 
 /// One CES event decoded from an execution transform.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen(getter_with_clone))]
+#[cfg_attr(
+    all(feature = "js", target_arch = "wasm32"),
+    wasm_bindgen(getter_with_clone)
+)]
 pub struct CESEvent {
     pub name: String,
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = "contractHash"))]
+    #[cfg_attr(
+        all(feature = "js", target_arch = "wasm32"),
+        wasm_bindgen(js_name = "contractHash")
+    )]
     pub contract_hash: Option<String>,
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = "contractPackageHash"))]
+    #[cfg_attr(
+        all(feature = "js", target_arch = "wasm32"),
+        wasm_bindgen(js_name = "contractPackageHash")
+    )]
     pub contract_package_hash: Option<String>,
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = "eventId"))]
+    #[cfg_attr(
+        all(feature = "js", target_arch = "wasm32"),
+        wasm_bindgen(js_name = "eventId")
+    )]
     pub event_id: u64,
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = "transformIdx"))]
+    #[cfg_attr(
+        all(feature = "js", target_arch = "wasm32"),
+        wasm_bindgen(js_name = "transformIdx")
+    )]
     pub transform_idx: usize,
     /// Field name → JSON string of CLValue map (use `dataJson` from wasm).
     #[serde(default)]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = "dataJson"))]
+    #[cfg_attr(
+        all(feature = "js", target_arch = "wasm32"),
+        wasm_bindgen(js_name = "dataJson")
+    )]
     pub data_json: String,
 }
 
@@ -36,10 +54,10 @@ impl CESEvent {
     }
 }
 
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl CESEvent {
-    #[wasm_bindgen(js_name = "data")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "data"))]
     pub fn data_js(&self) -> String {
         self.data_json.clone()
     }
@@ -47,16 +65,19 @@ impl CESEvent {
 
 /// Parse result for one transform (error soft-fails like ces-js-parser).
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen(getter_with_clone))]
+#[cfg_attr(
+    all(feature = "js", target_arch = "wasm32"),
+    wasm_bindgen(getter_with_clone)
+)]
 pub struct CESParseResult {
     pub event: CESEvent,
     pub error: Option<String>,
 }
 
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl CESParseResult {
-    #[wasm_bindgen(js_name = "toJson")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "toJson"))]
     pub fn to_json(&self) -> Result<String, String> {
         serde_json::to_string(self).map_err(|e| e.to_string())
     }

--- a/src/sdk/sse/ces/parser.rs
+++ b/src/sdk/sse/ces/parser.rs
@@ -12,9 +12,10 @@ use casper_types::{
 };
 use serde_json::Value;
 use std::collections::HashMap;
+#[cfg(feature = "js")]
 use wasm_bindgen::prelude::*;
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use gloo_utils::format::JsValueSerdeExt;
 
 pub const EVENTS_SCHEMA_NAMED_KEY: &str = "__events_schema";
@@ -34,14 +35,14 @@ pub struct ContractMetadata {
 
 /// CES consume parser (ces-js-parser `Parser` parity).
 #[derive(Debug, Clone, Default)]
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 pub struct CESParser {
     contracts_metadata: HashMap<String, ContractMetadata>,
 }
 
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
+#[cfg_attr(all(feature = "js", target_arch = "wasm32"), wasm_bindgen)]
 impl CESParser {
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(constructor))]
+    #[cfg_attr(all(feature = "js", target_arch = "wasm32"), wasm_bindgen(constructor))]
     pub fn new() -> Self {
         Self {
             contracts_metadata: HashMap::new(),
@@ -49,13 +50,19 @@ impl CESParser {
     }
 
     /// Number of contracts loaded into this parser.
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = "contractCount"))]
+    #[cfg_attr(
+        all(feature = "js", target_arch = "wasm32"),
+        wasm_bindgen(js_name = "contractCount")
+    )]
     pub fn contract_count(&self) -> usize {
         self.contracts_metadata.len()
     }
 
     /// JSON schemas for all loaded contracts (keyed by events uref).
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = "schemasJson"))]
+    #[cfg_attr(
+        all(feature = "js", target_arch = "wasm32"),
+        wasm_bindgen(js_name = "schemasJson")
+    )]
     pub fn schemas_json(&self) -> Result<String, String> {
         let mut root = serde_json::Map::new();
         for (uref, meta) in &self.contracts_metadata {
@@ -503,10 +510,11 @@ async fn query_stored_value_json(
     Ok(stored)
 }
 
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl CESParser {
-    #[wasm_bindgen(js_name = "parseExecutionResultJson")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "parseExecutionResultJson"))]
+    #[cfg(feature = "js")]
     pub fn parse_execution_result_json_js(
         &self,
         execution_result_json: &str,

--- a/src/sdk/sse/ces/schema.rs
+++ b/src/sdk/sse/ces/schema.rs
@@ -6,7 +6,7 @@ use casper_types::{
 };
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use wasm_bindgen::prelude::*;
 
 const CL_TYPE_TAG_BOOL: u8 = 0;
@@ -202,10 +202,16 @@ pub fn parse_schemas_from_hex(hex_str: &str) -> Result<Schemas, String> {
 
 /// JSON-friendly schema field for wasm / MCP.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen(getter_with_clone))]
+#[cfg_attr(
+    all(feature = "js", target_arch = "wasm32"),
+    wasm_bindgen(getter_with_clone)
+)]
 pub struct SchemaFieldJson {
     pub name: String,
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = "clType"))]
+    #[cfg_attr(
+        all(feature = "js", target_arch = "wasm32"),
+        wasm_bindgen(js_name = "clType")
+    )]
     pub cl_type: String,
 }
 

--- a/src/sdk/sse/client.rs
+++ b/src/sdk/sse/client.rs
@@ -5,9 +5,10 @@ use super::framing::{extract_frames, url_with_start_from};
 use crate::SDK;
 use futures_util::StreamExt;
 use std::sync::{Arc, Mutex};
+#[cfg(feature = "js")]
 use wasm_bindgen::prelude::*;
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use gloo_utils::format::JsValueSerdeExt;
 
 /// HTTP client for native SSE. Disables idle keep-alive so a dropped tokio
@@ -28,16 +29,16 @@ fn sse_http_client() -> Result<reqwest::Client, String> {
 }
 
 /// Native event handler.
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(all(feature = "js", target_arch = "wasm32")))]
 pub type SSEHandlerFn = Arc<Mutex<dyn Fn(RawEvent) + Send + Sync>>;
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(all(feature = "js", target_arch = "wasm32")))]
 fn call_handler(handler: &SSEHandlerFn, event: RawEvent) {
     let f = handler.lock().unwrap();
     f(event);
 }
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 fn call_handler(handler: &js_sys::Function, event: RawEvent) {
     let this = JsValue::null();
     let args = js_sys::Array::new();
@@ -47,15 +48,15 @@ fn call_handler(handler: &js_sys::Function, event: RawEvent) {
 
 struct Subscription {
     event_name: EventName,
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(not(all(feature = "js", target_arch = "wasm32")))]
     handler: SSEHandlerFn,
-    #[cfg(target_arch = "wasm32")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
     handler: js_sys::Function,
 }
 
 /// Node SSE client: subscribe by [`EventName`], start/stop stream.
 #[derive(Clone)]
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 pub struct SSEClient {
     events_url: String,
     subscriptions: Arc<Mutex<Vec<Subscription>>>,
@@ -82,18 +83,18 @@ impl SDK {
     }
 }
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl SDK {
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(js_name = "SSE_client")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "SSE_client"))]
     #[allow(non_snake_case)]
     pub fn SSE_client_js(&self, events_url: &str) -> SSEClient {
         self.SSE_client(events_url)
     }
 
     /// Build a [`CESParser`] for `contract_hashes` (JS array of hex / `hash-…` strings).
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(js_name = "CES_parser")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "CES_parser"))]
     #[allow(non_snake_case)]
     pub async fn CES_parser_js(
         &self,
@@ -110,9 +111,9 @@ impl SDK {
     }
 }
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl SSEClient {
-    #[wasm_bindgen(constructor)]
+    #[cfg_attr(feature = "js", wasm_bindgen(constructor))]
     pub fn new(events_url: String) -> Self {
         Self {
             events_url,
@@ -122,7 +123,7 @@ impl SSEClient {
     }
 
     /// Stop the running stream loop.
-    #[wasm_bindgen]
+    #[cfg_attr(feature = "js", wasm_bindgen)]
     pub fn stop(&self) {
         if let Ok(mut active) = self.active.lock() {
             *active = false;
@@ -130,8 +131,8 @@ impl SSEClient {
     }
 
     /// Unsubscribe by event name string (wasm).
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(js_name = "unsubscribe")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "unsubscribe"))]
     pub fn unsubscribe_js(&self, event_name: &str) -> Result<(), String> {
         let name =
             EventName::parse(event_name).ok_or_else(|| format!("unknown event: {event_name}"))?;
@@ -139,8 +140,8 @@ impl SSEClient {
     }
 
     /// Subscribe with a JS function handler (wasm).
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(js_name = "subscribe")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "subscribe"))]
     pub fn subscribe_js(&self, event_name: &str, handler: js_sys::Function) -> Result<(), String> {
         let name =
             EventName::parse(event_name).ok_or_else(|| format!("unknown event: {event_name}"))?;
@@ -156,8 +157,8 @@ impl SSEClient {
     }
 
     /// Start streaming (wasm). Resolves when stopped, errored, or stream ends.
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(js_name = "start")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "start"))]
     pub async fn start_js(&self, start_from: Option<u64>) -> Result<(), JsError> {
         self.start(start_from).await.map_err(|e| JsError::new(&e))
     }
@@ -165,7 +166,7 @@ impl SSEClient {
 
 impl SSEClient {
     /// Subscribe to one event name (native).
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(not(all(feature = "js", target_arch = "wasm32")))]
     pub fn subscribe<F>(&self, event_name: EventName, handler: F) -> Result<(), String>
     where
         F: Fn(RawEvent) + Send + Sync + 'static,

--- a/src/sdk/sse/event.rs
+++ b/src/sdk/sse/event.rs
@@ -3,7 +3,7 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::fmt;
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use wasm_bindgen::prelude::*;
 
 /// Node SSE event type names (JS `EventName` parity).
@@ -92,12 +92,21 @@ impl fmt::Display for EventName {
 
 /// Raw SSE envelope before typed parse (JS `RawEvent` parity).
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen(getter_with_clone))]
+#[cfg_attr(
+    all(feature = "js", target_arch = "wasm32"),
+    wasm_bindgen(getter_with_clone)
+)]
 pub struct RawEvent {
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = "eventType"))]
+    #[cfg_attr(
+        all(feature = "js", target_arch = "wasm32"),
+        wasm_bindgen(js_name = "eventType")
+    )]
     pub event_type: String,
     pub data: String,
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = "lastEventId"))]
+    #[cfg_attr(
+        all(feature = "js", target_arch = "wasm32"),
+        wasm_bindgen(js_name = "lastEventId")
+    )]
     pub last_event_id: String,
 }
 
@@ -145,15 +154,18 @@ impl RawEvent {
     }
 }
 
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
+#[cfg_attr(all(feature = "js", target_arch = "wasm32"), wasm_bindgen)]
 impl RawEvent {
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(constructor)]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(constructor))]
     pub fn new_js(event_type: String, data: String, last_event_id: String) -> Self {
         Self::new(event_type, data, last_event_id)
     }
 
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = "parseAsApiVersion"))]
+    #[cfg_attr(
+        all(feature = "js", target_arch = "wasm32"),
+        wasm_bindgen(js_name = "parseAsApiVersion")
+    )]
     pub fn parse_as_api_version(&self) -> Result<ApiVersionEvent, String> {
         let v = self.extract_named(EventName::ApiVersion)?;
         match v {
@@ -164,7 +176,10 @@ impl RawEvent {
         }
     }
 
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = "parseAsBlockAdded"))]
+    #[cfg_attr(
+        all(feature = "js", target_arch = "wasm32"),
+        wasm_bindgen(js_name = "parseAsBlockAdded")
+    )]
     pub fn parse_as_block_added(&self) -> Result<SSEPayload, String> {
         SSEPayload::from_named(
             EventName::BlockAdded,
@@ -173,7 +188,7 @@ impl RawEvent {
     }
 
     #[cfg_attr(
-        target_arch = "wasm32",
+        all(feature = "js", target_arch = "wasm32"),
         wasm_bindgen(js_name = "parseAsDeployProcessed")
     )]
     pub fn parse_as_deploy_processed(&self) -> Result<SSEPayload, String> {
@@ -184,7 +199,7 @@ impl RawEvent {
     }
 
     #[cfg_attr(
-        target_arch = "wasm32",
+        all(feature = "js", target_arch = "wasm32"),
         wasm_bindgen(js_name = "parseAsDeployAccepted")
     )]
     pub fn parse_as_deploy_accepted(&self) -> Result<SSEPayload, String> {
@@ -194,7 +209,10 @@ impl RawEvent {
         )
     }
 
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = "parseAsDeployExpired"))]
+    #[cfg_attr(
+        all(feature = "js", target_arch = "wasm32"),
+        wasm_bindgen(js_name = "parseAsDeployExpired")
+    )]
     pub fn parse_as_deploy_expired(&self) -> Result<SSEPayload, String> {
         SSEPayload::from_named(
             EventName::DeployExpired,
@@ -203,7 +221,7 @@ impl RawEvent {
     }
 
     #[cfg_attr(
-        target_arch = "wasm32",
+        all(feature = "js", target_arch = "wasm32"),
         wasm_bindgen(js_name = "parseAsTransactionProcessed")
     )]
     pub fn parse_as_transaction_processed(&self) -> Result<SSEPayload, String> {
@@ -214,7 +232,7 @@ impl RawEvent {
     }
 
     #[cfg_attr(
-        target_arch = "wasm32",
+        all(feature = "js", target_arch = "wasm32"),
         wasm_bindgen(js_name = "parseAsTransactionAccepted")
     )]
     pub fn parse_as_transaction_accepted(&self) -> Result<SSEPayload, String> {
@@ -225,7 +243,7 @@ impl RawEvent {
     }
 
     #[cfg_attr(
-        target_arch = "wasm32",
+        all(feature = "js", target_arch = "wasm32"),
         wasm_bindgen(js_name = "parseAsTransactionExpired")
     )]
     pub fn parse_as_transaction_expired(&self) -> Result<SSEPayload, String> {
@@ -236,7 +254,7 @@ impl RawEvent {
     }
 
     #[cfg_attr(
-        target_arch = "wasm32",
+        all(feature = "js", target_arch = "wasm32"),
         wasm_bindgen(js_name = "parseAsFinalitySignature")
     )]
     pub fn parse_as_finality_signature(&self) -> Result<SSEPayload, String> {
@@ -246,19 +264,25 @@ impl RawEvent {
         )
     }
 
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = "parseAsStep"))]
+    #[cfg_attr(
+        all(feature = "js", target_arch = "wasm32"),
+        wasm_bindgen(js_name = "parseAsStep")
+    )]
     pub fn parse_as_step(&self) -> Result<SSEPayload, String> {
         SSEPayload::from_named(EventName::Step, self.extract_named(EventName::Step)?)
     }
 
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = "parseAsFault"))]
+    #[cfg_attr(
+        all(feature = "js", target_arch = "wasm32"),
+        wasm_bindgen(js_name = "parseAsFault")
+    )]
     pub fn parse_as_fault(&self) -> Result<SSEPayload, String> {
         SSEPayload::from_named(EventName::Fault, self.extract_named(EventName::Fault)?)
     }
 
     /// JSON string of the named payload body (wasm-friendly).
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(js_name = "payloadJson")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "payloadJson"))]
     pub fn payload_json_js(&self, event_name: &str) -> Result<String, String> {
         let name =
             EventName::parse(event_name).ok_or_else(|| format!("unknown event: {event_name}"))?;
@@ -269,11 +293,17 @@ impl RawEvent {
 
 /// Typed wrapper with event name and JSON payload body.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen(getter_with_clone))]
+#[cfg_attr(
+    all(feature = "js", target_arch = "wasm32"),
+    wasm_bindgen(getter_with_clone)
+)]
 pub struct SSEPayload {
     pub name: String,
     /// JSON string of the named payload body.
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = "bodyJson"))]
+    #[cfg_attr(
+        all(feature = "js", target_arch = "wasm32"),
+        wasm_bindgen(js_name = "bodyJson")
+    )]
     pub body_json: String,
 }
 
@@ -290,10 +320,10 @@ impl SSEPayload {
     }
 }
 
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl SSEPayload {
-    #[wasm_bindgen(js_name = "body")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "body"))]
     pub fn body_js(&self) -> Result<String, String> {
         Ok(self.body_json.clone())
     }
@@ -301,9 +331,15 @@ impl SSEPayload {
 
 /// `ApiVersion` handshake payload.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen(getter_with_clone))]
+#[cfg_attr(
+    all(feature = "js", target_arch = "wasm32"),
+    wasm_bindgen(getter_with_clone)
+)]
 pub struct ApiVersionEvent {
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = "apiVersion"))]
+    #[cfg_attr(
+        all(feature = "js", target_arch = "wasm32"),
+        wasm_bindgen(js_name = "apiVersion")
+    )]
     pub api_version: String,
 }
 

--- a/src/sdk/sse/watcher/mod.rs
+++ b/src/sdk/sse/watcher/mod.rs
@@ -7,9 +7,9 @@ use crate::sdk::sse::framing::{extract_frames, url_with_start_from};
 use crate::SDK;
 use chrono::{Duration, Utc};
 use futures_util::StreamExt;
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use gloo_utils::format::JsValueSerdeExt;
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use js_sys::Promise;
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::Value;
@@ -17,8 +17,9 @@ use std::{
     fmt,
     sync::{Arc, Mutex},
 };
+#[cfg(feature = "js")]
 use wasm_bindgen::prelude::*;
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use wasm_bindgen_futures::future_to_promise;
 
 const DEFAULT_TIMEOUT_MS: u64 = 60000;
@@ -153,7 +154,7 @@ impl SDK {
     }
 }
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl SDK {
     /// Creates a new Watcher instance to watch deploys (JavaScript-friendly).
     /// Legacy alias
@@ -166,8 +167,8 @@ impl SDK {
     /// # Returns
     ///
     /// A `Watcher` instance.
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(js_name = "watchDeploy")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "watchDeploy"))]
     #[deprecated(note = "prefer 'watchTransaction'")]
     #[allow(deprecated)]
     pub fn watch_deploy_js_alias(
@@ -188,8 +189,8 @@ impl SDK {
     /// # Returns
     ///
     /// A `Watcher` instance.
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(js_name = "watchTransaction")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "watchTransaction"))]
     pub fn watch_transaction_js_alias(
         &self,
         events_url: &str,
@@ -210,8 +211,8 @@ impl SDK {
     /// # Returns
     ///
     /// A JavaScript `Promise` resolving to either the processed `EventParseResult` or an error message.
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(js_name = "waitDeploy")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "waitDeploy"))]
     #[deprecated(note = "prefer 'waitTransaction' with transaction")]
     #[allow(deprecated)]
     pub async fn wait_deploy_js_alias(
@@ -235,8 +236,8 @@ impl SDK {
     /// # Returns
     ///
     /// A JavaScript `Promise` resolving to either the processed `EventParseResult` or an error message.
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(js_name = "waitTransaction")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "waitTransaction"))]
     pub async fn wait_transaction_js_alias(
         &self,
         events_url: &str,
@@ -275,7 +276,7 @@ impl SDK {
 /// * `active` - Reference-counted cell indicating whether the deploy watcher is active.
 /// * `timeout_duration` - Duration representing the optional timeout for watching events.
 #[derive(Clone)]
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 pub struct Watcher {
     events_url: String,
     subscriptions: Vec<Subscription>,
@@ -283,7 +284,7 @@ pub struct Watcher {
     timeout_duration: Duration,
 }
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl Watcher {
     /// Creates a new `Watcher` instance.
     ///
@@ -296,7 +297,7 @@ impl Watcher {
     /// # Returns
     ///
     /// A new `Watcher` instance.
-    #[wasm_bindgen(constructor)]
+    #[cfg_attr(feature = "js", wasm_bindgen(constructor))]
     pub fn new(events_url: String, timeout_duration: Option<u64>) -> Self {
         let timeout_duration = Duration::try_milliseconds(
             timeout_duration
@@ -323,8 +324,8 @@ impl Watcher {
     /// # Returns
     ///
     /// Result indicating success or an error message.
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(js_name = "subscribe")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "subscribe"))]
     pub fn subscribe_js_alias(&mut self, subscriptions: Vec<Subscription>) -> Result<(), String> {
         self.subscribe(subscriptions)
     }
@@ -336,7 +337,7 @@ impl Watcher {
     /// * `transaction_hash` - The transaction hash to unsubscribe.
     ///
     /// This method removes the deploy subscription associated with the provided transaction hash.
-    #[wasm_bindgen]
+    #[cfg_attr(feature = "js", wasm_bindgen)]
     pub fn unsubscribe(&mut self, target_hash: String) {
         self.subscriptions.retain(|s| s.target_hash != target_hash);
     }
@@ -346,8 +347,8 @@ impl Watcher {
     /// # Returns
     ///
     /// Result containing the serialized transaction events data or an error message.
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(js_name = "start")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "start"))]
     pub async fn start_js_alias(&self) -> Result<JsValue, JsError> {
         let result = match self.start_internal(None).await {
             Some(res) => res,
@@ -363,7 +364,7 @@ impl Watcher {
     /// Stops watching for transaction events.
     ///
     /// This method sets the deploy watcher as inactive and stops the event listener if it exists.
-    #[wasm_bindgen]
+    #[cfg_attr(feature = "js", wasm_bindgen)]
     pub fn stop(&self) {
         {
             let mut active = self.active.lock().unwrap();
@@ -618,11 +619,11 @@ impl Watcher {
                             if transaction_hash_processed == subscription.target_hash {
                                 let event_handler = &subscription.event_handler_fn;
 
-                                #[cfg(not(target_arch = "wasm32"))]
+                                #[cfg(not(all(feature = "js", target_arch = "wasm32")))]
                                 {
                                     event_handler.call(event_parse_result.clone());
                                 }
-                                #[cfg(target_arch = "wasm32")]
+                                #[cfg(all(feature = "js", target_arch = "wasm32"))]
                                 {
                                     let this = JsValue::null();
                                     let args = js_sys::Array::new();
@@ -708,9 +709,9 @@ impl Default for EventHandlerFn {
     }
 }
 
-// Define Subscription struct with different configurations based on the target architecture.
-#[cfg(not(target_arch = "wasm32"))]
-/// Represents a subscription to transaction events for non-wasm32 target architecture.
+// Define Subscription struct with different configurations based on JS/wasm surface.
+#[cfg(not(all(feature = "js", target_arch = "wasm32")))]
+/// Represents a subscription to transaction events (native / Rust-only wasm).
 #[derive(Debug, Clone, Default)]
 pub struct Subscription {
     /// Transaction target hash to identify the subscription.
@@ -719,16 +720,16 @@ pub struct Subscription {
     pub event_handler_fn: EventHandlerFn,
 }
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 /// Represents a subscription to transaction events for wasm32 target architecture.
 #[derive(Debug, Clone, Default)]
-#[wasm_bindgen(getter_with_clone)]
+#[cfg_attr(feature = "js", wasm_bindgen(getter_with_clone))]
 pub struct Subscription {
     /// Transaction target hash to identify the subscription.
-    #[wasm_bindgen(js_name = "targetHash")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "targetHash"))]
     pub target_hash: String,
     /// Handler function for transaction events.
-    #[wasm_bindgen(js_name = "eventHandlerFn")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "eventHandlerFn"))]
     pub event_handler_fn: js_sys::Function,
 }
 
@@ -739,7 +740,7 @@ impl Subscription {
     ///
     /// * `target_hash` - Transaction target hash to identify the subscription.
     /// * `event_handler_fn` - Handler function for transaction events.
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(not(all(feature = "js", target_arch = "wasm32")))]
     pub fn new(target_hash: String, event_handler_fn: EventHandlerFn) -> Self {
         Self {
             target_hash,
@@ -748,7 +749,7 @@ impl Subscription {
     }
 }
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl Subscription {
     /// Constructor for Subscription for wasm32 target architecture.
     ///
@@ -756,8 +757,8 @@ impl Subscription {
     ///
     /// * `transaction_hash` - Transaction hash to identify the subscription.
     /// * `event_handler_fn` - Handler function for transaction events.
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(constructor)]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(constructor))]
     pub fn new(target_hash: String, event_handler_fn: js_sys::Function) -> Self {
         Self {
             target_hash,
@@ -768,7 +769,7 @@ impl Subscription {
 
 /// Represents a failure response containing an error message.
 #[derive(Debug, Deserialize, Clone, Default, Serialize)]
-#[wasm_bindgen(getter_with_clone)]
+#[cfg_attr(feature = "js", wasm_bindgen(getter_with_clone))]
 pub struct Failure {
     pub cost: String,
     pub error_message: String,
@@ -776,7 +777,7 @@ pub struct Failure {
 
 /// Represents a success response containing a cost value.
 #[derive(Debug, Deserialize, Clone, Default, Serialize)]
-#[wasm_bindgen(getter_with_clone)]
+#[cfg_attr(feature = "js", wasm_bindgen(getter_with_clone))]
 pub struct Version2 {
     pub initiator: PublicKeyString,
     pub error_message: Option<String>,
@@ -787,27 +788,27 @@ pub struct Version2 {
 }
 
 #[derive(Debug, Deserialize, Clone, Default, Serialize)]
-#[wasm_bindgen(getter_with_clone)]
+#[cfg_attr(feature = "js", wasm_bindgen(getter_with_clone))]
 pub struct Payment {
     pub source: String,
 }
 
 /// Represents the result of an execution, either Success or Failure.
 #[derive(Debug, Deserialize, Clone, Default, Serialize)]
-#[wasm_bindgen(getter_with_clone)]
+#[cfg_attr(feature = "js", wasm_bindgen(getter_with_clone))]
 pub struct ExecutionResult {
     /// Optional Success information.
     #[serde(rename = "Version2")]
-    #[wasm_bindgen(js_name = "Success")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "Success"))]
     pub success: Option<Version2>,
     /// Optional Failure information.
     #[serde(rename = "Failure")]
-    #[wasm_bindgen(js_name = "Failure")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "Failure"))]
     pub failure: Option<Failure>,
 }
 
 #[derive(Debug, Clone, Serialize, Default)]
-#[wasm_bindgen(getter_with_clone)]
+#[cfg_attr(feature = "js", wasm_bindgen(getter_with_clone))]
 pub struct HashString {
     pub hash: String,
 }
@@ -834,19 +835,19 @@ impl<'de> Deserialize<'de> for HashString {
     }
 }
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl HashString {
-    #[wasm_bindgen(getter, js_name = "Deploy")]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter, js_name = "Deploy"))]
     pub fn deploy(&self) -> String {
         self.hash.clone()
     }
 
-    #[wasm_bindgen(getter, js_name = "Version1")]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter, js_name = "Version1"))]
     pub fn version1(&self) -> String {
         self.hash.clone()
     }
 
-    #[wasm_bindgen(js_name = "toString")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "toString"))]
     pub fn to_string_js(&self) -> String {
         self.to_string()
     }
@@ -859,23 +860,23 @@ impl fmt::Display for HashString {
 }
 
 #[derive(Debug, Deserialize, Clone, Serialize, Default)]
-#[wasm_bindgen(getter_with_clone)]
+#[cfg_attr(feature = "js", wasm_bindgen(getter_with_clone))]
 pub struct PublicKeyString {
     #[serde(rename = "PublicKey")]
-    #[wasm_bindgen(js_name = "PublicKey")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "PublicKey"))]
     pub public_key: String,
 }
 
 #[derive(Debug, Deserialize, Clone, Serialize, Default)]
-#[wasm_bindgen(getter_with_clone)]
+#[cfg_attr(feature = "js", wasm_bindgen(getter_with_clone))]
 pub struct Message {
     #[serde(rename = "String")]
-    #[wasm_bindgen(js_name = "String")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "String"))]
     pub string: String,
 }
 
 #[derive(Debug, Deserialize, Clone, Serialize, Default)]
-#[wasm_bindgen(getter_with_clone)]
+#[cfg_attr(feature = "js", wasm_bindgen(getter_with_clone))]
 pub struct Messages {
     pub entity_hash: String,
     pub message: Message,
@@ -887,7 +888,7 @@ pub struct Messages {
 
 /// Represents processed deploy information.
 #[derive(Debug, Deserialize, Clone, Default, Serialize)]
-#[wasm_bindgen(getter_with_clone)]
+#[cfg_attr(feature = "js", wasm_bindgen(getter_with_clone))]
 pub struct TransactionProcessed {
     #[serde(alias = "transaction_hash")]
     pub hash: HashString,
@@ -902,23 +903,26 @@ pub struct TransactionProcessed {
 
 /// Represents the body of an event, containing processed deploy information.
 #[derive(Debug, Deserialize, Clone, Default, Serialize)]
-#[wasm_bindgen(getter_with_clone)]
+#[cfg_attr(feature = "js", wasm_bindgen(getter_with_clone))]
 pub struct Body {
     #[serde(rename = "TransactionProcessed")]
     pub transaction_processed: Option<TransactionProcessed>,
 }
 
 // Implementing methods to get the field using different aliases
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl Body {
-    #[wasm_bindgen(getter, js_name = "get_deploy_processed")]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter, js_name = "get_deploy_processed"))]
     #[deprecated(note = "prefer 'get_transaction_processed'")]
     #[allow(deprecated)]
     pub fn get_deploy_processed(&self) -> Option<TransactionProcessed> {
         self.transaction_processed.clone()
     }
 
-    #[wasm_bindgen(getter, js_name = "get_transaction_processed")]
+    #[cfg_attr(
+        feature = "js",
+        wasm_bindgen(getter, js_name = "get_transaction_processed")
+    )]
     pub fn get_transaction_processed(&self) -> Option<TransactionProcessed> {
         self.transaction_processed.clone()
     }
@@ -926,7 +930,7 @@ impl Body {
 
 /// Represents the result of parsing an event, containing error information and the event body.
 #[derive(Debug, Deserialize, Clone, Default, Serialize)]
-#[wasm_bindgen(getter_with_clone)]
+#[cfg_attr(feature = "js", wasm_bindgen(getter_with_clone))]
 pub struct EventParseResult {
     pub err: Option<String>,
     pub body: Option<Body>,

--- a/src/sdk/transaction/speculative_transaction.rs
+++ b/src/sdk/transaction/speculative_transaction.rs
@@ -1,4 +1,4 @@
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use crate::rpcs::speculative_exec::SpeculativeExecTxnResult;
 use crate::{
     types::{
@@ -19,11 +19,11 @@ use casper_client::{
     cli::make_transaction, rpcs::results::SpeculativeExecTxnResult as _SpeculativeExecTxnResult,
     SuccessResponse,
 };
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use wasm_bindgen::prelude::*;
 
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl SDK {
     /// This function allows executing a transaction speculatively.
     ///
@@ -37,8 +37,9 @@ impl SDK {
     /// # Returns
     ///
     /// A `Result` containing either a `SpeculativeExecTxnResult` or a `JsError` in case of an error.
-    #[wasm_bindgen(js_name = "speculative_transaction")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "speculative_transaction"))]
     #[allow(clippy::too_many_arguments)]
+    #[cfg(feature = "js")]
     pub async fn speculative_transaction_js_alias(
         &self,
         builder_params: TransactionBuilderParams,

--- a/src/sdk/transaction/speculative_transfer_transaction.rs
+++ b/src/sdk/transaction/speculative_transfer_transaction.rs
@@ -1,4 +1,4 @@
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use crate::rpcs::speculative_exec::SpeculativeExecTxnResult;
 use crate::{
     make_transfer_transaction,
@@ -11,11 +11,11 @@ use crate::{
 use casper_client::{
     rpcs::results::SpeculativeExecTxnResult as _SpeculativeExecTxnResult, SuccessResponse,
 };
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use wasm_bindgen::prelude::*;
 
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl SDK {
     /// JS function for speculative transfer transaction.
     ///
@@ -33,7 +33,11 @@ impl SDK {
     ///
     /// A `Result` containing the result of the speculative transfer or a `JsError` in case of an error.
     #[allow(clippy::too_many_arguments)]
-    #[wasm_bindgen(js_name = "speculative_transfer_transaction")]
+    #[cfg_attr(
+        feature = "js",
+        wasm_bindgen(js_name = "speculative_transfer_transaction")
+    )]
+    #[cfg(feature = "js")]
     pub async fn speculative_transfer_transaction_js_alias(
         &self,
         maybe_source: Option<URef>,

--- a/src/sdk/transaction/transaction.rs
+++ b/src/sdk/transaction/transaction.rs
@@ -1,4 +1,4 @@
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use crate::types::hash::transaction_hash::TransactionHash;
 use crate::{
     types::{
@@ -20,27 +20,27 @@ use casper_client::{
     cli::make_transaction, rpcs::results::PutTransactionResult as _PutTransactionResult,
     SuccessResponse,
 };
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use gloo_utils::format::JsValueSerdeExt;
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use serde::{Deserialize, Serialize};
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use wasm_bindgen::prelude::*;
 
 // Define a struct to wrap the result of a transaction.
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 #[derive(Debug, Deserialize, Clone, Serialize)]
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 pub struct PutTransactionResult(_PutTransactionResult);
 
 /// Implement conversions between PutTransactionResult and _PutTransactionResult.
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 impl From<PutTransactionResult> for _PutTransactionResult {
     fn from(result: PutTransactionResult) -> Self {
         result.0
     }
 }
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 impl From<_PutTransactionResult> for PutTransactionResult {
     fn from(result: _PutTransactionResult) -> Self {
         PutTransactionResult(result)
@@ -48,30 +48,32 @@ impl From<_PutTransactionResult> for PutTransactionResult {
 }
 
 /// Implement JavaScript bindings for PutTransactionResult.
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl PutTransactionResult {
     /// Gets the API version as a JavaScript value.
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
+    #[cfg(feature = "js")]
     pub fn api_version(&self) -> JsValue {
         JsValue::from_serde(&self.0.api_version).unwrap()
     }
 
     /// Gets the transaction hash associated with this result.
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
     pub fn transaction_hash(&self) -> TransactionHash {
         self.0.transaction_hash.into()
     }
 
     /// Converts PutTransactionResult to a JavaScript object.
-    #[wasm_bindgen(js_name = "toJson")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "toJson"))]
+    #[cfg(feature = "js")]
     pub fn to_json(&self) -> JsValue {
         JsValue::from_serde(&self.0).unwrap_or(JsValue::null())
     }
 }
 
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl SDK {
     /// JavaScript function for transactioning with deserialized parameters.
     ///
@@ -85,7 +87,8 @@ impl SDK {
     /// # Returns
     ///
     /// A result containing PutTransactionResult or a JsError.
-    #[wasm_bindgen(js_name = "transaction")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "transaction"))]
+    #[cfg(feature = "js")]
     pub async fn transaction_js_alias(
         &self,
         builder_params: TransactionBuilderParams,

--- a/src/sdk/transaction/transfer_transaction.rs
+++ b/src/sdk/transaction/transfer_transaction.rs
@@ -1,4 +1,4 @@
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use crate::transaction::transaction::PutTransactionResult;
 use crate::{
     make_transfer_transaction,
@@ -11,11 +11,11 @@ use crate::{
 use casper_client::{
     rpcs::results::PutTransactionResult as _PutTransactionResult, SuccessResponse,
 };
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use wasm_bindgen::prelude::*;
 
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl SDK {
     /// JS function for transaction transferring funds.
     ///
@@ -32,8 +32,9 @@ impl SDK {
     /// # Returns
     ///
     /// A `Result` containing the result of the transfer or a `JsError` in case of an error.
-    #[wasm_bindgen(js_name = "transfer_transaction")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "transfer_transaction"))]
     #[allow(clippy::too_many_arguments)]
+    #[cfg(feature = "js")]
     pub async fn transfer_transactionjs_alias(
         &self,
         maybe_source: Option<URef>,

--- a/src/sdk/transaction_utils/make_transaction.rs
+++ b/src/sdk/transaction_utils/make_transaction.rs
@@ -14,12 +14,12 @@ use crate::{
     SDK,
 };
 use casper_client::cli::make_transaction as client_make_transaction;
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use wasm_bindgen::prelude::*;
 
 /// Exposes the `make_transaction` function to JavaScript with an alias.
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl SDK {
     /// JS function for `make_transaction`.
     ///
@@ -31,7 +31,8 @@ impl SDK {
     /// # Returns
     ///
     /// A `Result` containing the created `Transaction` or a `JsError` in case of an error.
-    #[wasm_bindgen(js_name = "make_transaction")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "make_transaction"))]
+    #[cfg(feature = "js")]
     pub fn make_transaction_js_alias(
         &self,
         builder_params: TransactionBuilderParams,

--- a/src/sdk/transaction_utils/make_transfer_transaction.rs
+++ b/src/sdk/transaction_utils/make_transfer_transaction.rs
@@ -15,12 +15,12 @@ use casper_client::cli::{
 use casper_types::U512;
 use rand::Rng;
 use std::str::FromStr;
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use wasm_bindgen::prelude::*;
 
 /// Exposes the `make_transfer_transaction` function to JavaScript with an alias.
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl SDK {
     /// JS function for `make_transfer_transaction`.
     ///
@@ -35,7 +35,8 @@ impl SDK {
     /// # Returns
     ///
     /// A `Result` containing the created `Transaction` or a `JsError` in case of an error.
-    #[wasm_bindgen(js_name = "make_transfer_transaction")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "make_transfer_transaction"))]
+    #[cfg(feature = "js")]
     pub fn make_transfer_transaction_js_alias(
         &self,
         maybe_source: Option<URef>,

--- a/src/sdk/transaction_utils/sign_transaction.rs
+++ b/src/sdk/transaction_utils/sign_transaction.rs
@@ -1,10 +1,10 @@
 use crate::{types::transaction::Transaction, SDK};
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use wasm_bindgen::prelude::*;
 
 /// Exposes the `sign_transaction` function to JavaScript with an alias.
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl SDK {
     /// JS function for `sign_transaction`.
     ///
@@ -16,7 +16,7 @@ impl SDK {
     /// # Returns
     ///
     /// The signed `Transaction`.
-    #[wasm_bindgen(js_name = "sign_transaction")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "sign_transaction"))]
     pub fn sign_transaction_js_alias(
         &self,
         transaction: Transaction,

--- a/src/types/access_rights.rs
+++ b/src/types/access_rights.rs
@@ -1,62 +1,65 @@
 use casper_types::AccessRights as _AccessRights;
+#[cfg(feature = "js")]
 use wasm_bindgen::prelude::*;
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 #[derive(Debug, Default)]
 pub struct AccessRights(_AccessRights);
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl AccessRights {
-    #[wasm_bindgen(js_name = "NONE")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "NONE"))]
     pub fn none() -> u8 {
         _AccessRights::NONE.bits()
     }
 
-    #[wasm_bindgen(js_name = "READ")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "READ"))]
     pub fn read() -> u8 {
         _AccessRights::READ.bits()
     }
 
-    #[wasm_bindgen(js_name = "WRITE")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "WRITE"))]
     pub fn write() -> u8 {
         _AccessRights::WRITE.bits()
     }
 
-    #[wasm_bindgen(js_name = "ADD")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "ADD"))]
     pub fn add() -> u8 {
         _AccessRights::ADD.bits()
     }
 
-    #[wasm_bindgen(js_name = "READ_ADD")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "READ_ADD"))]
     pub fn read_add() -> u8 {
         _AccessRights::READ_ADD.bits()
     }
 
-    #[wasm_bindgen(js_name = "READ_WRITE")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "READ_WRITE"))]
     pub fn read_write() -> u8 {
         _AccessRights::READ_WRITE.bits()
     }
 
-    #[wasm_bindgen(js_name = "ADD_WRITE")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "ADD_WRITE"))]
     pub fn add_write() -> u8 {
         _AccessRights::ADD_WRITE.bits()
     }
 
-    #[wasm_bindgen(js_name = "READ_ADD_WRITE")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "READ_ADD_WRITE"))]
     pub fn read_add_write() -> u8 {
         _AccessRights::READ_ADD_WRITE.bits()
     }
 
-    // Utility method to create AccessRights with u8
-    #[wasm_bindgen(constructor)]
-    pub fn new(access_rights: u8) -> Result<AccessRights, JsError> {
-        match _AccessRights::from_bits(access_rights) {
-            Some(rights) => Ok(AccessRights(rights)),
-            None => Err(JsError::new("Invalid URef access rights")),
-        }
+    /// Construct from bit flags; `None` if the bits are invalid.
+    pub fn try_from_u8(access_rights: u8) -> Option<AccessRights> {
+        _AccessRights::from_bits(access_rights).map(AccessRights)
     }
 
-    #[wasm_bindgen]
+    #[cfg_attr(feature = "js", wasm_bindgen(constructor))]
+    #[cfg(feature = "js")]
+    pub fn new(access_rights: u8) -> Result<AccessRights, JsError> {
+        Self::try_from_u8(access_rights).ok_or_else(|| JsError::new("Invalid URef access rights"))
+    }
+
+    #[cfg_attr(feature = "js", wasm_bindgen)]
     pub fn from_bits(read: bool, write: bool, add: bool) -> Self {
         let mut access_rights = _AccessRights::NONE;
         if read {
@@ -71,25 +74,25 @@ impl AccessRights {
         AccessRights(access_rights)
     }
 
-    #[wasm_bindgen]
+    #[cfg_attr(feature = "js", wasm_bindgen)]
     // Utility method to check if the READ flag is set.
     pub fn is_readable(&self) -> bool {
         self.0.is_readable()
     }
 
-    #[wasm_bindgen]
+    #[cfg_attr(feature = "js", wasm_bindgen)]
     // Utility method to check if the WRITE flag is set.
     pub fn is_writeable(&self) -> bool {
         self.0.is_writeable()
     }
 
-    #[wasm_bindgen]
+    #[cfg_attr(feature = "js", wasm_bindgen)]
     // Utility method to check if the ADD flag is set.
     pub fn is_addable(&self) -> bool {
         self.0.is_addable()
     }
 
-    #[wasm_bindgen]
+    #[cfg_attr(feature = "js", wasm_bindgen)]
     // Utility method to check if no flags are set.
     pub fn is_none(&self) -> bool {
         self.0.is_none()

--- a/src/types/account.rs
+++ b/src/types/account.rs
@@ -1,13 +1,14 @@
 use crate::types::{hash::account_hash::AccountHash, named_keys::NamedKeys, uref::URef};
 use casper_types::account::Account as _Account;
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use gloo_utils::format::JsValueSerdeExt;
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "js")]
 use wasm_bindgen::prelude::*;
 
 /// Wasm/native wrapper around [`casper_types::account::Account`].
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 pub struct Account(_Account);
 
 impl Account {
@@ -28,25 +29,25 @@ impl Account {
     }
 }
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl Account {
-    #[wasm_bindgen(js_name = "accountHash")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "accountHash"))]
     pub fn account_hash_js(&self) -> AccountHash {
         self.account_hash()
     }
 
-    #[wasm_bindgen(js_name = "namedKeys")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "namedKeys"))]
     pub fn named_keys_js(&self) -> NamedKeys {
         self.named_keys()
     }
 
-    #[wasm_bindgen(js_name = "mainPurse")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "mainPurse"))]
     pub fn main_purse_js(&self) -> URef {
         self.main_purse()
     }
 
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(js_name = "toJson")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "toJson"))]
     pub fn to_json(&self) -> JsValue {
         JsValue::from_serde(&self.0).unwrap_or(JsValue::null())
     }

--- a/src/types/addr/dictionary_addr.rs
+++ b/src/types/addr/dictionary_addr.rs
@@ -1,13 +1,14 @@
 use casper_types::{DictionaryAddr as _DictionaryAddr, KEY_DICTIONARY_LENGTH};
+#[cfg(feature = "js")]
 use wasm_bindgen::prelude::*;
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 pub struct DictionaryAddr(_DictionaryAddr);
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl DictionaryAddr {
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(constructor)]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(constructor))]
     pub fn new(bytes: Vec<u8>) -> Result<DictionaryAddr, JsError> {
         if bytes.len() != KEY_DICTIONARY_LENGTH {
             return Err(JsError::new("Invalid DictionaryAddr length"));

--- a/src/types/addr/entity_addr.rs
+++ b/src/types/addr/entity_addr.rs
@@ -3,13 +3,14 @@ use casper_types::{
     bytesrepr::{self, FromBytes, ToBytes},
     EntityAddr as _EntityAddr,
 };
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use gloo_utils::format::JsValueSerdeExt;
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "js")]
 use wasm_bindgen::prelude::*;
 
 #[derive(Debug, Deserialize, Clone, Serialize)]
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 pub struct EntityAddr(_EntityAddr);
 
 impl EntityAddr {
@@ -28,10 +29,10 @@ impl EntityAddr {
     }
 }
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl EntityAddr {
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(js_name = "fromFormattedStr")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "fromFormattedStr"))]
     pub fn from_formatted_str_js_alias(formatted_str: &str) -> Result<EntityAddr, JsError> {
         Self::from_formatted_str(formatted_str).map_err(|err| {
             JsError::new(&format!(
@@ -40,18 +41,18 @@ impl EntityAddr {
         })
     }
 
-    #[wasm_bindgen(js_name = "toFormattedString")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "toFormattedString"))]
     pub fn to_formatted_string(&self) -> String {
         self.0.to_formatted_string()
     }
 
-    #[wasm_bindgen(js_name = "toHexString")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "toHexString"))]
     pub fn to_hex_string(&self) -> String {
         self.value().to_hex_string()
     }
 
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(js_name = "toJson")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "toJson"))]
     pub fn to_json(&self) -> JsValue {
         JsValue::from_serde(self).unwrap_or(JsValue::null())
     }

--- a/src/types/addr/hash_addr.rs
+++ b/src/types/addr/hash_addr.rs
@@ -1,14 +1,15 @@
 use casper_types::{HashAddr as _HashAddr, KEY_HASH_LENGTH};
 use core::fmt::{Display, Formatter};
+#[cfg(feature = "js")]
 use wasm_bindgen::prelude::*;
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 pub struct HashAddr(_HashAddr);
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl HashAddr {
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(constructor)]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(constructor))]
     pub fn new(bytes: Vec<u8>) -> Result<HashAddr, JsError> {
         if bytes.len() != KEY_HASH_LENGTH {
             return Err(JsError::new("Invalid HashAddr length"));
@@ -18,14 +19,14 @@ impl HashAddr {
         Ok(HashAddr(array))
     }
 
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(js_name = "toBytes")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "toBytes"))]
     pub fn to_bytes_js_alias(&self) -> Vec<u8> {
         self.to_bytes()
     }
 
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(js_name = "toHexString")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "toHexString"))]
     pub fn to_hex_string_js_alias(&self) -> String {
         self.to_string()
     }

--- a/src/types/addr/transfer_addr.rs
+++ b/src/types/addr/transfer_addr.rs
@@ -1,13 +1,14 @@
 use casper_types::{TransferAddr as _TransferAddr, TRANSFER_ADDR_LENGTH};
+#[cfg(feature = "js")]
 use wasm_bindgen::prelude::*;
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 pub struct TransferAddr(_TransferAddr);
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl TransferAddr {
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(constructor)]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(constructor))]
     pub fn new(bytes: Vec<u8>) -> Result<TransferAddr, JsError> {
         if bytes.len() != TRANSFER_ADDR_LENGTH {
             return Err(JsError::new("Invalid TransferAddr length"));

--- a/src/types/addr/uref_addr.rs
+++ b/src/types/addr/uref_addr.rs
@@ -1,13 +1,14 @@
 use casper_types::{URefAddr as _URefAddr, UREF_ADDR_LENGTH};
+#[cfg(feature = "js")]
 use wasm_bindgen::prelude::*;
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 pub struct URefAddr(_URefAddr);
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl URefAddr {
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(constructor)]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(constructor))]
     pub fn new(bytes: Vec<u8>) -> Result<URefAddr, JsError> {
         if bytes.len() != UREF_ADDR_LENGTH {
             return Err(JsError::new("Invalid URefAddr length"));

--- a/src/types/addressable_entity.rs
+++ b/src/types/addressable_entity.rs
@@ -3,14 +3,15 @@ use casper_types::{
     account::AccountHash as _AccountHash, addressable_entity::EntityKind as _EntityKind,
     AddressableEntity as _AddressableEntity,
 };
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use gloo_utils::format::JsValueSerdeExt;
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "js")]
 use wasm_bindgen::prelude::*;
 
 /// Wasm/native wrapper around [`casper_types::AddressableEntity`].
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 pub struct AddressableEntity(_AddressableEntity);
 
 impl AddressableEntity {
@@ -53,40 +54,40 @@ impl AddressableEntity {
     }
 }
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl AddressableEntity {
-    #[wasm_bindgen(js_name = "packageHash")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "packageHash"))]
     pub fn package_hash_js(&self) -> PackageHash {
         self.package_hash()
     }
 
-    #[wasm_bindgen(js_name = "byteCodeHash")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "byteCodeHash"))]
     pub fn byte_code_hash_js(&self) -> String {
         self.byte_code_hash()
     }
 
-    #[wasm_bindgen(js_name = "mainPurse")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "mainPurse"))]
     pub fn main_purse_js(&self) -> URef {
         self.main_purse()
     }
 
-    #[wasm_bindgen(js_name = "protocolVersion")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "protocolVersion"))]
     pub fn protocol_version_js(&self) -> String {
         self.protocol_version()
     }
 
-    #[wasm_bindgen(js_name = "entityKind")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "entityKind"))]
     pub fn entity_kind_js(&self) -> String {
         self.entity_kind()
     }
 
-    #[wasm_bindgen(js_name = "accountHash")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "accountHash"))]
     pub fn account_hash_js(&self) -> Option<String> {
         self.account_hash()
     }
 
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(js_name = "toJson")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "toJson"))]
     pub fn to_json(&self) -> JsValue {
         JsValue::from_serde(&self.0).unwrap_or(JsValue::null())
     }

--- a/src/types/byte_code.rs
+++ b/src/types/byte_code.rs
@@ -1,12 +1,13 @@
 use casper_types::{ByteCode as _ByteCode, ByteCodeKind as _ByteCodeKind};
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use gloo_utils::format::JsValueSerdeExt;
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "js")]
 use wasm_bindgen::prelude::*;
 
 /// Wasm/native wrapper around [`casper_types::ByteCode`].
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 pub struct ByteCode(_ByteCode);
 
 impl ByteCode {
@@ -35,30 +36,30 @@ impl ByteCode {
     }
 }
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl ByteCode {
-    #[wasm_bindgen(js_name = "kind")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "kind"))]
     pub fn kind_js(&self) -> String {
         self.kind()
     }
 
-    #[wasm_bindgen(js_name = "bytes")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "bytes"))]
     pub fn bytes_js(&self) -> Vec<u8> {
         self.bytes()
     }
 
-    #[wasm_bindgen(js_name = "len")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "len"))]
     pub fn len_js(&self) -> usize {
         self.len()
     }
 
-    #[wasm_bindgen(js_name = "isEmpty")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "isEmpty"))]
     pub fn is_empty_js(&self) -> bool {
         self.is_empty()
     }
 
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(js_name = "toJson")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "toJson"))]
     pub fn to_json(&self) -> JsValue {
         JsValue::from_serde(&self.0).unwrap_or(JsValue::null())
     }

--- a/src/types/cl/bytes.rs
+++ b/src/types/cl/bytes.rs
@@ -1,19 +1,21 @@
 use casper_types::{bytesrepr::Bytes as _Bytes, CLType, CLTyped};
 use core::ops::Deref;
+#[cfg(feature = "js")]
 use wasm_bindgen::prelude::*;
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 #[derive(Clone, Ord, PartialOrd, Eq, PartialEq, Debug, Default, Hash)]
 pub struct Bytes(Vec<u8>);
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl Bytes {
-    #[wasm_bindgen(constructor)]
+    #[cfg_attr(feature = "js", wasm_bindgen(constructor))]
     pub fn new() -> Self {
         Bytes(Vec::new())
     }
 
-    #[wasm_bindgen(js_name = "fromUint8Array")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "fromUint8Array"))]
+    #[cfg(feature = "js")]
     pub fn from_uint8_array(uint8_array: js_sys::Uint8Array) -> Self {
         let length = uint8_array.length() as usize;
         let mut bytes_vec = Vec::with_capacity(length);

--- a/src/types/cl/cl_type.rs
+++ b/src/types/cl/cl_type.rs
@@ -1,8 +1,9 @@
 use std::fmt;
 
+#[cfg(feature = "js")]
 use wasm_bindgen::prelude::*;
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum CLTypeEnum {
     Bool,
@@ -31,135 +32,135 @@ pub enum CLTypeEnum {
 }
 
 #[derive(Clone, Debug)]
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 #[allow(dead_code)]
 pub struct CLType(CLTypeEnum);
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 #[allow(non_snake_case)]
 impl CLType {
-    #[wasm_bindgen(js_name = "Bool")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "Bool"))]
     pub fn Bool() -> Self {
         CLType(CLTypeEnum::Bool)
     }
 
-    #[wasm_bindgen(js_name = "I32")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "I32"))]
     pub fn I32() -> Self {
         CLType(CLTypeEnum::I32)
     }
 
-    #[wasm_bindgen(js_name = "I64")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "I64"))]
     pub fn I64() -> Self {
         CLType(CLTypeEnum::I64)
     }
 
-    #[wasm_bindgen(js_name = "U8")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "U8"))]
     pub fn U8() -> Self {
         CLType(CLTypeEnum::U8)
     }
 
-    #[wasm_bindgen(js_name = "U32")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "U32"))]
     pub fn U32() -> Self {
         CLType(CLTypeEnum::U32)
     }
 
-    #[wasm_bindgen(js_name = "U64")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "U64"))]
     pub fn U64() -> Self {
         CLType(CLTypeEnum::U64)
     }
 
-    #[wasm_bindgen(js_name = "U128")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "U128"))]
     pub fn U128() -> Self {
         CLType(CLTypeEnum::U128)
     }
 
-    #[wasm_bindgen(js_name = "U256")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "U256"))]
     pub fn U256() -> Self {
         CLType(CLTypeEnum::U256)
     }
 
-    #[wasm_bindgen(js_name = "U512")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "U512"))]
     pub fn U512() -> Self {
         CLType(CLTypeEnum::U512)
     }
 
-    #[wasm_bindgen(js_name = "Unit")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "Unit"))]
     pub fn unit() -> Self {
         CLType(CLTypeEnum::Unit)
     }
 
-    #[wasm_bindgen(js_name = "String")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "String"))]
     pub fn string() -> Self {
         CLType(CLTypeEnum::String)
     }
 
-    #[wasm_bindgen(js_name = "Key")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "Key"))]
     pub fn key() -> Self {
         CLType(CLTypeEnum::Key)
     }
 
-    #[wasm_bindgen(js_name = "URef")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "URef"))]
     pub fn uref() -> Self {
         CLType(CLTypeEnum::URef)
     }
 
-    #[wasm_bindgen(js_name = "PublicKey")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "PublicKey"))]
     pub fn public_key() -> Self {
         CLType(CLTypeEnum::PublicKey)
     }
 
-    #[wasm_bindgen(js_name = "Option")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "Option"))]
     pub fn option(_inner_type: CLType) -> Self {
         CLType(CLTypeEnum::Option)
     }
 
-    #[wasm_bindgen(js_name = "List")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "List"))]
     pub fn list(_inner_type: CLType) -> Self {
         CLType(CLTypeEnum::List)
     }
 
-    #[wasm_bindgen(js_name = "ByteArray")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "ByteArray"))]
     pub fn byte_array() -> Self {
         CLType(CLTypeEnum::ByteArray)
     }
 
-    #[wasm_bindgen(js_name = "Result")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "Result"))]
     pub fn result(_inner_type: CLType, _error_type: CLType) -> Self {
         CLType(CLTypeEnum::Result)
     }
 
-    #[wasm_bindgen(js_name = "Map")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "Map"))]
     pub fn map(_key_type: CLType, _value_type: CLType) -> Self {
         CLType(CLTypeEnum::Map)
     }
 
-    #[wasm_bindgen(js_name = "Tuple1")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "Tuple1"))]
     pub fn tuple1(_value_type: CLType) -> Self {
         CLType(CLTypeEnum::Tuple1)
     }
 
-    #[wasm_bindgen(js_name = "Tuple2")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "Tuple2"))]
     pub fn tuple2(_value_type: CLType, _value_type2: CLType) -> Self {
         CLType(CLTypeEnum::Tuple2)
     }
 
-    #[wasm_bindgen(js_name = "Tuple3")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "Tuple3"))]
     pub fn tuple3(_value_type: CLType, _value_type2: CLType, _value_type3: CLType) -> Self {
         CLType(CLTypeEnum::Tuple3)
     }
 
-    #[wasm_bindgen(js_name = "Any")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "Any"))]
     pub fn any() -> Self {
         CLType(CLTypeEnum::Any)
     }
 
-    #[wasm_bindgen(constructor)]
+    #[cfg_attr(feature = "js", wasm_bindgen(constructor))]
     pub fn new(cl_type: CLTypeEnum) -> Self {
         CLType(cl_type)
     }
 
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(js_name = "toString")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "toString"))]
     pub fn to_string_js_alias(&self) -> String {
         self.to_string()
     }

--- a/src/types/cl/cl_value.rs
+++ b/src/types/cl/cl_value.rs
@@ -1,21 +1,22 @@
 use crate::types::sdk_error::SdkError;
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use crate::types::{cl::bytes::Bytes, key::Key, public_key::PublicKey, uref::URef};
 use casper_types::{
     bytesrepr::{FromBytes, ToBytes},
     CLTyped, CLValue as _CLValue,
 };
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use casper_types::{U128, U256, U512};
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use gloo_utils::format::JsValueSerdeExt;
+#[cfg(feature = "js")]
 use wasm_bindgen::prelude::*;
 
 /// Wasm/native wrapper around [`casper_types::CLValue`].
 ///
 /// Minimal surface for building [`crate::types::runtime_args::RuntimeArgs`].
 /// This wrapper currently focuses on runtime-args construction.
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CLValue(_CLValue);
 
@@ -31,110 +32,110 @@ impl CLValue {
     }
 }
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl CLValue {
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(js_name = "fromBool")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "fromBool"))]
     pub fn from_bool_js(value: bool) -> Result<CLValue, JsError> {
         Self::from_t(value).map_err(|err| JsError::new(&err.to_string()))
     }
 
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(js_name = "fromI32")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "fromI32"))]
     pub fn from_i32_js(value: i32) -> Result<CLValue, JsError> {
         Self::from_t(value).map_err(|err| JsError::new(&err.to_string()))
     }
 
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(js_name = "fromI64")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "fromI64"))]
     pub fn from_i64_js(value: i64) -> Result<CLValue, JsError> {
         Self::from_t(value).map_err(|err| JsError::new(&err.to_string()))
     }
 
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(js_name = "fromU8")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "fromU8"))]
     pub fn from_u8_js(value: u8) -> Result<CLValue, JsError> {
         Self::from_t(value).map_err(|err| JsError::new(&err.to_string()))
     }
 
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(js_name = "fromU32")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "fromU32"))]
     pub fn from_u32_js(value: u32) -> Result<CLValue, JsError> {
         Self::from_t(value).map_err(|err| JsError::new(&err.to_string()))
     }
 
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(js_name = "fromU64")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "fromU64"))]
     pub fn from_u64_js(value: u64) -> Result<CLValue, JsError> {
         Self::from_t(value).map_err(|err| JsError::new(&err.to_string()))
     }
 
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(js_name = "fromU128")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "fromU128"))]
     pub fn from_u128_js(value: &str) -> Result<CLValue, JsError> {
         let parsed = U128::from_dec_str(value)
             .map_err(|err| JsError::new(&format!("Invalid U128: {err:?}")))?;
         Self::from_t(parsed).map_err(|err| JsError::new(&err.to_string()))
     }
 
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(js_name = "fromU256")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "fromU256"))]
     pub fn from_u256_js(value: &str) -> Result<CLValue, JsError> {
         let parsed = U256::from_dec_str(value)
             .map_err(|err| JsError::new(&format!("Invalid U256: {err:?}")))?;
         Self::from_t(parsed).map_err(|err| JsError::new(&err.to_string()))
     }
 
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(js_name = "fromU512")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "fromU512"))]
     pub fn from_u512_js(value: &str) -> Result<CLValue, JsError> {
         let parsed = U512::from_dec_str(value)
             .map_err(|err| JsError::new(&format!("Invalid U512: {err:?}")))?;
         Self::from_t(parsed).map_err(|err| JsError::new(&err.to_string()))
     }
 
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(js_name = "fromString")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "fromString"))]
     pub fn from_string_js(value: &str) -> Result<CLValue, JsError> {
         Self::from_t(value.to_string()).map_err(|err| JsError::new(&err.to_string()))
     }
 
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(js_name = "fromUnit")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "fromUnit"))]
     pub fn from_unit_js() -> Result<CLValue, JsError> {
         Self::from_t(()).map_err(|err| JsError::new(&err.to_string()))
     }
 
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(js_name = "fromKey")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "fromKey"))]
     pub fn from_key_js(key: &Key) -> Result<CLValue, JsError> {
         Self::from_t(casper_types::Key::from(key.clone()))
             .map_err(|err| JsError::new(&err.to_string()))
     }
 
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(js_name = "fromURef")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "fromURef"))]
     pub fn from_uref_js(uref: &URef) -> Result<CLValue, JsError> {
         Self::from_t(casper_types::URef::from(uref.clone()))
             .map_err(|err| JsError::new(&err.to_string()))
     }
 
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(js_name = "fromPublicKey")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "fromPublicKey"))]
     pub fn from_public_key_js(public_key: &PublicKey) -> Result<CLValue, JsError> {
         Self::from_t(casper_types::PublicKey::from(public_key.clone()))
             .map_err(|err| JsError::new(&err.to_string()))
     }
 
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(js_name = "fromBytes")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "fromBytes"))]
     pub fn from_bytes_js(bytes: &Bytes) -> Result<CLValue, JsError> {
         Self::from_t(casper_types::bytesrepr::Bytes::from(bytes.clone()))
             .map_err(|err| JsError::new(&err.to_string()))
     }
 
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(js_name = "toJson")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "toJson"))]
     pub fn to_json(&self) -> JsValue {
         JsValue::from_serde(&self.0).unwrap_or(JsValue::null())
     }

--- a/src/types/contract_wasm.rs
+++ b/src/types/contract_wasm.rs
@@ -1,12 +1,13 @@
 use casper_types::ContractWasm as _ContractWasm;
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use gloo_utils::format::JsValueSerdeExt;
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "js")]
 use wasm_bindgen::prelude::*;
 
 /// Wasm/native wrapper around [`casper_types::ContractWasm`].
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 pub struct ContractWasm(_ContractWasm);
 
 impl ContractWasm {
@@ -27,25 +28,25 @@ impl ContractWasm {
     }
 }
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl ContractWasm {
-    #[wasm_bindgen(js_name = "bytes")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "bytes"))]
     pub fn bytes_js(&self) -> Vec<u8> {
         self.bytes()
     }
 
-    #[wasm_bindgen(js_name = "len")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "len"))]
     pub fn len_js(&self) -> usize {
         self.len()
     }
 
-    #[wasm_bindgen(js_name = "isEmpty")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "isEmpty"))]
     pub fn is_empty_js(&self) -> bool {
         self.is_empty()
     }
 
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(js_name = "toJson")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "toJson"))]
     pub fn to_json(&self) -> JsValue {
         JsValue::from_serde(&self.0).unwrap_or(JsValue::null())
     }

--- a/src/types/contracts/contract.rs
+++ b/src/types/contracts/contract.rs
@@ -3,14 +3,15 @@ use crate::types::{
     hash::contract_package_hash::ContractPackageHash, named_keys::NamedKeys,
 };
 use casper_types::contracts::Contract as _Contract;
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use gloo_utils::format::JsValueSerdeExt;
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "js")]
 use wasm_bindgen::prelude::*;
 
 /// Wasm/native wrapper around [`casper_types::contracts::Contract`].
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 pub struct Contract(_Contract);
 
 impl Contract {
@@ -47,45 +48,45 @@ impl Contract {
     }
 }
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl Contract {
-    #[wasm_bindgen(js_name = "contractPackageHash")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "contractPackageHash"))]
     pub fn contract_package_hash_js(&self) -> ContractPackageHash {
         self.contract_package_hash()
     }
 
-    #[wasm_bindgen(js_name = "contractWasmHash")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "contractWasmHash"))]
     pub fn contract_wasm_hash_js(&self) -> String {
         self.contract_wasm_hash()
     }
 
-    #[wasm_bindgen(js_name = "namedKeys")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "namedKeys"))]
     pub fn named_keys_js(&self) -> NamedKeys {
         self.named_keys()
     }
 
-    #[wasm_bindgen(js_name = "entryPoints")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "entryPoints"))]
     pub fn entry_points_js(&self) -> EntryPoints {
         self.entry_points()
     }
 
-    #[wasm_bindgen(js_name = "entryPoint")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "entryPoint"))]
     pub fn entry_point_js(&self, name: &str) -> Option<EntryPoint> {
         self.entry_point(name)
     }
 
-    #[wasm_bindgen(js_name = "hasEntryPoint")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "hasEntryPoint"))]
     pub fn has_entry_point_js(&self, name: &str) -> bool {
         self.has_entry_point(name)
     }
 
-    #[wasm_bindgen(js_name = "protocolVersion")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "protocolVersion"))]
     pub fn protocol_version_js(&self) -> String {
         self.protocol_version()
     }
 
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(js_name = "toJson")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "toJson"))]
     pub fn to_json(&self) -> JsValue {
         JsValue::from_serde(&self.0).unwrap_or(JsValue::null())
     }

--- a/src/types/contracts/contract_package.rs
+++ b/src/types/contracts/contract_package.rs
@@ -1,13 +1,14 @@
 use crate::types::{hash::contract_hash::ContractHash, uref::URef};
 use casper_types::contracts::ContractPackage as _ContractPackage;
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use gloo_utils::format::JsValueSerdeExt;
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "js")]
 use wasm_bindgen::prelude::*;
 
 /// Wasm/native wrapper around [`casper_types::contracts::ContractPackage`].
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 pub struct ContractPackage(_ContractPackage);
 
 impl ContractPackage {
@@ -28,26 +29,26 @@ impl ContractPackage {
     }
 }
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl ContractPackage {
-    #[wasm_bindgen(js_name = "accessKey")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "accessKey"))]
     pub fn access_key_js(&self) -> URef {
         self.access_key()
     }
 
-    #[wasm_bindgen(js_name = "isLocked")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "isLocked"))]
     pub fn is_locked_js(&self) -> bool {
         self.is_locked()
     }
 
-    #[wasm_bindgen(js_name = "currentContractHash")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "currentContractHash"))]
     pub fn current_contract_hash_js(&self) -> Option<ContractHash> {
         self.current_contract_hash()
     }
 
     /// Versions / groups / lock metadata as JSON for escape-hatch parsing.
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(js_name = "toJson")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "toJson"))]
     pub fn to_json(&self) -> JsValue {
         JsValue::from_serde(&self.0).unwrap_or(JsValue::null())
     }

--- a/src/types/contracts/entry_point.rs
+++ b/src/types/contracts/entry_point.rs
@@ -1,14 +1,15 @@
 use casper_types::{
     addressable_entity::EntryPointType as _EntryPointType, contracts::EntryPoint as _EntryPoint,
 };
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use gloo_utils::format::JsValueSerdeExt;
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "js")]
 use wasm_bindgen::prelude::*;
 
 /// Wasm/native wrapper around [`casper_types::contracts::EntryPoint`].
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 pub struct EntryPoint(_EntryPoint);
 
 impl EntryPoint {
@@ -29,21 +30,21 @@ impl EntryPoint {
     }
 }
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl EntryPoint {
-    #[wasm_bindgen(js_name = "name")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "name"))]
     pub fn name_js(&self) -> String {
         self.name()
     }
 
-    #[wasm_bindgen(js_name = "entryPointType")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "entryPointType"))]
     pub fn entry_point_type_js(&self) -> String {
         self.entry_point_type()
     }
 
     /// Nested args / access / return type as JSON for escape-hatch parsing.
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(js_name = "toJson")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "toJson"))]
     pub fn to_json(&self) -> JsValue {
         JsValue::from_serde(&self.0).unwrap_or(JsValue::null())
     }

--- a/src/types/contracts/entry_points.rs
+++ b/src/types/contracts/entry_points.rs
@@ -1,13 +1,14 @@
 use crate::types::contracts::entry_point::EntryPoint;
 use casper_types::contracts::EntryPoints as _EntryPoints;
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use gloo_utils::format::JsValueSerdeExt;
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "js")]
 use wasm_bindgen::prelude::*;
 
 /// Wasm/native wrapper around [`casper_types::contracts::EntryPoints`].
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 pub struct EntryPoints(_EntryPoints);
 
 impl EntryPoints {
@@ -36,35 +37,35 @@ impl EntryPoints {
     }
 }
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl EntryPoints {
-    #[wasm_bindgen(js_name = "len")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "len"))]
     pub fn len_js(&self) -> usize {
         self.len()
     }
 
-    #[wasm_bindgen(js_name = "isEmpty")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "isEmpty"))]
     pub fn is_empty_js(&self) -> bool {
         self.is_empty()
     }
 
-    #[wasm_bindgen(js_name = "hasEntryPoint")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "hasEntryPoint"))]
     pub fn has_entry_point_js(&self, name: &str) -> bool {
         self.has_entry_point(name)
     }
 
-    #[wasm_bindgen(js_name = "get")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "get"))]
     pub fn get_js(&self, name: &str) -> Option<EntryPoint> {
         self.get(name)
     }
 
-    #[wasm_bindgen(js_name = "names")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "names"))]
     pub fn names_js(&self) -> Vec<String> {
         self.names()
     }
 
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(js_name = "toJson")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "toJson"))]
     pub fn to_json(&self) -> JsValue {
         JsValue::from_serde(&self.0).unwrap_or(JsValue::null())
     }

--- a/src/types/deploy.rs
+++ b/src/types/deploy.rs
@@ -1,4 +1,4 @@
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use crate::helpers::insert_js_value_arg;
 #[cfg(feature = "deploy")]
 #[allow(deprecated)]
@@ -32,15 +32,16 @@ use casper_types::{
     RuntimeArgs, SecretKey, TimeDiff, Timestamp, U512,
 };
 use chrono::{DateTime, Utc};
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use gloo_utils::format::JsValueSerdeExt;
 use num_traits::cast::FromPrimitive;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
+#[cfg(feature = "js")]
 use wasm_bindgen::prelude::*;
 
 #[derive(Debug, Deserialize, Clone, Serialize)]
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 pub struct Deploy(_Deploy);
 
 #[derive(Default)]
@@ -54,12 +55,12 @@ struct BuildParams {
     account: Option<PublicKey>,
 }
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 #[deprecated(note = "prefer Transaction type")]
 #[allow(deprecated)]
 impl Deploy {
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(constructor)]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(constructor))]
     pub fn new(deploy: JsValue) -> Deploy {
         let deploy: _Deploy = deploy
             .into_serde()
@@ -75,8 +76,8 @@ impl Deploy {
         deploy.into()
     }
 
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(js_name = "toJson")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "toJson"))]
     pub fn to_json_js_alias(&self) -> JsValue {
         match JsValue::from_serde(&self.0) {
             Ok(json) => json,
@@ -89,7 +90,7 @@ impl Deploy {
 
     // static context
     #[cfg(feature = "deploy")]
-    #[wasm_bindgen(js_name = "withPaymentAndSession")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "withPaymentAndSession"))]
     pub fn with_payment_and_session(
         deploy_params: DeployStrParams,
         session_params: SessionStrParams,
@@ -103,7 +104,7 @@ impl Deploy {
 
     // static context
     #[cfg(feature = "deploy")]
-    #[wasm_bindgen(js_name = "withTransfer")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "withTransfer"))]
     pub fn with_transfer(
         amount: &str,
         target_account: &str,
@@ -121,7 +122,7 @@ impl Deploy {
         .map_err(|err| format!("Error creating transfer deploy: {err}"))
     }
 
-    #[wasm_bindgen(js_name = "withTTL")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "withTTL"))]
     pub fn with_ttl(&self, ttl: &str, secret_key: Option<String>) -> Deploy {
         let mut ttl = parse_ttl(ttl);
         if let Err(err) = &ttl {
@@ -135,7 +136,7 @@ impl Deploy {
         })
     }
 
-    #[wasm_bindgen(js_name = "withTimestamp")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "withTimestamp"))]
     pub fn with_timestamp(&self, timestamp: &str, secret_key: Option<String>) -> Deploy {
         let mut timestamp = parse_timestamp(timestamp);
         if let Err(err) = &timestamp {
@@ -149,7 +150,7 @@ impl Deploy {
         })
     }
 
-    #[wasm_bindgen(js_name = "withChainName")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "withChainName"))]
     pub fn with_chain_name(&self, chain_name: &str, secret_key: Option<String>) -> Deploy {
         self.build(BuildParams {
             secret_key,
@@ -158,7 +159,7 @@ impl Deploy {
         })
     }
 
-    #[wasm_bindgen(js_name = "withAccount")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "withAccount"))]
     pub fn with_account(&self, account: PublicKey, secret_key: Option<String>) -> Deploy {
         self.build(BuildParams {
             secret_key,
@@ -167,7 +168,7 @@ impl Deploy {
         })
     }
 
-    #[wasm_bindgen(js_name = "withEntryPointName")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "withEntryPointName"))]
     pub fn with_entry_point_name(
         &self,
         entry_point_name: &str,
@@ -189,7 +190,7 @@ impl Deploy {
         })
     }
 
-    #[wasm_bindgen(js_name = "withHash")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "withHash"))]
     pub fn with_hash(&self, hash: ContractHash, secret_key: Option<String>) -> Deploy {
         let deploy = self.0.clone();
         let session = deploy.session();
@@ -207,7 +208,7 @@ impl Deploy {
         })
     }
 
-    #[wasm_bindgen(js_name = "withPackageHash")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "withPackageHash"))]
     pub fn with_package_hash(
         &self,
         package_hash: ContractPackageHash,
@@ -229,7 +230,7 @@ impl Deploy {
         })
     }
 
-    #[wasm_bindgen(js_name = "withModuleBytes")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "withModuleBytes"))]
     pub fn with_module_bytes(&self, module_bytes: Bytes, secret_key: Option<String>) -> Deploy {
         let deploy = self.0.clone();
         let session = deploy.session();
@@ -247,7 +248,7 @@ impl Deploy {
         })
     }
 
-    #[wasm_bindgen(js_name = "withSecretKey")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "withSecretKey"))]
     pub fn with_secret_key(&self, secret_key: Option<String>) -> Deploy {
         self.build(BuildParams {
             secret_key,
@@ -255,7 +256,7 @@ impl Deploy {
         })
     }
 
-    #[wasm_bindgen(js_name = "withStandardPayment")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "withStandardPayment"))]
     pub fn with_standard_payment(&self, amount: &str, secret_key: Option<String>) -> Deploy {
         let cloned_amount = amount.to_string();
         let amount = U512::from_dec_str(&cloned_amount);
@@ -271,8 +272,8 @@ impl Deploy {
     }
 
     // Load payment from json
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(js_name = "withPayment")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "withPayment"))]
     pub fn with_payment(&self, payment: JsValue, secret_key: Option<String>) -> Deploy {
         let payment_item_result = payment.into_serde();
 
@@ -290,8 +291,8 @@ impl Deploy {
     }
 
     // Load session from json
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(js_name = "withSession")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "withSession"))]
     pub fn with_session(&self, session: JsValue, secret_key: Option<String>) -> Deploy {
         let session_item_result = session.into_serde();
 
@@ -308,7 +309,7 @@ impl Deploy {
         }
     }
 
-    #[wasm_bindgen(js_name = "validateDeploySize")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "validateDeploySize"))]
     pub fn validate_deploy_size(&self) -> bool {
         let deploy: _Deploy = self.0.clone();
         match deploy.is_valid_size(MAX_SERIALIZED_SIZE_OF_DEPLOY) {
@@ -320,7 +321,7 @@ impl Deploy {
         }
     }
 
-    #[wasm_bindgen(js_name = "isValid")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "isValid"))]
     pub fn is_valid(&self) -> bool {
         let deploy: _Deploy = self.0.clone();
         match deploy.is_valid() {
@@ -332,13 +333,13 @@ impl Deploy {
         }
     }
 
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
     pub fn hash(&self) -> DeployHash {
         let deploy: _Deploy = self.0.clone();
         (*deploy.hash()).into()
     }
 
-    #[wasm_bindgen(js_name = "hasValidHash")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "hasValidHash"))]
     pub fn has_valid_hash(&self) -> bool {
         let deploy: _Deploy = self.0.clone();
         match deploy.has_valid_hash() {
@@ -350,7 +351,7 @@ impl Deploy {
         }
     }
 
-    #[wasm_bindgen(js_name = "isExpired")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "isExpired"))]
     pub fn expired(&self) -> bool {
         let deploy: _Deploy = self.0.clone();
         let now: DateTime<Utc> = Utc::now();
@@ -365,7 +366,7 @@ impl Deploy {
         }
     }
 
-    #[wasm_bindgen(js_name = "sign")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "sign"))]
     pub fn sign(&mut self, secret_key: &str) -> Deploy {
         let mut deploy: _Deploy = self.0.clone();
         let secret_key_from_pem = secret_key_from_pem(secret_key);
@@ -380,8 +381,8 @@ impl Deploy {
         deploy.into()
     }
 
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(js_name = "approvalsHash")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "approvalsHash"))]
     pub fn compute_approvals_hash_js_alias(&self) -> JsValue {
         match JsValue::from_serde(&self.compute_approvals_hash()) {
             Ok(json) => json,
@@ -394,8 +395,8 @@ impl Deploy {
         }
     }
 
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(js_name = "approvals")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "approvals"))]
     pub fn approvals_alias(&self) -> JsValue {
         match JsValue::from_serde(&self.approvals()) {
             Ok(json) => json,
@@ -406,12 +407,12 @@ impl Deploy {
         }
     }
 
-    #[wasm_bindgen(js_name = "isTransfer")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "isTransfer"))]
     pub fn is_transfer(&self) -> bool {
         self.0.clone().session().is_transfer()
     }
 
-    #[wasm_bindgen(js_name = "isStandardPayment")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "isStandardPayment"))]
     pub fn is_standard_payment(&self, phase: u8) -> bool {
         if let Some(phase_enum) = Phase::from_u8(phase) {
             self.0.clone().session().is_standard_payment(phase_enum)
@@ -420,37 +421,37 @@ impl Deploy {
         }
     }
 
-    #[wasm_bindgen(js_name = "isStoredContract")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "isStoredContract"))]
     pub fn is_stored_contract(&self) -> bool {
         self.0.clone().session().is_stored_contract()
     }
 
-    #[wasm_bindgen(js_name = "isStoredContractPackage")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "isStoredContractPackage"))]
     pub fn is_stored_contract_package(&self) -> bool {
         self.0.clone().session().is_stored_contract_package()
     }
 
-    #[wasm_bindgen(js_name = "isModuleBytes")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "isModuleBytes"))]
     pub fn is_module_bytes(&self) -> bool {
         self.0.clone().session().is_module_bytes()
     }
 
-    #[wasm_bindgen(js_name = "isByName")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "isByName"))]
     pub fn is_by_name(&self) -> bool {
         self.0.clone().session().is_by_name()
     }
 
-    #[wasm_bindgen(js_name = "byName")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "byName"))]
     pub fn by_name(&self) -> Option<String> {
         self.0.clone().session().by_name()
     }
 
-    #[wasm_bindgen(js_name = "entryPointName")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "entryPointName"))]
     pub fn entry_point_name(&self) -> String {
         self.0.clone().session().entry_point_name().to_string()
     }
 
-    #[wasm_bindgen(js_name = "addSignature")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "addSignature"))]
     pub fn add_signature(&self, public_key: &str, signature: &str) -> Deploy {
         // Serialize the existing approvals to JSON
         let casper_deploy: _Deploy = self.0.clone();
@@ -492,28 +493,28 @@ impl Deploy {
         updated_deploy
     }
 
-    #[wasm_bindgen(js_name = "TTL")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "TTL"))]
     pub fn ttl(&self) -> String {
         self.0.clone().header().ttl().to_string()
     }
 
-    #[wasm_bindgen(js_name = "timestamp")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "timestamp"))]
     pub fn timestamp(&self) -> String {
         self.0.clone().header().timestamp().to_string()
     }
 
-    #[wasm_bindgen(js_name = "chainName")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "chainName"))]
     pub fn chain_name(&self) -> String {
         self.0.clone().header().chain_name().to_string()
     }
 
-    #[wasm_bindgen(js_name = "account")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "account"))]
     pub fn account(&self) -> String {
         let public_key: PublicKey = self.0.clone().header().account().clone().into();
         public_key.to_string()
     }
 
-    #[wasm_bindgen(js_name = "paymentAmount")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "paymentAmount"))]
     pub fn payment_amount(&self, conv_rate: u8) -> String {
         self.0
             .clone()
@@ -523,8 +524,8 @@ impl Deploy {
             .to_string()
     }
 
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(js_name = "args")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "args"))]
     pub fn args_js_alias(&self) -> JsValue {
         match JsValue::from_serde(&self.args()) {
             Ok(json) => json,
@@ -535,8 +536,8 @@ impl Deploy {
         }
     }
 
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(js_name = "addArg")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "addArg"))]
     pub fn add_arg_js_alias(
         &mut self,
         js_value_arg: JsValue,

--- a/src/types/deploy_info.rs
+++ b/src/types/deploy_info.rs
@@ -1,13 +1,14 @@
 use crate::types::{hash::account_hash::AccountHash, uref::URef};
 use casper_types::DeployInfo as _DeployInfo;
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use gloo_utils::format::JsValueSerdeExt;
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "js")]
 use wasm_bindgen::prelude::*;
 
 /// Wasm/native wrapper around [`casper_types::DeployInfo`].
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 pub struct DeployInfo(_DeployInfo);
 
 impl DeployInfo {
@@ -44,40 +45,40 @@ impl DeployInfo {
     }
 }
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl DeployInfo {
-    #[wasm_bindgen(js_name = "deployHash")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "deployHash"))]
     pub fn deploy_hash_js(&self) -> String {
         self.deploy_hash()
     }
 
-    #[wasm_bindgen(js_name = "fromAccount")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "fromAccount"))]
     pub fn from_account_js(&self) -> AccountHash {
         self.from_account()
     }
 
-    #[wasm_bindgen(js_name = "source")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "source"))]
     pub fn source_js(&self) -> URef {
         self.source()
     }
 
-    #[wasm_bindgen(js_name = "gas")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "gas"))]
     pub fn gas_js(&self) -> String {
         self.gas()
     }
 
-    #[wasm_bindgen(js_name = "transferCount")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "transferCount"))]
     pub fn transfer_count_js(&self) -> usize {
         self.transfer_count()
     }
 
-    #[wasm_bindgen(js_name = "transferAddrs")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "transferAddrs"))]
     pub fn transfer_addrs_js(&self) -> Vec<String> {
         self.transfer_addrs()
     }
 
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(js_name = "toJson")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "toJson"))]
     pub fn to_json(&self) -> JsValue {
         JsValue::from_serde(&self.0).unwrap_or(JsValue::null())
     }

--- a/src/types/deploy_params/args_simple.rs
+++ b/src/types/deploy_params/args_simple.rs
@@ -1,13 +1,16 @@
+#[cfg(feature = "js")]
 use js_sys::Array;
+#[cfg(feature = "js")]
 use wasm_bindgen::prelude::*;
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 #[derive(Default, Debug, Clone)]
 pub struct ArgsSimple {
     args: Vec<String>,
 }
 
 impl ArgsSimple {
+    #[cfg(feature = "js")]
     pub fn new(args: JsValue) -> Self {
         let args: Array = args.into();
         let args: Vec<String> = args
@@ -39,6 +42,7 @@ impl From<Vec<String>> for ArgsSimple {
     }
 }
 
+#[cfg(feature = "js")]
 impl FromIterator<JsValue> for ArgsSimple {
     fn from_iter<I: IntoIterator<Item = JsValue>>(iter: I) -> Self {
         let args: Vec<String> = iter

--- a/src/types/deploy_params/deploy_str_params.rs
+++ b/src/types/deploy_params/deploy_str_params.rs
@@ -3,9 +3,10 @@ use crate::helpers::get_str_or_default;
 use crate::helpers::get_ttl_or_default;
 use casper_client::cli::DeployStrParams as _DeployStrParams;
 use once_cell::sync::OnceCell;
+#[cfg(feature = "js")]
 use wasm_bindgen::prelude::*;
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 #[derive(Debug, Clone)]
 pub struct DeployStrParams {
     secret_key: OnceCell<String>,
@@ -29,9 +30,9 @@ impl Default for DeployStrParams {
     }
 }
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl DeployStrParams {
-    #[wasm_bindgen(constructor)]
+    #[cfg_attr(feature = "js", wasm_bindgen(constructor))]
     pub fn new(
         chain_name: &str,
         session_account: &str,
@@ -58,23 +59,23 @@ impl DeployStrParams {
     }
 
     // Getter and setter for secret_key field
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
     pub fn secret_key(&self) -> Option<String> {
         self.secret_key.get().cloned()
     }
 
-    #[wasm_bindgen(setter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(setter))]
     pub fn set_secret_key(&self, secret_key: &str) {
         self.secret_key.set(secret_key.to_string()).unwrap();
     }
 
     // Getter and setter for timestamp field
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
     pub fn timestamp(&self) -> Option<String> {
         self.timestamp.get().cloned()
     }
 
-    #[wasm_bindgen(setter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(setter))]
     pub fn set_timestamp(&self, timestamp: Option<String>) {
         if let Some(mut timestamp) = timestamp {
             if timestamp.is_empty() {
@@ -87,19 +88,19 @@ impl DeployStrParams {
         };
     }
 
-    #[wasm_bindgen(js_name = "setDefaultTimestamp")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "setDefaultTimestamp"))]
     pub fn set_default_timestamp(&self) {
         let current_timestamp = get_current_timestamp(None);
         self.timestamp.set(current_timestamp).unwrap();
     }
 
     // Getter and setter for ttl field
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
     pub fn ttl(&self) -> Option<String> {
         self.ttl.get().cloned()
     }
 
-    #[wasm_bindgen(setter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(setter))]
     pub fn set_ttl(&self, ttl: Option<String>) {
         if let Some(mut ttl) = ttl {
             if ttl.is_empty() {
@@ -112,30 +113,30 @@ impl DeployStrParams {
         };
     }
 
-    #[wasm_bindgen(js_name = "setDefaultTTL")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "setDefaultTTL"))]
     pub fn set_default_ttl(&self) {
         let ttl = get_ttl_or_default(None);
         self.ttl.set(ttl).unwrap();
     }
 
     // Getter and setter for chain_name field
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
     pub fn chain_name(&self) -> Option<String> {
         self.chain_name.get().cloned()
     }
 
-    #[wasm_bindgen(setter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(setter))]
     pub fn set_chain_name(&self, chain_name: &str) {
         self.chain_name.set(chain_name.to_string()).unwrap();
     }
 
     // Getter and setter for session_account field
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
     pub fn session_account(&self) -> Option<String> {
         self.session_account.get().cloned()
     }
 
-    #[wasm_bindgen(setter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(setter))]
     pub fn set_session_account(&self, session_account: &str) {
         self.session_account
             .set(session_account.to_string())
@@ -143,12 +144,12 @@ impl DeployStrParams {
     }
 
     // Getter and setter for gas_price_tolerance field
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
     pub fn gas_price_tolerance(&self) -> Option<String> {
         self.gas_price_tolerance.get().cloned()
     }
 
-    #[wasm_bindgen(setter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(setter))]
     pub fn set_gas_price_tolerance(&self, gas_price_tolerance: String) {
         self.gas_price_tolerance.set(gas_price_tolerance).unwrap();
     }

--- a/src/types/deploy_params/dictionary_item_str_params.rs
+++ b/src/types/deploy_params/dictionary_item_str_params.rs
@@ -1,10 +1,11 @@
 use crate::{helpers::get_str_or_default, types::sdk_error::SdkError};
 use casper_client::cli::DictionaryItemStrParams as _DictionaryItemStrParams;
 use casper_types::URef;
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use gloo_utils::format::JsValueSerdeExt;
 use once_cell::sync::OnceCell;
 use serde::{de::Error as SerdeError, Deserialize, Serialize, Serializer};
+#[cfg(feature = "js")]
 use wasm_bindgen::prelude::*;
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -82,7 +83,7 @@ where
     serializer.serialize_str(value_str)
 }
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct DictionaryItemStrParams {
     account_named_key: Option<AccountNamedKey>,
@@ -92,9 +93,9 @@ pub struct DictionaryItemStrParams {
     dictionary: Option<DictionaryVariant>,
 }
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl DictionaryItemStrParams {
-    #[wasm_bindgen(constructor)]
+    #[cfg_attr(feature = "js", wasm_bindgen(constructor))]
     pub fn new() -> Self {
         DictionaryItemStrParams {
             account_named_key: None,
@@ -105,7 +106,7 @@ impl DictionaryItemStrParams {
         }
     }
 
-    #[wasm_bindgen(js_name = "setAccountNamedKey")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "setAccountNamedKey"))]
     pub fn set_account_named_key(
         &mut self,
         key: &str,
@@ -129,7 +130,7 @@ impl DictionaryItemStrParams {
         }
     }
 
-    #[wasm_bindgen(js_name = "setContractNamedKey")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "setContractNamedKey"))]
     pub fn set_contract_named_key(
         &mut self,
         key: &str,
@@ -153,7 +154,7 @@ impl DictionaryItemStrParams {
         }
     }
 
-    #[wasm_bindgen(js_name = "setEntityNamedKey")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "setEntityNamedKey"))]
     pub fn set_entity_named_key(
         &mut self,
         key: &str,
@@ -177,7 +178,7 @@ impl DictionaryItemStrParams {
         }
     }
 
-    #[wasm_bindgen(js_name = "setUref")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "setUref"))]
     pub fn set_uref(&mut self, seed_uref: &str, dictionary_item_key: &str) {
         self.uref = Some(URefVariant {
             seed_uref: OnceCell::new(),
@@ -197,7 +198,7 @@ impl DictionaryItemStrParams {
         }
     }
 
-    #[wasm_bindgen(js_name = "setDictionary")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "setDictionary"))]
     pub fn set_dictionary(&mut self, value: &str) {
         self.dictionary = Some(DictionaryVariant {
             value: OnceCell::new(),
@@ -208,8 +209,8 @@ impl DictionaryItemStrParams {
         }
     }
 
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(js_name = "toJson")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "toJson"))]
     pub fn to_json(&self) -> JsValue {
         JsValue::from_serde(self).unwrap_or(JsValue::null())
     }

--- a/src/types/deploy_params/payment_str_params.rs
+++ b/src/types/deploy_params/payment_str_params.rs
@@ -1,10 +1,10 @@
 use crate::{helpers::get_str_or_default, types::deploy_params::args_simple::ArgsSimple};
 use casper_client::cli::PaymentStrParams as _PaymentStrParams;
-use js_sys::Array;
 use once_cell::sync::OnceCell;
+#[cfg(feature = "js")]
 use wasm_bindgen::prelude::*;
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 #[derive(Default, Debug, Clone)]
 pub struct PaymentStrParams {
     payment_amount: OnceCell<String>,
@@ -19,10 +19,10 @@ pub struct PaymentStrParams {
     payment_entry_point: OnceCell<String>,
 }
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl PaymentStrParams {
     #[allow(clippy::too_many_arguments)]
-    #[wasm_bindgen(constructor)]
+    #[cfg_attr(feature = "js", wasm_bindgen(constructor))]
     pub fn new(
         payment_amount: Option<String>,
         payment_hash: Option<String>,
@@ -30,7 +30,7 @@ impl PaymentStrParams {
         payment_package_hash: Option<String>,
         payment_package_name: Option<String>,
         payment_path: Option<String>,
-        payment_args_simple: Option<Array>,
+        payment_args_simple: Option<Vec<String>>,
         payment_args_json: Option<String>,
         payment_version: Option<String>,
         payment_entry_point: Option<String>,
@@ -70,113 +70,111 @@ impl PaymentStrParams {
         payment_params
     }
 
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
     pub fn payment_amount(&self) -> Option<String> {
         self.payment_amount.get().cloned()
     }
 
-    #[wasm_bindgen(setter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(setter))]
     pub fn set_payment_amount(&self, payment_amount: &str) {
         self.payment_amount.set(payment_amount.to_string()).unwrap();
     }
 
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
     pub fn payment_hash(&self) -> Option<String> {
         self.payment_hash.get().cloned()
     }
 
-    #[wasm_bindgen(setter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(setter))]
     pub fn set_payment_hash(&self, payment_hash: &str) {
         self.payment_hash.set(payment_hash.to_string()).unwrap();
     }
 
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
     pub fn payment_name(&self) -> Option<String> {
         self.payment_name.get().cloned()
     }
 
-    #[wasm_bindgen(setter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(setter))]
     pub fn set_payment_name(&self, payment_name: &str) {
         self.payment_name.set(payment_name.to_string()).unwrap();
     }
 
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
     pub fn payment_package_hash(&self) -> Option<String> {
         self.payment_package_hash.get().cloned()
     }
 
-    #[wasm_bindgen(setter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(setter))]
     pub fn set_payment_package_hash(&self, payment_package_hash: &str) {
         self.payment_package_hash
             .set(payment_package_hash.to_string())
             .unwrap();
     }
 
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
     pub fn payment_package_name(&self) -> Option<String> {
         self.payment_package_name.get().cloned()
     }
 
-    #[wasm_bindgen(setter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(setter))]
     pub fn set_payment_package_name(&self, payment_package_name: &str) {
         self.payment_package_name
             .set(payment_package_name.to_string())
             .unwrap();
     }
 
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
     pub fn payment_path(&self) -> Option<String> {
         self.payment_path.get().cloned()
     }
 
-    #[wasm_bindgen(setter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(setter))]
     pub fn set_payment_path(&self, payment_path: &str) {
         self.payment_path.set(payment_path.to_string()).unwrap();
     }
 
-    #[wasm_bindgen(getter)]
-    pub fn payment_args_simple(&self) -> Option<Array> {
-        let args_simple = self.payment_args_simple.get()?;
-        let array: Array = args_simple.args().iter().map(JsValue::from).collect();
-        Some(array)
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
+    pub fn payment_args_simple(&self) -> Option<ArgsSimple> {
+        self.payment_args_simple.get().cloned()
     }
 
-    #[wasm_bindgen(setter)]
-    pub fn set_payment_args_simple(&self, payment_args_simple: Array) {
-        let args_simple: ArgsSimple = payment_args_simple.into_iter().collect();
+    #[cfg_attr(feature = "js", wasm_bindgen(setter))]
+    pub fn set_payment_args_simple(&self, payment_args_simple: Vec<String>) {
+        let args_simple = ArgsSimple::from(payment_args_simple);
         self.payment_args_simple.set(args_simple).unwrap();
     }
 
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
     pub fn payment_args_json(&self) -> Option<String> {
         self.payment_args_json.get().cloned()
     }
 
-    #[wasm_bindgen(setter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(setter))]
     pub fn set_payment_args_json(&self, payment_args_json: &str) {
         self.payment_args_json
             .set(payment_args_json.to_string())
             .unwrap();
     }
 
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
     pub fn payment_version(&self) -> Option<String> {
         self.payment_version.get().cloned()
     }
 
-    #[wasm_bindgen(setter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(setter))]
     pub fn set_payment_version(&self, payment_version: &str) {
         self.payment_version
             .set(payment_version.to_string())
             .unwrap();
     }
 
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
     pub fn payment_entry_point(&self) -> Option<String> {
         self.payment_entry_point.get().cloned()
     }
 
-    #[wasm_bindgen(setter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(setter))]
     pub fn set_payment_entry_point(&self, payment_entry_point: &str) {
         self.payment_entry_point
             .set(payment_entry_point.to_string())

--- a/src/types/deploy_params/session_str_params.rs
+++ b/src/types/deploy_params/session_str_params.rs
@@ -4,6 +4,7 @@ use crate::{
 };
 use casper_client::cli::SessionStrParams as _SessionStrParams;
 use once_cell::sync::OnceCell;
+#[cfg(feature = "js")]
 use wasm_bindgen::prelude::*;
 
 /// Legacy deploy session params. Prefer [`crate::types::transaction_params::transaction_str_params::TransactionStrParams`].
@@ -14,7 +15,7 @@ use wasm_bindgen::prelude::*;
 /// - [`Self::set_session_args`] — typed [`RuntimeArgs`]
 #[deprecated(note = "prefer TransactionStrParams")]
 #[allow(deprecated)]
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 #[derive(Default, Debug, Clone)]
 pub struct SessionStrParams {
     session_hash: OnceCell<String>,
@@ -30,10 +31,10 @@ pub struct SessionStrParams {
     is_session_transfer: OnceCell<bool>,
 }
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 #[allow(deprecated)]
 impl SessionStrParams {
-    #[wasm_bindgen(constructor)]
+    #[cfg_attr(feature = "js", wasm_bindgen(constructor))]
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         session_hash: Option<String>,
@@ -87,34 +88,34 @@ impl SessionStrParams {
     }
 
     // Getter and setter for session_hash field
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
     pub fn session_hash(&self) -> Option<String> {
         self.session_hash.get().cloned()
     }
 
-    #[wasm_bindgen(setter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(setter))]
     pub fn set_session_hash(&self, session_hash: &str) {
         self.session_hash.set(session_hash.to_string()).unwrap();
     }
 
     // Getter and setter for session_name field
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
     pub fn session_name(&self) -> Option<String> {
         self.session_name.get().cloned()
     }
 
-    #[wasm_bindgen(setter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(setter))]
     pub fn set_session_name(&self, session_name: &str) {
         self.session_name.set(session_name.to_string()).unwrap();
     }
 
     // Getter and setter for session_package_hash field
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
     pub fn session_package_hash(&self) -> Option<String> {
         self.session_package_hash.get().cloned()
     }
 
-    #[wasm_bindgen(setter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(setter))]
     pub fn set_session_package_hash(&self, session_package_hash: &str) {
         self.session_package_hash
             .set(session_package_hash.to_string())
@@ -122,12 +123,12 @@ impl SessionStrParams {
     }
 
     // Getter and setter for session_package_name field
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
     pub fn session_package_name(&self) -> Option<String> {
         self.session_package_name.get().cloned()
     }
 
-    #[wasm_bindgen(setter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(setter))]
     pub fn set_session_package_name(&self, session_package_name: &str) {
         self.session_package_name
             .set(session_package_name.to_string())
@@ -135,48 +136,48 @@ impl SessionStrParams {
     }
 
     // Getter and setter for session_path field
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
     pub fn session_path(&self) -> Option<String> {
         self.session_path.get().cloned()
     }
 
-    #[wasm_bindgen(setter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(setter))]
     pub fn set_session_path(&self, session_path: &str) {
         self.session_path.set(session_path.to_string()).unwrap();
     }
 
     // Getter and setter for session_bytes field
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
     pub fn session_bytes(&self) -> Option<Bytes> {
         self.session_bytes.get().cloned()
     }
 
-    #[wasm_bindgen(setter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(setter))]
     pub fn set_session_bytes(&self, session_bytes: Bytes) {
         self.session_bytes.set(session_bytes).unwrap();
     }
 
     // Getter and setter for session_args_simple field
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
     pub fn session_args_simple(&self) -> Option<ArgsSimple> {
         self.session_args_simple.get().cloned()
     }
 
     /// CLI-style simple args (`name:Type='value'`).
-    #[wasm_bindgen(setter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(setter))]
     pub fn set_session_args_simple(&mut self, session_args_simple: Vec<String>) {
         let args_simple = ArgsSimple::from(session_args_simple);
         self.session_args_simple.set(args_simple).unwrap();
     }
 
     // Getter and setter for session_args_json field
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
     pub fn session_args_json(&self) -> Option<String> {
         self.session_args_json.get().cloned()
     }
 
     /// JSON session args string (human-typed or ByteArray bridge encoding).
-    #[wasm_bindgen(setter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(setter))]
     pub fn set_session_args_json(&self, session_args_json: &str) {
         self.session_args_json
             .set(session_args_json.to_string())
@@ -192,12 +193,12 @@ impl SessionStrParams {
     }
 
     // Getter and setter for session_version field
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
     pub fn session_version(&self) -> Option<String> {
         self.session_version.get().cloned()
     }
 
-    #[wasm_bindgen(setter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(setter))]
     pub fn set_session_version(&self, session_version: &str) {
         self.session_version
             .set(session_version.to_string())
@@ -205,12 +206,12 @@ impl SessionStrParams {
     }
 
     // Getter and setter for session_entry_point field
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
     pub fn session_entry_point(&self) -> Option<String> {
         self.session_entry_point.get().cloned()
     }
 
-    #[wasm_bindgen(setter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(setter))]
     pub fn set_session_entry_point(&self, session_entry_point: &str) {
         self.session_entry_point
             .set(session_entry_point.to_string())
@@ -218,12 +219,12 @@ impl SessionStrParams {
     }
 
     // Getter and setter for is_session_transfer field
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
     pub fn is_session_transfer(&self) -> Option<bool> {
         self.is_session_transfer.get().cloned()
     }
 
-    #[wasm_bindgen(setter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(setter))]
     pub fn set_is_session_transfer(&self, is_session_transfer: bool) {
         self.is_session_transfer.set(is_session_transfer).unwrap();
     }

--- a/src/types/digest.rs
+++ b/src/types/digest.rs
@@ -3,14 +3,15 @@ use casper_types::{
     bytesrepr::{self, FromBytes, ToBytes},
     Digest as _Digest, DigestError,
 };
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use gloo_utils::format::JsValueSerdeExt;
 use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Formatter};
+#[cfg(feature = "js")]
 use wasm_bindgen::prelude::*;
 
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 pub struct Digest(_Digest);
 
 impl Digest {
@@ -28,30 +29,34 @@ impl Digest {
     }
 }
 
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl Digest {
-    #[wasm_bindgen(constructor)]
+    #[cfg_attr(feature = "js", wasm_bindgen(constructor))]
+    #[cfg(feature = "js")]
     pub fn new_js_alias(digest_hex_str: &str) -> Result<Digest, JsError> {
         Self::from_string(digest_hex_str)
     }
 
-    #[wasm_bindgen(js_name = "fromString")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "fromString"))]
+    #[cfg(feature = "js")]
     pub fn from_string(digest_hex_str: &str) -> Result<Digest, JsError> {
         Self::try_from(digest_hex_str).map_err(Into::into)
     }
 
-    #[wasm_bindgen(js_name = "fromRaw")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "fromRaw"))]
+    #[cfg(feature = "js")]
     pub fn from_raw_js_alias(bytes: Vec<u8>) -> Result<Digest, JsError> {
         Self::from_raw(bytes).map_err(|err| JsError::new(&format!("{err:?}")))
     }
 
-    #[wasm_bindgen(js_name = "toJson")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "toJson"))]
+    #[cfg(feature = "js")]
     pub fn to_json(&self) -> JsValue {
         JsValue::from_serde(self).unwrap_or(JsValue::null())
     }
 
-    #[wasm_bindgen(js_name = "toString")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "toString"))]
     pub fn to_string_js_alias(&self) -> String {
         self.to_string()
     }

--- a/src/types/entity_or_account.rs
+++ b/src/types/entity_or_account.rs
@@ -4,16 +4,17 @@ use crate::types::{
 };
 // Client's RPC wrapper type is also named AddressableEntity (entity + named_keys + entry_points).
 use casper_client::rpcs::{AddressableEntity as _EntityInfo, EntityOrAccount as _EntityOrAccount};
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use gloo_utils::format::JsValueSerdeExt;
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "js")]
 use wasm_bindgen::prelude::*;
 
 /// Typed view of `state_get_entity` payload for addressable-entity mode.
 ///
 /// Contains the entity body plus named keys and entry points returned by the RPC.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 pub struct AddressableEntityInfo(_EntityInfo);
 
 impl AddressableEntityInfo {
@@ -39,25 +40,25 @@ impl AddressableEntityInfo {
     }
 }
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl AddressableEntityInfo {
-    #[wasm_bindgen(js_name = "entity")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "entity"))]
     pub fn entity_js(&self) -> AddressableEntity {
         self.entity()
     }
 
-    #[wasm_bindgen(js_name = "namedKeys")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "namedKeys"))]
     pub fn named_keys_js(&self) -> NamedKeys {
         self.named_keys()
     }
 
-    #[wasm_bindgen(js_name = "entryPoints")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "entryPoints"))]
     pub fn entry_points_js(&self) -> Vec<EntryPointValue> {
         self.entry_points()
     }
 
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(js_name = "toJson")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "toJson"))]
     pub fn to_json(&self) -> JsValue {
         JsValue::from_serde(&self.0).unwrap_or(JsValue::null())
     }
@@ -80,7 +81,7 @@ impl From<_EntityInfo> for AddressableEntityInfo {
 /// - Addressable-entity mode (`enable_addressable_entity = true`): `AddressableEntity`
 /// - Legacy mode (default in NCTL/CI): `LegacyAccount` (node may serialize as `Account`)
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 pub struct EntityOrAccount(_EntityOrAccount);
 
 impl EntityOrAccount {
@@ -107,25 +108,25 @@ impl EntityOrAccount {
     }
 }
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl EntityOrAccount {
-    #[wasm_bindgen(js_name = "variant")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "variant"))]
     pub fn variant_js(&self) -> String {
         self.variant().to_string()
     }
 
-    #[wasm_bindgen(js_name = "asAddressableEntity")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "asAddressableEntity"))]
     pub fn as_addressable_entity_js(&self) -> Option<AddressableEntityInfo> {
         self.as_addressable_entity()
     }
 
-    #[wasm_bindgen(js_name = "asLegacyAccount")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "asLegacyAccount"))]
     pub fn as_legacy_account_js(&self) -> Option<Account> {
         self.as_legacy_account()
     }
 
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(js_name = "toJson")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "toJson"))]
     pub fn to_json(&self) -> JsValue {
         JsValue::from_serde(&self.0).unwrap_or(JsValue::null())
     }

--- a/src/types/entry_point_value.rs
+++ b/src/types/entry_point_value.rs
@@ -1,14 +1,15 @@
 use casper_types::{
     addressable_entity::EntryPointType as _EntryPointType, EntryPointValue as _EntryPointValue,
 };
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use gloo_utils::format::JsValueSerdeExt;
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "js")]
 use wasm_bindgen::prelude::*;
 
 /// Wasm/native wrapper around [`casper_types::EntryPointValue`].
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 pub struct EntryPointValue(_EntryPointValue);
 
 impl EntryPointValue {
@@ -41,25 +42,25 @@ impl EntryPointValue {
     }
 }
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl EntryPointValue {
-    #[wasm_bindgen(js_name = "variant")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "variant"))]
     pub fn variant_js(&self) -> String {
         self.variant().to_string()
     }
 
-    #[wasm_bindgen(js_name = "name")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "name"))]
     pub fn name_js(&self) -> Option<String> {
         self.name()
     }
 
-    #[wasm_bindgen(js_name = "entryPointType")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "entryPointType"))]
     pub fn entry_point_type_js(&self) -> Option<String> {
         self.entry_point_type()
     }
 
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(js_name = "toJson")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "toJson"))]
     pub fn to_json(&self) -> JsValue {
         JsValue::from_serde(&self.0).unwrap_or(JsValue::null())
     }

--- a/src/types/era_id.rs
+++ b/src/types/era_id.rs
@@ -1,14 +1,15 @@
 use casper_types::EraId as _EraId;
+#[cfg(feature = "js")]
 use wasm_bindgen::prelude::*;
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 #[derive(Default, Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 
 pub struct EraId(_EraId);
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl EraId {
-    #[wasm_bindgen(constructor)]
+    #[cfg_attr(feature = "js", wasm_bindgen(constructor))]
     pub fn new(value: u64) -> EraId {
         EraId(value.into())
     }

--- a/src/types/era_info.rs
+++ b/src/types/era_info.rs
@@ -1,12 +1,13 @@
 use casper_types::system::auction::EraInfo as _EraInfo;
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use gloo_utils::format::JsValueSerdeExt;
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "js")]
 use wasm_bindgen::prelude::*;
 
 /// Wasm/native wrapper around [`casper_types::EraInfo`].
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 pub struct EraInfo(_EraInfo);
 
 impl EraInfo {
@@ -19,15 +20,15 @@ impl EraInfo {
     }
 }
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl EraInfo {
-    #[wasm_bindgen(js_name = "seigniorageAllocationCount")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "seigniorageAllocationCount"))]
     pub fn seigniorage_allocation_count_js(&self) -> usize {
         self.seigniorage_allocation_count()
     }
 
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(js_name = "toJson")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "toJson"))]
     pub fn to_json(&self) -> JsValue {
         JsValue::from_serde(&self.0).unwrap_or(JsValue::null())
     }

--- a/src/types/hash/account_hash.rs
+++ b/src/types/hash/account_hash.rs
@@ -9,13 +9,14 @@ use casper_types::{
     account::AccountHash as _AccountHash,
     bytesrepr::{self, FromBytes, ToBytes},
 };
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use gloo_utils::format::JsValueSerdeExt;
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "js")]
 use wasm_bindgen::prelude::*;
 
 #[derive(Debug, Deserialize, Clone, Serialize, Ord, PartialOrd, Eq, PartialEq)]
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 pub struct AccountHash(_AccountHash);
 
 impl AccountHash {
@@ -63,10 +64,10 @@ impl AccountHash {
     }
 }
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl AccountHash {
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(constructor)]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(constructor))]
     pub fn new_js_alias(account_hash_hex_str: &str) -> Result<AccountHash, JsError> {
         Self::new(account_hash_hex_str).map_err(|err| {
             JsError::new(&format!(
@@ -75,8 +76,8 @@ impl AccountHash {
         })
     }
 
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(js_name = "fromFormattedStr")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "fromFormattedStr"))]
     pub fn from_formatted_str_js_alias(formatted_str: &str) -> Result<AccountHash, JsError> {
         Self::from_formatted_str(formatted_str).map_err(|err| {
             JsError::new(&format!(
@@ -85,32 +86,32 @@ impl AccountHash {
         })
     }
 
-    #[wasm_bindgen(js_name = "fromPublicKey")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "fromPublicKey"))]
     pub fn from_public_key(public_key: PublicKey) -> AccountHash {
         let account_hash =
             _AccountHash::from_public_key(&(public_key.into()), Self::custom_blake2b);
         Self(account_hash)
     }
 
-    #[wasm_bindgen(js_name = "toFormattedString")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "toFormattedString"))]
     pub fn to_formatted_string(&self) -> String {
         self.0.to_formatted_string()
     }
 
-    #[wasm_bindgen(js_name = "toHexString")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "toHexString"))]
     pub fn to_hex_string(&self) -> String {
         self.0.to_string()
     }
 
-    #[wasm_bindgen(js_name = "fromUint8Array")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "fromUint8Array"))]
     pub fn from_bytes(bytes: Vec<u8>) -> AccountHash {
         let account_hash =
             _AccountHash::try_from(&bytes).expect("Failed to convert bytes to AccountHash");
         Self(account_hash)
     }
 
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(js_name = "toJson")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "toJson"))]
     pub fn to_json(&self) -> JsValue {
         JsValue::from_serde(self).unwrap_or(JsValue::null())
     }

--- a/src/types/hash/addressable_entity_hash.rs
+++ b/src/types/hash/addressable_entity_hash.rs
@@ -9,9 +9,10 @@ use casper_types::{
     bytesrepr::{self, FromBytes, ToBytes, U8_SERIALIZED_LENGTH},
 };
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "js")]
 use wasm_bindgen::prelude::*;
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 #[derive(Debug, Deserialize, Clone, Serialize, Copy, PartialEq, Eq)]
 pub struct AddressableEntityHash(_AddressableEntityHash);
 
@@ -32,10 +33,10 @@ impl AddressableEntityHash {
     }
 }
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl AddressableEntityHash {
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(constructor)]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(constructor))]
     pub fn new_js_alias(
         addressable_entity_hex_str: &str,
     ) -> Result<AddressableEntityHash, JsError> {
@@ -46,8 +47,8 @@ impl AddressableEntityHash {
         })
     }
 
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(js_name = "fromFormattedStr")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "fromFormattedStr"))]
     pub fn from_formatted_str_js_alias(
         formatted_str: &str,
     ) -> Result<AddressableEntityHash, JsError> {
@@ -58,12 +59,12 @@ impl AddressableEntityHash {
         })
     }
 
-    #[wasm_bindgen(js_name = "toFormattedString")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "toFormattedString"))]
     pub fn to_formatted_string(&self) -> String {
         self.0.to_formatted_string()
     }
 
-    #[wasm_bindgen(js_name = "fromUint8Array")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "fromUint8Array"))]
     pub fn from_bytes(bytes: Vec<u8>) -> AddressableEntityHash {
         let addressable_entity_hash = _AddressableEntityHash::try_from(&bytes)
             .expect("Failed to convert bytes to AddressableEntityHash");

--- a/src/types/hash/block_hash.rs
+++ b/src/types/hash/block_hash.rs
@@ -1,12 +1,13 @@
 use crate::types::{digest::Digest, sdk_error::SdkError};
 use casper_types::{BlockHash as _BlockHash, Digest as _Digest};
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use gloo_utils::format::JsValueSerdeExt;
 use serde::{Deserialize, Serialize};
 use std::fmt;
+#[cfg(feature = "js")]
 use wasm_bindgen::prelude::*;
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 #[derive(Debug, Deserialize, Clone, Serialize)]
 pub struct BlockHash(_BlockHash);
 
@@ -27,25 +28,28 @@ impl BlockHash {
     }
 }
 
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl BlockHash {
-    #[wasm_bindgen(constructor)]
+    #[cfg_attr(feature = "js", wasm_bindgen(constructor))]
+    #[cfg(feature = "js")]
     pub fn new_js_alias(block_hash_hex_str: &str) -> Result<BlockHash, JsError> {
         Self::new(block_hash_hex_str).map_err(Into::into)
     }
 
-    #[wasm_bindgen(js_name = "fromDigest")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "fromDigest"))]
+    #[cfg(feature = "js")]
     pub fn from_digest_js_alias(digest: Digest) -> Result<BlockHash, JsError> {
         Self::from_digest(digest).map_err(Into::into)
     }
 
-    #[wasm_bindgen(js_name = "toJson")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "toJson"))]
+    #[cfg(feature = "js")]
     pub fn to_json(&self) -> JsValue {
         JsValue::from_serde(self).unwrap_or(JsValue::null())
     }
 
-    #[wasm_bindgen(js_name = "toString")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "toString"))]
     pub fn to_string_js_alias(&self) -> String {
         self.to_string()
     }

--- a/src/types/hash/contract_hash.rs
+++ b/src/types/hash/contract_hash.rs
@@ -6,9 +6,10 @@ use casper_types::{
     AddressableEntityHash as _AddressableEntityHash,
 };
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "js")]
 use wasm_bindgen::prelude::*;
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 #[derive(Debug, Deserialize, Clone, Serialize, Copy)]
 pub struct ContractHash(_ContractHash);
 
@@ -29,10 +30,10 @@ impl ContractHash {
     }
 }
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl ContractHash {
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(constructor)]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(constructor))]
     pub fn new_js_alias(contract_hash_hex_str: &str) -> Result<ContractHash, JsError> {
         Self::new(contract_hash_hex_str).map_err(|err| {
             JsError::new(&format!(
@@ -41,8 +42,8 @@ impl ContractHash {
         })
     }
 
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(js_name = "fromFormattedStr")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "fromFormattedStr"))]
     pub fn from_formatted_str_js_alias(formatted_str: &str) -> Result<ContractHash, JsError> {
         Self::from_formatted_str(formatted_str).map_err(|err| {
             JsError::new(&format!(
@@ -51,12 +52,12 @@ impl ContractHash {
         })
     }
 
-    #[wasm_bindgen(js_name = "toFormattedString")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "toFormattedString"))]
     pub fn to_formatted_string(&self) -> String {
         self.0.to_formatted_string()
     }
 
-    #[wasm_bindgen(js_name = "fromUint8Array")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "fromUint8Array"))]
     pub fn from_bytes(bytes: Vec<u8>) -> ContractHash {
         let contract_hash =
             _ContractHash::try_from(&bytes).expect("Failed to convert bytes to ContractHash");

--- a/src/types/hash/contract_package_hash.rs
+++ b/src/types/hash/contract_package_hash.rs
@@ -5,9 +5,10 @@ use casper_types::{
     PackageHash,
 };
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "js")]
 use wasm_bindgen::prelude::*;
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 #[derive(Debug, Deserialize, Clone, Serialize, Copy)]
 pub struct ContractPackageHash(_ContractPackageHash);
 
@@ -27,10 +28,10 @@ impl ContractPackageHash {
     }
 }
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl ContractPackageHash {
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(constructor)]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(constructor))]
     pub fn new_js_alias(
         contract_package_hash_hex_str: &str,
     ) -> Result<ContractPackageHash, JsError> {
@@ -41,8 +42,8 @@ impl ContractPackageHash {
         })
     }
 
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(js_name = "fromFormattedStr")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "fromFormattedStr"))]
     pub fn from_formatted_str_js_alias(
         formatted_str: &str,
     ) -> Result<ContractPackageHash, JsError> {
@@ -53,12 +54,12 @@ impl ContractPackageHash {
         })
     }
 
-    #[wasm_bindgen(js_name = "toFormattedString")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "toFormattedString"))]
     pub fn to_formatted_string(&self) -> String {
         self.0.to_formatted_string()
     }
 
-    #[wasm_bindgen(js_name = "fromUint8Array")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "fromUint8Array"))]
     pub fn from_bytes(bytes: Vec<u8>) -> ContractPackageHash {
         let contract_package_hash = _ContractPackageHash::try_from(&bytes)
             .expect("Failed to convert bytes to ContractPackageHash");

--- a/src/types/hash/deploy_hash.rs
+++ b/src/types/hash/deploy_hash.rs
@@ -1,13 +1,14 @@
 use crate::types::{digest::Digest, sdk_error::SdkError};
 use casper_types::{DeployHash as _DeployHash, Digest as _Digest};
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use gloo_utils::format::JsValueSerdeExt;
 use serde::{Deserialize, Serialize};
 use std::fmt;
+#[cfg(feature = "js")]
 use wasm_bindgen::prelude::*;
 
 #[derive(Debug, Deserialize, Clone, Serialize)]
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 pub struct DeployHash(_DeployHash);
 
 impl DeployHash {
@@ -27,25 +28,28 @@ impl DeployHash {
     }
 }
 
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl DeployHash {
-    #[wasm_bindgen(constructor)]
+    #[cfg_attr(feature = "js", wasm_bindgen(constructor))]
+    #[cfg(feature = "js")]
     pub fn new_js_alias(deploy_hash_hex_str: &str) -> Result<DeployHash, JsError> {
         Self::new(deploy_hash_hex_str).map_err(Into::into)
     }
 
-    #[wasm_bindgen(js_name = "fromDigest")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "fromDigest"))]
+    #[cfg(feature = "js")]
     pub fn from_digest_js_alias(digest: Digest) -> Result<DeployHash, JsError> {
         Self::from_digest(digest).map_err(Into::into)
     }
 
-    #[wasm_bindgen(js_name = "toJson")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "toJson"))]
+    #[cfg(feature = "js")]
     pub fn to_json(&self) -> JsValue {
         JsValue::from_serde(self).unwrap_or(JsValue::null())
     }
 
-    #[wasm_bindgen(js_name = "toString")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "toString"))]
     pub fn to_string_js_alias(&self) -> String {
         self.to_string()
     }

--- a/src/types/hash/package_hash.rs
+++ b/src/types/hash/package_hash.rs
@@ -4,9 +4,10 @@ use casper_types::{
     PackageAddr, PackageHash as _PackageHash,
 };
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "js")]
 use wasm_bindgen::prelude::*;
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 #[derive(Debug, Deserialize, Clone, Serialize, Copy)]
 pub struct PackageHash(_PackageHash);
 
@@ -27,10 +28,10 @@ impl PackageHash {
     }
 }
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl PackageHash {
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(constructor)]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(constructor))]
     pub fn new_js_alias(package_hash_hex_str: &str) -> Result<PackageHash, JsError> {
         Self::new(package_hash_hex_str).map_err(|err| {
             JsError::new(&format!(
@@ -39,8 +40,8 @@ impl PackageHash {
         })
     }
 
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(js_name = "fromFormattedStr")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "fromFormattedStr"))]
     pub fn from_formatted_str_js_alias(formatted_str: &str) -> Result<PackageHash, JsError> {
         Self::from_formatted_str(formatted_str).map_err(|err| {
             JsError::new(&format!(
@@ -49,12 +50,12 @@ impl PackageHash {
         })
     }
 
-    #[wasm_bindgen(js_name = "toFormattedString")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "toFormattedString"))]
     pub fn to_formatted_string(&self) -> String {
         self.0.to_formatted_string()
     }
 
-    #[wasm_bindgen(js_name = "fromUint8Array")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "fromUint8Array"))]
     pub fn from_bytes(bytes: Vec<u8>) -> PackageHash {
         let package_hash =
             _PackageHash::try_from(&bytes).expect("Failed to convert bytes to PackageHash");

--- a/src/types/hash/transaction_hash.rs
+++ b/src/types/hash/transaction_hash.rs
@@ -1,13 +1,14 @@
 use crate::types::{digest::Digest, sdk_error::SdkError};
 use casper_types::{Digest as _Digest, DigestError, TransactionHash as _TransactionHash};
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use gloo_utils::format::JsValueSerdeExt;
 use serde::{Deserialize, Serialize};
 use std::fmt;
+#[cfg(feature = "js")]
 use wasm_bindgen::prelude::*;
 
 #[derive(Debug, Deserialize, Clone, Serialize)]
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 pub struct TransactionHash(_TransactionHash);
 
 impl TransactionHash {
@@ -39,36 +40,36 @@ impl TransactionHash {
     }
 }
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl TransactionHash {
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(constructor)]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(constructor))]
     pub fn new_js_alias(transaction_hash_hex_str: &str) -> Result<TransactionHash, JsError> {
         TransactionHash::new(transaction_hash_hex_str)
             .map_err(|err| JsError::new(&format!("{err:?}")))
     }
 
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(js_name = "fromRaw")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "fromRaw"))]
     pub fn from_raw_js_alias(bytes: &[u8]) -> Result<TransactionHash, JsError> {
         TransactionHash::from_raw(bytes).map_err(|err| JsError::new(&format!("{err:?}")))
     }
 
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(js_name = "digest")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "digest"))]
     pub fn digest_js_alias(&self) -> Result<Digest, JsError> {
         self.digest()
             .map_err(|err| JsError::new(&format!("{err:?}")))
     }
 
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(js_name = "toJson")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "toJson"))]
     pub fn to_json(&self) -> JsValue {
         JsValue::from_serde(self).unwrap_or(JsValue::null())
     }
 
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(js_name = "toString")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "toString"))]
     pub fn to_string_js_alias(&self) -> String {
         self.to_string()
     }

--- a/src/types/identifier/account_identifier.rs
+++ b/src/types/identifier/account_identifier.rs
@@ -1,14 +1,15 @@
 use crate::types::{hash::account_hash::AccountHash, public_key::PublicKey, sdk_error::SdkError};
 use casper_client::rpcs::AccountIdentifier as _AccountIdentifier;
 use casper_types::account::ACCOUNT_HASH_FORMATTED_STRING_PREFIX;
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use gloo_utils::format::JsValueSerdeExt;
 use serde::{Deserialize, Serialize};
 use std::fmt;
+#[cfg(feature = "js")]
 use wasm_bindgen::prelude::*;
 
 #[derive(Debug, Deserialize, Clone, Serialize)]
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 pub struct AccountIdentifier(_AccountIdentifier);
 
 #[deprecated(note = "prefer 'EntityIdentifier'")]
@@ -25,18 +26,18 @@ impl AccountIdentifier {
     }
 }
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 #[deprecated(note = "prefer 'EntityIdentifier'")]
 #[allow(deprecated)]
 impl AccountIdentifier {
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(constructor)]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(constructor))]
     pub fn new(formatted_str: &str) -> Result<AccountIdentifier, JsError> {
         Self::from_formatted_str_js_alias(formatted_str)
     }
 
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(js_name = "fromFormattedStr")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "fromFormattedStr"))]
     pub fn from_formatted_str_js_alias(formatted_str: &str) -> Result<AccountIdentifier, JsError> {
         Self::from_formatted_str(formatted_str).map_err(|err| {
             JsError::new(&format!(
@@ -45,18 +46,18 @@ impl AccountIdentifier {
         })
     }
 
-    #[wasm_bindgen(js_name = "fromPublicKey")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "fromPublicKey"))]
     pub fn from_account_under_public_key(key: PublicKey) -> Self {
         Self(_AccountIdentifier::PublicKey(key.into()))
     }
 
-    #[wasm_bindgen(js_name = "fromAccountHash")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "fromAccountHash"))]
     pub fn from_account_under_account_hash(account_hash: AccountHash) -> Self {
         Self(_AccountIdentifier::AccountHash(account_hash.into()))
     }
 
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(js_name = "toJson")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "toJson"))]
     pub fn to_json(&self) -> JsValue {
         JsValue::from_serde(self).unwrap_or(JsValue::null())
     }

--- a/src/types/identifier/block_identifier.rs
+++ b/src/types/identifier/block_identifier.rs
@@ -2,18 +2,19 @@ use core::fmt;
 
 use crate::types::hash::block_hash::BlockHash;
 use casper_client::rpcs::common::BlockIdentifier as _BlockIdentifier;
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use gloo_utils::format::JsValueSerdeExt;
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "js")]
 use wasm_bindgen::prelude::*;
 
 #[derive(Debug, Deserialize, Clone, Serialize, Copy)]
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 pub struct BlockIdentifier(_BlockIdentifier);
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl BlockIdentifier {
-    #[wasm_bindgen(constructor)]
+    #[cfg_attr(feature = "js", wasm_bindgen(constructor))]
     pub fn new(block_identifier: BlockIdentifier) -> Self {
         block_identifier
     }
@@ -22,13 +23,13 @@ impl BlockIdentifier {
         Self(_BlockIdentifier::Hash(hash.into()))
     }
 
-    #[wasm_bindgen(js_name = "fromHeight")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "fromHeight"))]
     pub fn from_height(height: u64) -> Self {
         Self(_BlockIdentifier::Height(height))
     }
 
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(js_name = "toJson")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "toJson"))]
     pub fn to_json(&self) -> JsValue {
         JsValue::from_serde(self).unwrap_or(JsValue::null())
     }

--- a/src/types/identifier/dictionary_item_identifier.rs
+++ b/src/types/identifier/dictionary_item_identifier.rs
@@ -1,12 +1,13 @@
 use crate::types::{key::Key, sdk_error::SdkError};
 use casper_client::rpcs::DictionaryItemIdentifier as _DictionaryItemIdentifier;
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use gloo_utils::format::JsValueSerdeExt;
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "js")]
 use wasm_bindgen::prelude::*;
 
 #[derive(Debug, Deserialize, Clone, Serialize)]
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 pub struct DictionaryItemIdentifier(_DictionaryItemIdentifier);
 
 impl DictionaryItemIdentifier {
@@ -99,10 +100,11 @@ impl DictionaryItemIdentifier {
     }
 }
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl DictionaryItemIdentifier {
     // static context
-    #[wasm_bindgen(js_name = "newFromAccountInfo")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "newFromAccountInfo"))]
+    #[cfg(feature = "js")]
     pub fn new_from_account_info_js_alias(
         account_hash: &str,
         dictionary_name: &str,
@@ -113,7 +115,8 @@ impl DictionaryItemIdentifier {
     }
 
     // static context
-    #[wasm_bindgen(js_name = "newFromContractInfo")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "newFromContractInfo"))]
+    #[cfg(feature = "js")]
     pub fn new_from_contract_info_js_alias(
         contract_addr: &str,
         dictionary_name: &str,
@@ -123,7 +126,8 @@ impl DictionaryItemIdentifier {
             .map_err(Into::into)
     }
 
-    #[wasm_bindgen(js_name = "newFromEntityInfo")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "newFromEntityInfo"))]
+    #[cfg(feature = "js")]
     pub fn new_from_entity_info_js_alias(
         entity_addr: &str,
         dictionary_name: &str,
@@ -134,7 +138,8 @@ impl DictionaryItemIdentifier {
     }
 
     // static context
-    #[wasm_bindgen(js_name = "newFromSeedUref")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "newFromSeedUref"))]
+    #[cfg(feature = "js")]
     pub fn new_from_seed_uref_js_alias(
         seed_uref: &str,
         dictionary_item_key: &str,
@@ -143,15 +148,16 @@ impl DictionaryItemIdentifier {
     }
 
     // static context
-    #[wasm_bindgen(js_name = "newFromDictionaryKey")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "newFromDictionaryKey"))]
+    #[cfg(feature = "js")]
     pub fn new_from_dictionary_key_js_alias(
         dictionary_key: &str,
     ) -> Result<DictionaryItemIdentifier, JsError> {
         Self::new_from_dictionary_key(dictionary_key).map_err(Into::into)
     }
 
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(js_name = "toJson")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "toJson"))]
     pub fn to_json(&self) -> JsValue {
         JsValue::from_serde(self).unwrap_or(JsValue::null())
     }

--- a/src/types/identifier/entity_identifier.rs
+++ b/src/types/identifier/entity_identifier.rs
@@ -6,14 +6,15 @@ use casper_client::rpcs::EntityIdentifier as _EntityIdentifier;
 use casper_types::{
     account::ACCOUNT_HASH_FORMATTED_STRING_PREFIX, addressable_entity::ENTITY_PREFIX,
 };
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use gloo_utils::format::JsValueSerdeExt;
 use serde::{Deserialize, Serialize};
 use std::fmt;
+#[cfg(feature = "js")]
 use wasm_bindgen::prelude::*;
 
 #[derive(Debug, Deserialize, Clone, Serialize)]
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 pub struct EntityIdentifier(_EntityIdentifier);
 
 impl EntityIdentifier {
@@ -35,37 +36,37 @@ impl EntityIdentifier {
     }
 }
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl EntityIdentifier {
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(constructor)]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(constructor))]
     pub fn new_js_alias(formatted_str: &str) -> Result<EntityIdentifier, JsError> {
         Self::from_formatted_str(formatted_str).map_err(|err| JsError::new(&err.to_string()))
     }
 
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(js_name = "fromFormattedStr")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "fromFormattedStr"))]
     pub fn from_formatted_str_js_alias(formatted_str: &str) -> Result<EntityIdentifier, JsError> {
         Self::from_formatted_str(formatted_str).map_err(|err| JsError::new(&err.to_string()))
     }
 
-    #[wasm_bindgen(js_name = "fromPublicKey")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "fromPublicKey"))]
     pub fn from_entity_under_public_key(key: PublicKey) -> Self {
         Self(_EntityIdentifier::PublicKey(key.into()))
     }
 
-    #[wasm_bindgen(js_name = "fromAccountHash")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "fromAccountHash"))]
     pub fn from_entity_under_account_hash(account_hash: AccountHash) -> Self {
         Self(_EntityIdentifier::AccountHash(account_hash.into()))
     }
 
-    #[wasm_bindgen(js_name = "fromEntityAddr")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "fromEntityAddr"))]
     pub fn from_entity_under_entity_addr(entity_addr: EntityAddr) -> Self {
         Self(_EntityIdentifier::EntityAddr(entity_addr.into()))
     }
 
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(js_name = "toJson")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "toJson"))]
     pub fn to_json(&self) -> JsValue {
         JsValue::from_serde(self).unwrap_or(JsValue::null())
     }

--- a/src/types/identifier/global_state_identifier.rs
+++ b/src/types/identifier/global_state_identifier.rs
@@ -1,40 +1,41 @@
 use crate::types::{digest::Digest, hash::block_hash::BlockHash};
 use casper_client::rpcs::common::GlobalStateIdentifier as _GlobalStateIdentifier;
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use gloo_utils::format::JsValueSerdeExt;
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "js")]
 use wasm_bindgen::prelude::*;
 
 #[derive(Debug, Deserialize, Clone, Serialize)]
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 pub struct GlobalStateIdentifier(_GlobalStateIdentifier);
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl GlobalStateIdentifier {
-    #[wasm_bindgen(constructor)]
+    #[cfg_attr(feature = "js", wasm_bindgen(constructor))]
     pub fn new(global_state_identifier: GlobalStateIdentifier) -> GlobalStateIdentifier {
         global_state_identifier
     }
 
-    #[wasm_bindgen(js_name = "fromBlockHash")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "fromBlockHash"))]
     pub fn from_block_hash(block_hash: BlockHash) -> GlobalStateIdentifier {
         GlobalStateIdentifier(_GlobalStateIdentifier::BlockHash(block_hash.into()))
     }
 
-    #[wasm_bindgen(js_name = "fromBlockHeight")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "fromBlockHeight"))]
     pub fn from_block_height(block_height: u64) -> GlobalStateIdentifier {
         GlobalStateIdentifier(_GlobalStateIdentifier::BlockHeight(block_height))
     }
 
-    #[wasm_bindgen(js_name = "fromStateRootHash")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "fromStateRootHash"))]
     pub fn from_state_root_hash(state_root_hash: Digest) -> GlobalStateIdentifier {
         GlobalStateIdentifier(_GlobalStateIdentifier::StateRootHash(
             state_root_hash.into(),
         ))
     }
 
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(js_name = "toJson")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "toJson"))]
     pub fn to_json(&self) -> JsValue {
         JsValue::from_serde(self).unwrap_or(JsValue::null())
     }

--- a/src/types/identifier/purse_identifier.rs
+++ b/src/types/identifier/purse_identifier.rs
@@ -1,37 +1,38 @@
 use crate::types::{hash::account_hash::AccountHash, public_key::PublicKey, uref::URef};
 use casper_client::rpcs::PurseIdentifier as _PurseIdentifier;
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use gloo_utils::format::JsValueSerdeExt;
 use serde::{Deserialize, Serialize};
 use std::fmt;
+#[cfg(feature = "js")]
 use wasm_bindgen::prelude::*;
 
 #[derive(Debug, Deserialize, Clone, Serialize)]
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 pub struct PurseIdentifier(_PurseIdentifier);
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl PurseIdentifier {
-    #[wasm_bindgen(constructor)]
-    #[wasm_bindgen(js_name = "fromPublicKey")]
+    #[cfg_attr(feature = "js", wasm_bindgen(constructor))]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "fromPublicKey"))]
     pub fn from_main_purse_under_public_key(key: PublicKey) -> Self {
         PurseIdentifier(_PurseIdentifier::MainPurseUnderPublicKey(key.into()))
     }
 
-    #[wasm_bindgen(js_name = "fromAccountHash")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "fromAccountHash"))]
     pub fn from_main_purse_under_account_hash(account_hash: AccountHash) -> Self {
         PurseIdentifier(_PurseIdentifier::MainPurseUnderAccountHash(
             account_hash.into(),
         ))
     }
 
-    #[wasm_bindgen(js_name = "fromURef")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "fromURef"))]
     pub fn from_purse_uref(uref: URef) -> Self {
         PurseIdentifier(_PurseIdentifier::PurseUref(uref.into()))
     }
 
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(js_name = "toJson")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "toJson"))]
     pub fn to_json(&self) -> JsValue {
         JsValue::from_serde(self).unwrap_or(JsValue::null())
     }

--- a/src/types/key.rs
+++ b/src/types/key.rs
@@ -9,81 +9,83 @@ use crate::types::{
     uref::URef,
 };
 use casper_types::{bytesrepr::ToBytes, Key as _Key};
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use gloo_utils::format::JsValueSerdeExt;
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "js")]
 use wasm_bindgen::prelude::*;
 
 #[derive(Debug, Deserialize, Clone, Serialize)]
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 pub struct Key(_Key);
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl Key {
-    #[wasm_bindgen(constructor)]
+    #[cfg_attr(feature = "js", wasm_bindgen(constructor))]
+    #[cfg(feature = "js")]
     pub fn new(key: Key) -> Result<Key, JsError> {
         let key: _Key = key.into();
         Ok(Key(key))
     }
 
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(js_name = "toJson")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "toJson"))]
     pub fn to_json(&self) -> JsValue {
         JsValue::from_serde(self).unwrap_or(JsValue::null())
     }
 
-    #[wasm_bindgen(js_name = "fromURef")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "fromURef"))]
     pub fn from_uref(key: URef) -> Self {
         Self(_Key::URef(key.into()))
     }
 
-    #[wasm_bindgen(js_name = "fromDeployInfo")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "fromDeployInfo"))]
     pub fn from_deploy_info(key: DeployHash) -> Self {
         Self(_Key::DeployInfo(key.into()))
     }
 
-    #[wasm_bindgen(js_name = "fromAccount")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "fromAccount"))]
     pub fn from_account(key: AccountHash) -> Self {
         Self(_Key::Account(key.into()))
     }
 
-    #[wasm_bindgen]
-    #[wasm_bindgen(js_name = "fromHash")]
+    #[cfg_attr(feature = "js", wasm_bindgen)]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "fromHash"))]
     pub fn from_hash(key: HashAddr) -> Self {
         Self(_Key::Hash(key.into()))
     }
 
-    #[wasm_bindgen(js_name = "fromTransfer")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "fromTransfer"))]
     pub fn from_transfer(key: Vec<u8>) -> Self {
         Self(_Key::Transfer(TransferAddr::from(key).into()))
     }
 
-    #[wasm_bindgen(js_name = "fromEraInfo")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "fromEraInfo"))]
     pub fn from_era_info(key: EraId) -> Self {
         Self(_Key::EraInfo(key.into()))
     }
 
-    #[wasm_bindgen(js_name = "fromBalance")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "fromBalance"))]
     pub fn from_balance(key: URefAddr) -> Self {
         Self(_Key::Balance(key.into()))
     }
 
-    #[wasm_bindgen(js_name = "fromBid")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "fromBid"))]
     pub fn from_bid(key: AccountHash) -> Self {
         Self(_Key::Bid(key.into()))
     }
 
-    #[wasm_bindgen(js_name = "fromWithdraw")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "fromWithdraw"))]
     pub fn from_withdraw(key: AccountHash) -> Self {
         Self(_Key::Withdraw(key.into()))
     }
 
-    #[wasm_bindgen(js_name = "fromDictionaryAddr")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "fromDictionaryAddr"))]
     pub fn from_dictionary_addr(key: DictionaryAddr) -> Self {
         Self(_Key::Dictionary(key.into()))
     }
 
-    #[wasm_bindgen(js_name = "asDictionaryAddr")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "asDictionaryAddr"))]
     pub fn as_dictionary(&self) -> Option<DictionaryAddr> {
         match &self.0 {
             _Key::Dictionary(v) => Some((*v).into()),
@@ -91,54 +93,54 @@ impl Key {
         }
     }
 
-    #[wasm_bindgen(js_name = "fromSystemEntityRegistry")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "fromSystemEntityRegistry"))]
     pub fn from_system_contract_registry() -> Self {
         Self(_Key::SystemEntityRegistry)
     }
 
-    #[wasm_bindgen(js_name = "fromEraSummary")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "fromEraSummary"))]
     pub fn from_era_summary() -> Self {
         Self(_Key::EraSummary)
     }
 
-    #[wasm_bindgen(js_name = "fromUnbond")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "fromUnbond"))]
     pub fn from_unbond(key: AccountHash) -> Self {
         Self(_Key::Unbond(key.into()))
     }
 
-    #[wasm_bindgen(js_name = "fromChainspecRegistry")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "fromChainspecRegistry"))]
     pub fn from_chainspec_registry() -> Self {
         Self(_Key::ChainspecRegistry)
     }
 
-    #[wasm_bindgen(js_name = "fromChecksumRegistry")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "fromChecksumRegistry"))]
     pub fn from_checksum_registry() -> Self {
         Self(_Key::ChecksumRegistry)
     }
 
-    #[wasm_bindgen(js_name = "toFormattedString")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "toFormattedString"))]
     pub fn to_formatted_string(&self) -> String {
         _Key::to_formatted_string(self.0)
     }
 
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(js_name = "fromFormattedString")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "fromFormattedString"))]
     pub fn from_formatted_str_js_alias(formatted_str: &str) -> Result<Key, JsError> {
         Self::from_formatted_str(formatted_str)
             .map_err(|err| JsError::new(&format!("Error parsing Key from formatted string, {err}")))
     }
 
-    #[wasm_bindgen(js_name = "fromDictionaryKey")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "fromDictionaryKey"))]
     pub fn from_dictionary_key(seed_uref: URef, dictionary_item_key: &[u8]) -> Self {
         _Key::dictionary(seed_uref.into(), dictionary_item_key).into()
     }
 
-    #[wasm_bindgen(js_name = "isDictionaryKey")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "isDictionaryKey"))]
     pub fn is_dictionary_key(&self) -> bool {
         matches!(&self.0, _Key::Dictionary(_))
     }
 
-    #[wasm_bindgen(js_name = "intoAccount")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "intoAccount"))]
     pub fn into_account(self) -> Option<AccountHash> {
         match self.0 {
             _Key::Account(bytes) => Some(bytes.into()),
@@ -146,7 +148,7 @@ impl Key {
         }
     }
 
-    #[wasm_bindgen(js_name = "intoHash")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "intoHash"))]
     pub fn into_hash(self) -> Option<HashAddr> {
         match self.0 {
             _Key::Hash(hash) => Some(hash.into()),
@@ -154,7 +156,7 @@ impl Key {
         }
     }
 
-    #[wasm_bindgen(js_name = "asBalance")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "asBalance"))]
     pub fn as_balance(&self) -> Option<URefAddr> {
         match &self.0 {
             _Key::Balance(v) => Some((*v).into()),
@@ -162,7 +164,7 @@ impl Key {
         }
     }
 
-    #[wasm_bindgen(js_name = "intoURef")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "intoURef"))]
     pub fn into_uref(self) -> Option<URef> {
         match self.0 {
             _Key::URef(uref) => Some(uref.into()),
@@ -170,7 +172,7 @@ impl Key {
         }
     }
 
-    #[wasm_bindgen(js_name = "urefToHash")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "urefToHash"))]
     pub fn uref_to_hash(&self) -> Option<Key> {
         if let _Key::URef(uref) = &self.0 {
             let addr = uref.addr();
@@ -179,7 +181,7 @@ impl Key {
         None
     }
 
-    #[wasm_bindgen(js_name = "withdrawToUnbond")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "withdrawToUnbond"))]
     pub fn withdraw_to_unbond(&self) -> Option<Key> {
         if let _Key::Withdraw(account_hash) = &self.0 {
             return Some(Key(_Key::Unbond(*account_hash)));

--- a/src/types/named_key_value.rs
+++ b/src/types/named_key_value.rs
@@ -1,13 +1,14 @@
 use crate::types::{cl::cl_value::CLValue, key::Key};
 use casper_types::addressable_entity::NamedKeyValue as _NamedKeyValue;
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use gloo_utils::format::JsValueSerdeExt;
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "js")]
 use wasm_bindgen::prelude::*;
 
 /// Wasm/native wrapper around [`casper_types::NamedKeyValue`].
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 pub struct NamedKeyValue(_NamedKeyValue);
 
 impl NamedKeyValue {
@@ -32,30 +33,30 @@ impl NamedKeyValue {
     }
 }
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl NamedKeyValue {
-    #[wasm_bindgen(js_name = "nameClValue")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "nameClValue"))]
     pub fn name_cl_value_js(&self) -> CLValue {
         self.name_cl_value()
     }
 
-    #[wasm_bindgen(js_name = "keyClValue")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "keyClValue"))]
     pub fn key_cl_value_js(&self) -> CLValue {
         self.key_cl_value()
     }
 
-    #[wasm_bindgen(js_name = "name")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "name"))]
     pub fn name_js(&self) -> Option<String> {
         self.name()
     }
 
-    #[wasm_bindgen(js_name = "key")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "key"))]
     pub fn key_js(&self) -> Option<Key> {
         self.key()
     }
 
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(js_name = "toJson")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "toJson"))]
     pub fn to_json(&self) -> JsValue {
         JsValue::from_serde(&self.0).unwrap_or(JsValue::null())
     }

--- a/src/types/named_keys.rs
+++ b/src/types/named_keys.rs
@@ -1,13 +1,14 @@
 use crate::types::key::Key;
 use casper_types::NamedKeys as _NamedKeys;
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use gloo_utils::format::JsValueSerdeExt;
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "js")]
 use wasm_bindgen::prelude::*;
 
 /// Wasm/native wrapper around [`casper_types::NamedKeys`].
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 pub struct NamedKeys(_NamedKeys);
 
 impl NamedKeys {
@@ -32,35 +33,35 @@ impl NamedKeys {
     }
 }
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl NamedKeys {
-    #[wasm_bindgen(constructor)]
+    #[cfg_attr(feature = "js", wasm_bindgen(constructor))]
     pub fn new() -> Self {
         Self(_NamedKeys::new())
     }
 
-    #[wasm_bindgen(js_name = "len")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "len"))]
     pub fn len_js(&self) -> usize {
         self.len()
     }
 
-    #[wasm_bindgen(js_name = "isEmpty")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "isEmpty"))]
     pub fn is_empty_js(&self) -> bool {
         self.is_empty()
     }
 
-    #[wasm_bindgen(js_name = "get")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "get"))]
     pub fn get_js(&self, name: &str) -> Option<Key> {
         self.get(name)
     }
 
-    #[wasm_bindgen(js_name = "names")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "names"))]
     pub fn names_js(&self) -> Vec<String> {
         self.names()
     }
 
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(js_name = "toJson")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "toJson"))]
     pub fn to_json(&self) -> JsValue {
         JsValue::from_serde(&self.0).unwrap_or(JsValue::null())
     }

--- a/src/types/package.rs
+++ b/src/types/package.rs
@@ -1,13 +1,14 @@
 use crate::types::addr::entity_addr::EntityAddr;
 use casper_types::Package as _Package;
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use gloo_utils::format::JsValueSerdeExt;
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "js")]
 use wasm_bindgen::prelude::*;
 
 /// Wasm/native wrapper around [`casper_types::Package`] (`StoredValue::SmartContract`).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 pub struct Package(_Package);
 
 impl Package {
@@ -24,20 +25,20 @@ impl Package {
     }
 }
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl Package {
-    #[wasm_bindgen(js_name = "isLocked")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "isLocked"))]
     pub fn is_locked_js(&self) -> bool {
         self.is_locked()
     }
 
-    #[wasm_bindgen(js_name = "currentEntityHash")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "currentEntityHash"))]
     pub fn current_entity_hash_js(&self) -> Option<EntityAddr> {
         self.current_entity_hash()
     }
 
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(js_name = "toJson")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "toJson"))]
     pub fn to_json(&self) -> JsValue {
         JsValue::from_serde(&self.0).unwrap_or(JsValue::null())
     }

--- a/src/types/path.rs
+++ b/src/types/path.rs
@@ -1,19 +1,21 @@
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use gloo_utils::format::JsValueSerdeExt;
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use js_sys::Array;
 use serde::{Deserialize, Deserializer, Serialize};
+#[cfg(feature = "js")]
 use wasm_bindgen::prelude::*;
 
 #[derive(Debug, Clone, Serialize, Default)]
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 pub struct Path {
     path: Vec<String>,
 }
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl Path {
-    #[wasm_bindgen(constructor)]
+    #[cfg_attr(feature = "js", wasm_bindgen(constructor))]
+    #[cfg(feature = "js")]
     pub fn new(path: JsValue) -> Self {
         let path_string: String = if path.is_null() {
             String::from("")
@@ -23,8 +25,8 @@ impl Path {
         Path::from(path_string)
     }
 
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(js_name = "fromArray")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "fromArray"))]
     pub fn from_js_array(path: JsValue) -> Self {
         let path: Array = path.into();
         let path: Vec<String> = path
@@ -39,14 +41,14 @@ impl Path {
         Path { path }
     }
 
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(js_name = "toJson")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "toJson"))]
     pub fn to_json(&self) -> JsValue {
         JsValue::from_serde(&self.path).unwrap_or(JsValue::null())
     }
 
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(js_name = "toString")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "toString"))]
     pub fn to_string_js_alias(&self) -> String {
         self.to_string()
     }

--- a/src/types/peer_entry.rs
+++ b/src/types/peer_entry.rs
@@ -1,19 +1,20 @@
 use casper_client::rpcs::results::PeerEntry as _PeerEntry;
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "js")]
 use wasm_bindgen::prelude::*;
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 pub struct PeerEntry(_PeerEntry);
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl PeerEntry {
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
     pub fn node_id(&self) -> String {
         self.0.node_id.clone()
     }
 
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
     pub fn address(&self) -> String {
         self.0.address.clone()
     }

--- a/src/types/pricing_mode.rs
+++ b/src/types/pricing_mode.rs
@@ -1,8 +1,9 @@
 use casper_types::PricingMode as _PricingMode;
+#[cfg(feature = "js")]
 use wasm_bindgen::prelude::*;
 
 #[derive(Copy, Clone, Default, Debug, PartialEq, Eq)]
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 pub enum PricingMode {
     #[default]
     Fixed,

--- a/src/types/public_key.rs
+++ b/src/types/public_key.rs
@@ -6,13 +6,14 @@ use casper_types::{
     bytesrepr::{self, FromBytes, ToBytes},
     PublicKey as _PublicKey, ED25519_TAG, SECP256K1_TAG, SYSTEM_TAG,
 };
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use gloo_utils::format::JsValueSerdeExt;
 use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Formatter, Result as FmtResult};
+#[cfg(feature = "js")]
 use wasm_bindgen::prelude::*;
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 #[derive(Debug, Deserialize, Clone, Serialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct PublicKey(_PublicKey);
 
@@ -52,10 +53,10 @@ impl PublicKey {
     }
 }
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl PublicKey {
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(constructor)]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(constructor))]
     pub fn new_js_alias(public_key_hex_str: &str) -> Result<PublicKey, JsError> {
         Self::new(public_key_hex_str).map_err(|err| {
             JsError::new(&format!(
@@ -64,26 +65,26 @@ impl PublicKey {
         })
     }
 
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(js_name = "fromUint8Array")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "fromUint8Array"))]
     pub fn from_bytes_js_alias(bytes: Vec<u8>) -> Result<PublicKey, JsError> {
         Self::from_bytes(&bytes)
             .map(|(public_key, _)| public_key)
             .map_err(|err| JsError::new(&format!("Failed to parse PublicKey: {err:?}")))
     }
 
-    #[wasm_bindgen(js_name = "toAccountHash")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "toAccountHash"))]
     pub fn to_account_hash(&self) -> AccountHash {
         AccountHash::from_public_key(self.0.clone().into())
     }
 
-    #[wasm_bindgen(js_name = "toPurseUref")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "toPurseUref"))]
     pub fn to_purse_uref(&self) -> URef {
         PurseIdentifier::from_main_purse_under_public_key(self.0.clone().into()).into()
     }
 
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(js_name = "toJson")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "toJson"))]
     pub fn to_json(&self) -> JsValue {
         JsValue::from_serde(self).unwrap_or(JsValue::null())
     }

--- a/src/types/record_id.rs
+++ b/src/types/record_id.rs
@@ -1,15 +1,17 @@
 use crate::types::sdk_error::SdkError;
 use casper_binary_port::RecordId as _RecordId;
+#[cfg(feature = "js")]
 use wasm_bindgen::prelude::*;
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 
 pub struct RecordId(_RecordId);
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl RecordId {
-    #[wasm_bindgen(constructor)]
+    #[cfg_attr(feature = "js", wasm_bindgen(constructor))]
+    #[cfg(feature = "js")]
     pub fn new_js_alias(value: u16) -> Result<RecordId, JsError> {
         Self::new(value).map_err(|err| JsError::new(&err.to_string()))
     }

--- a/src/types/runtime_args.rs
+++ b/src/types/runtime_args.rs
@@ -1,15 +1,16 @@
 use crate::types::{cl::cl_value::CLValue, sdk_error::SdkError};
 use casper_types::{bytesrepr::ToBytes, CLValue as _CLValue, RuntimeArgs as _RuntimeArgs};
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use gloo_utils::format::JsValueSerdeExt;
 use serde_json::json;
+#[cfg(feature = "js")]
 use wasm_bindgen::prelude::*;
 
 /// Wasm/native wrapper around [`casper_types::RuntimeArgs`].
 ///
 /// Pass to `set_session_args` on transaction (or legacy deploy) session params (#43).
 /// `set_session_args_simple` / `set_session_args_json` remain for string bags.
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct RuntimeArgs(_RuntimeArgs);
 
@@ -65,30 +66,30 @@ pub fn runtime_args_to_json_array(args: &_RuntimeArgs) -> Vec<serde_json::Value>
         .collect()
 }
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl RuntimeArgs {
-    #[wasm_bindgen(constructor)]
+    #[cfg_attr(feature = "js", wasm_bindgen(constructor))]
     pub fn new() -> Self {
         RuntimeArgs(_RuntimeArgs::new())
     }
 
     /// Insert a named [`CLValue`].
-    #[cfg(target_arch = "wasm32")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
     pub fn insert(&mut self, name: &str, value: &CLValue) {
         self.insert_cl_value(name, value.clone());
     }
 
     /// Insert a CLI-style simple arg (`name:Type='value'`).
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(js_name = "insertSimple")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "insertSimple"))]
     pub fn insert_simple_js(&mut self, arg: &str) -> Result<(), JsError> {
         self.insert_simple(arg)
             .map_err(|err| JsError::new(&err.to_string()))
     }
 
     /// Insert from a JS object `{name,type,value}` or a simple arg string.
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(js_name = "insertJsValue")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "insertJsValue"))]
     pub fn insert_js_value(&mut self, js_value_arg: JsValue) -> Result<(), JsError> {
         crate::helpers::insert_js_value_arg(&mut self.0, js_value_arg)
             .map(|_| ())
@@ -96,15 +97,15 @@ impl RuntimeArgs {
     }
 
     /// JSON array suitable for `set_session_args_json` / payment args JSON.
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(js_name = "toSessionArgsJson")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "toSessionArgsJson"))]
     pub fn to_session_args_json_js(&self) -> Result<String, JsError> {
         self.to_session_args_json_string()
             .map_err(|err| JsError::new(&err.to_string()))
     }
 
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(js_name = "toJson")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "toJson"))]
     pub fn to_json(&self) -> JsValue {
         JsValue::from_serde(&self.to_session_args_json_array()).unwrap_or(JsValue::null())
     }

--- a/src/types/stored_value.rs
+++ b/src/types/stored_value.rs
@@ -13,9 +13,10 @@ use crate::types::{
     transfer::Transfer,
 };
 use casper_types::StoredValue as _StoredValue;
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use gloo_utils::format::JsValueSerdeExt;
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "js")]
 use wasm_bindgen::prelude::*;
 
 /// Wasm/native wrapper around [`casper_types::StoredValue`].
@@ -24,7 +25,7 @@ use wasm_bindgen::prelude::*;
 /// (`Bid`, `BidKind`, `Withdraw`, `Unbonding`, `MessageTopic`, `Message`,
 /// `Prepayment`) expose `variant` and `toJson` only.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 pub struct StoredValue(_StoredValue);
 
 impl StoredValue {
@@ -130,85 +131,85 @@ impl StoredValue {
     }
 }
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl StoredValue {
-    #[wasm_bindgen(js_name = "variant")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "variant"))]
     pub fn variant_js(&self) -> String {
         self.variant().to_string()
     }
 
-    #[wasm_bindgen(js_name = "asClValue")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "asClValue"))]
     pub fn as_cl_value_js(&self) -> Option<CLValue> {
         self.as_cl_value()
     }
 
-    #[wasm_bindgen(js_name = "asAccount")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "asAccount"))]
     pub fn as_account_js(&self) -> Option<Account> {
         self.as_account()
     }
 
-    #[wasm_bindgen(js_name = "asContract")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "asContract"))]
     pub fn as_contract_js(&self) -> Option<Contract> {
         self.as_contract()
     }
 
-    #[wasm_bindgen(js_name = "asContractPackage")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "asContractPackage"))]
     pub fn as_contract_package_js(&self) -> Option<ContractPackage> {
         self.as_contract_package()
     }
 
-    #[wasm_bindgen(js_name = "asAddressableEntity")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "asAddressableEntity"))]
     pub fn as_addressable_entity_js(&self) -> Option<AddressableEntity> {
         self.as_addressable_entity()
     }
 
-    #[wasm_bindgen(js_name = "asSmartContract")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "asSmartContract"))]
     pub fn as_smart_contract_js(&self) -> Option<Package> {
         self.as_smart_contract()
     }
 
-    #[wasm_bindgen(js_name = "asNamedKey")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "asNamedKey"))]
     pub fn as_named_key_js(&self) -> Option<NamedKeyValue> {
         self.as_named_key()
     }
 
-    #[wasm_bindgen(js_name = "asEntryPoint")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "asEntryPoint"))]
     pub fn as_entry_point_js(&self) -> Option<EntryPointValue> {
         self.as_entry_point()
     }
 
-    #[wasm_bindgen(js_name = "asContractWasm")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "asContractWasm"))]
     pub fn as_contract_wasm_js(&self) -> Option<ContractWasm> {
         self.as_contract_wasm()
     }
 
-    #[wasm_bindgen(js_name = "asByteCode")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "asByteCode"))]
     pub fn as_byte_code_js(&self) -> Option<ByteCode> {
         self.as_byte_code()
     }
 
-    #[wasm_bindgen(js_name = "asTransfer")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "asTransfer"))]
     pub fn as_transfer_js(&self) -> Option<Transfer> {
         self.as_transfer()
     }
 
-    #[wasm_bindgen(js_name = "asDeployInfo")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "asDeployInfo"))]
     pub fn as_deploy_info_js(&self) -> Option<DeployInfo> {
         self.as_deploy_info()
     }
 
-    #[wasm_bindgen(js_name = "asEraInfo")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "asEraInfo"))]
     pub fn as_era_info_js(&self) -> Option<EraInfo> {
         self.as_era_info()
     }
 
-    #[wasm_bindgen(js_name = "asRawBytes")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "asRawBytes"))]
     pub fn as_raw_bytes_js(&self) -> Option<Vec<u8>> {
         self.as_raw_bytes()
     }
 
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(js_name = "toJson")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "toJson"))]
     pub fn to_json(&self) -> JsValue {
         JsValue::from_serde(&self.0).unwrap_or(JsValue::null())
     }

--- a/src/types/transaction.rs
+++ b/src/types/transaction.rs
@@ -1,4 +1,4 @@
-#[cfg(all(target_arch = "wasm32", feature = "transaction"))]
+#[cfg(all(feature = "js", target_arch = "wasm32", feature = "transaction"))]
 use crate::helpers::insert_js_value_arg;
 use crate::helpers::secret_key_from_pem;
 #[cfg(feature = "transaction")]
@@ -38,14 +38,15 @@ use casper_types::{
     TransactionInvocationTarget, TransactionTarget, TransactionV1,
 };
 use chrono::{DateTime, Utc};
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use gloo_utils::format::JsValueSerdeExt;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
+#[cfg(feature = "js")]
 use wasm_bindgen::prelude::*;
 
 #[derive(Debug, Deserialize, Clone, Serialize)]
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 pub struct Transaction(_Transaction);
 
 const ARGS_MAP_KEY: u16 = 0;
@@ -53,10 +54,10 @@ const TARGET_MAP_KEY: u16 = 1;
 const ENTRY_POINT_MAP_KEY: u16 = 2;
 const DEFAULT_GAS_PRICE_TOLERANCE: u8 = 1;
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl Transaction {
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(constructor)]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(constructor))]
     pub fn new(transaction: JsValue) -> Self {
         let transaction: _Transaction = transaction
             .into_serde()
@@ -65,8 +66,8 @@ impl Transaction {
         transaction.into()
     }
 
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(js_name = "toJson")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "toJson"))]
     pub fn to_json_js_alias(&self) -> JsValue {
         match JsValue::from_serde(&self.0) {
             Ok(json) => json,
@@ -79,7 +80,7 @@ impl Transaction {
 
     #[cfg(feature = "transaction")]
     // static context
-    #[wasm_bindgen(js_name = "newSession")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "newSession"))]
     pub fn new_session(
         builder_params: TransactionBuilderParams,
         transaction_params: TransactionStrParams,
@@ -92,7 +93,7 @@ impl Transaction {
 
     #[cfg(feature = "transaction")]
     // static context
-    #[wasm_bindgen(js_name = "newTransfer")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "newTransfer"))]
     pub fn new_transfer(
         maybe_source: Option<URef>,
         target_account: &str,
@@ -111,7 +112,7 @@ impl Transaction {
     }
 
     #[cfg(feature = "transaction")]
-    #[wasm_bindgen(js_name = "withTTL")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "withTTL"))]
     pub fn with_ttl(&self, ttl: &str, secret_key: Option<String>) -> Transaction {
         let mut ttl = parse_ttl(ttl);
         if let Err(err) = &ttl {
@@ -129,7 +130,7 @@ impl Transaction {
     }
 
     #[cfg(feature = "transaction")]
-    #[wasm_bindgen(js_name = "withTimestamp")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "withTimestamp"))]
     pub fn with_timestamp(&self, timestamp: &str, secret_key: Option<String>) -> Transaction {
         let mut timestamp = parse_timestamp(timestamp);
         if let Err(err) = &timestamp {
@@ -147,7 +148,7 @@ impl Transaction {
     }
 
     #[cfg(feature = "transaction")]
-    #[wasm_bindgen(js_name = "withChainName")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "withChainName"))]
     pub fn with_chain_name(&self, chain_name: &str, secret_key: Option<String>) -> Transaction {
         self.rebuild(
             RebuildOverrides {
@@ -160,7 +161,7 @@ impl Transaction {
     }
 
     #[cfg(feature = "transaction")]
-    #[wasm_bindgen(js_name = "withPublicKey")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "withPublicKey"))]
     pub fn with_public_key(
         &self,
         public_key: PublicKey,
@@ -177,7 +178,7 @@ impl Transaction {
     }
 
     #[cfg(feature = "transaction")]
-    #[wasm_bindgen(js_name = "withAccountHash")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "withAccountHash"))]
     pub fn with_account_hash(
         &self,
         account_hash: AccountHash,
@@ -194,7 +195,7 @@ impl Transaction {
     }
 
     #[cfg(feature = "transaction")]
-    #[wasm_bindgen(js_name = "withEntryPoint")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "withEntryPoint"))]
     pub fn with_entry_point(&self, entry_point: &str, secret_key: Option<String>) -> Transaction {
         let new_builder_params = NewBuilderParams::<'_> {
             new_entry_point: Some(entry_point.to_string()),
@@ -210,7 +211,7 @@ impl Transaction {
     }
 
     #[cfg(feature = "transaction")]
-    #[wasm_bindgen(js_name = "withEntityHash")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "withEntityHash"))]
     pub fn with_entity_hash(
         &self,
         hash: AddressableEntityHash,
@@ -230,7 +231,7 @@ impl Transaction {
     }
 
     #[cfg(feature = "transaction")]
-    #[wasm_bindgen(js_name = "withPackageHash")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "withPackageHash"))]
     pub fn with_package_hash(
         &self,
         package_hash: PackageHash,
@@ -250,7 +251,7 @@ impl Transaction {
     }
 
     #[cfg(feature = "transaction")]
-    #[wasm_bindgen(js_name = "withTransactionBytes")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "withTransactionBytes"))]
     pub fn with_transaction_bytes(
         &self,
         transaction_bytes: Bytes,
@@ -272,7 +273,7 @@ impl Transaction {
     }
 
     #[cfg(feature = "transaction")]
-    #[wasm_bindgen(js_name = "withSecretKey")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "withSecretKey"))]
     pub fn with_secret_key(&self, secret_key: Option<String>) -> Transaction {
         self.rebuild(
             RebuildOverrides {
@@ -286,7 +287,7 @@ impl Transaction {
     /// Rebuild with `PaymentLimited` pricing (`standard_payment: true`), same role as Deploy's
     /// standard payment mutator.
     #[cfg(feature = "transaction")]
-    #[wasm_bindgen(js_name = "withStandardPayment")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "withStandardPayment"))]
     pub fn with_standard_payment(&self, amount: &str, secret_key: Option<String>) -> Transaction {
         let payment_amount = match amount.parse::<u64>() {
             Ok(value) => value,
@@ -310,7 +311,7 @@ impl Transaction {
         )
     }
 
-    #[wasm_bindgen(js_name = "verify")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "verify"))]
     pub fn verify(&self) -> bool {
         match self.0.verify() {
             Ok(()) => true,
@@ -321,12 +322,12 @@ impl Transaction {
         }
     }
 
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
     pub fn hash(&self) -> TransactionHash {
         self.0.hash().into()
     }
 
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
     pub fn expired(&self) -> bool {
         let now: DateTime<Utc> = Utc::now();
         let now_millis = now.timestamp_millis() as u64;
@@ -340,8 +341,8 @@ impl Transaction {
         }
     }
 
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(getter, js_name = "expires")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter, js_name = "expires"))]
     pub fn expires_js_alias(&self) -> JsValue {
         match JsValue::from_serde(&self.expires()) {
             Ok(expires) => expires,
@@ -352,8 +353,8 @@ impl Transaction {
         }
     }
 
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(getter, js_name = "signers")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter, js_name = "signers"))]
     pub fn signers_js_alias(&self) -> JsValue {
         match JsValue::from_serde(&self.signers()) {
             Ok(signers) => signers,
@@ -364,8 +365,8 @@ impl Transaction {
         }
     }
 
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(getter, js_name = "authorization_keys")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter, js_name = "authorization_keys"))]
     pub fn authorization_keys_js_alias(&self) -> JsValue {
         match JsValue::from_serde(&self.authorization_keys()) {
             Ok(authorization_keys) => authorization_keys,
@@ -378,7 +379,7 @@ impl Transaction {
         }
     }
 
-    #[wasm_bindgen(js_name = "sign")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "sign"))]
     pub fn sign(&mut self, secret_key: &str) -> Transaction {
         let mut transaction: _Transaction = self.0.clone();
         let secret_key_from_pem = secret_key_from_pem(secret_key);
@@ -393,8 +394,8 @@ impl Transaction {
         transaction.into()
     }
 
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(js_name = "approvalsHash")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "approvalsHash"))]
     pub fn compute_approvals_hash_js_alias(&self) -> JsValue {
         match JsValue::from_serde(&self.compute_approvals_hash()) {
             Ok(json) => json,
@@ -407,8 +408,8 @@ impl Transaction {
         }
     }
 
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(getter, js_name = "approvals")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter, js_name = "approvals"))]
     pub fn approvals_js_alias(&self) -> JsValue {
         match JsValue::from_serde(&self.approvals()) {
             Ok(json) => json,
@@ -419,7 +420,7 @@ impl Transaction {
         }
     }
 
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
     pub fn is_native(&self) -> bool {
         match &self.0 {
             _Transaction::Deploy(deploy) => deploy.is_transfer(),
@@ -432,8 +433,8 @@ impl Transaction {
         }
     }
 
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(getter, js_name = "target")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter, js_name = "target"))]
     pub fn target_js_alias(&self) -> JsValue {
         match self.target() {
             Ok(target_value) => match JsValue::from_serde(&target_value) {
@@ -450,13 +451,13 @@ impl Transaction {
         }
     }
 
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
     pub fn is_standard_payment(&self) -> bool {
         self.0.is_standard_payment()
     }
 
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(js_name = "session_args")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "session_args"))]
     pub fn session_args_js_alias(&self) -> JsValue {
         match self.session_args() {
             Ok(args) => match JsValue::from_serde(&args) {
@@ -474,31 +475,31 @@ impl Transaction {
     }
 
     /// Bytesrepr session args, or an error when args are named.
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(js_name = "session_args_bytes")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "session_args_bytes"))]
     pub fn session_args_bytes_js_alias(&self) -> Result<Bytes, JsError> {
         self.session_args_bytes()
             .map_err(|err| JsError::new(&format!("{err:?}")))
     }
 
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(getter, js_name = "is_bytesrepr")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter, js_name = "is_bytesrepr"))]
     pub fn is_bytesrepr_js_alias(&self) -> bool {
         self.is_bytesrepr()
     }
 
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(getter, js_name = "is_named")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter, js_name = "is_named"))]
     pub fn is_named_js_alias(&self) -> bool {
         self.is_named()
     }
 
-    #[wasm_bindgen(js_name = "addSignature")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "addSignature"))]
     pub fn add_signature_json_alias(&self, public_key: &str, signature: &str) -> Transaction {
         self.add_signature(public_key, signature)
     }
 
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
     pub fn entry_point(&self) -> String {
         match &self.0 {
             _Transaction::Deploy(deploy) => deploy.session().entry_point_name().into(),
@@ -512,27 +513,27 @@ impl Transaction {
         }
     }
 
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
     pub fn ttl(&self) -> String {
         self.0.ttl().to_string()
     }
 
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
     pub fn timestamp(&self) -> String {
         self.0.timestamp().to_string()
     }
 
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
     pub fn size_estimate(&self) -> usize {
         self.0.size_estimate()
     }
 
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
     pub fn chain_name(&self) -> String {
         self.0.chain_name()
     }
 
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
     pub fn initiator_addr(&self) -> String {
         let initiator_addr: InitiatorAddr = self.0.initiator_addr().clone();
         match initiator_addr {
@@ -541,7 +542,7 @@ impl Transaction {
         }
     }
 
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
     pub fn pricing_mode(&self) -> PricingMode {
         match &self.0 {
             _Transaction::Deploy(_deploy) => {
@@ -551,7 +552,7 @@ impl Transaction {
         }
     }
 
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
     pub fn payment_amount(&self) -> Option<u64> {
         match &self.0 {
             _Transaction::Deploy(_deploy) => _deploy
@@ -570,7 +571,7 @@ impl Transaction {
         }
     }
 
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
     pub fn additional_computation_factor(&self) -> u8 {
         match &self.0 {
             _Transaction::Deploy(_deploy) => {
@@ -582,7 +583,7 @@ impl Transaction {
         }
     }
 
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
     pub fn receipt(&self) -> Digest {
         match &self.0 {
             _Transaction::Deploy(_deploy) => {
@@ -595,7 +596,7 @@ impl Transaction {
         }
     }
 
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
     pub fn gas_price_tolerance(&self) -> u8 {
         match &self.0 {
             _Transaction::Deploy(deploy) => deploy
@@ -605,14 +606,14 @@ impl Transaction {
         }
     }
 
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
     pub fn account_hash(&self) -> AccountHash {
         let initiator_addr: InitiatorAddr = self.0.initiator_addr().clone();
         initiator_addr.account_hash().into()
     }
 
     /// True when the V1 target is a stored entity (`ByHash` / `ByName`), or the Deploy session is.
-    #[wasm_bindgen(js_name = "isStoredContract")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "isStoredContract"))]
     pub fn is_stored_contract(&self) -> bool {
         match &self.0 {
             _Transaction::Deploy(deploy) => deploy.session().is_stored_contract(),
@@ -630,7 +631,7 @@ impl Transaction {
     }
 
     /// True when the V1 target is a stored package, or the Deploy session is.
-    #[wasm_bindgen(js_name = "isStoredContractPackage")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "isStoredContractPackage"))]
     pub fn is_stored_contract_package(&self) -> bool {
         match &self.0 {
             _Transaction::Deploy(deploy) => deploy.session().is_stored_contract_package(),
@@ -648,7 +649,7 @@ impl Transaction {
     }
 
     /// True when the stored target (or Deploy session) is selected by name/alias.
-    #[wasm_bindgen(js_name = "isByName")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "isByName"))]
     pub fn is_by_name(&self) -> bool {
         match &self.0 {
             _Transaction::Deploy(deploy) => deploy.session().is_by_name(),
@@ -666,7 +667,7 @@ impl Transaction {
     }
 
     /// Alias or package name for a by-name stored target (Deploy session when wrapped).
-    #[wasm_bindgen(js_name = "byName")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "byName"))]
     pub fn by_name(&self) -> Option<String> {
         match &self.0 {
             _Transaction::Deploy(deploy) => deploy.session().by_name(),
@@ -682,7 +683,8 @@ impl Transaction {
     }
 
     #[cfg(all(target_arch = "wasm32", feature = "transaction"))]
-    #[wasm_bindgen(js_name = "addArg")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "addArg"))]
+    #[cfg(feature = "js")]
     pub fn add_arg_js_alias(
         &mut self,
         js_value_arg: JsValue,

--- a/src/types/transaction_params/transaction_builder_params.rs
+++ b/src/types/transaction_params/transaction_builder_params.rs
@@ -16,9 +16,10 @@ use casper_types::{
     contracts::ProtocolVersionMajor, TransactionRuntimeParams, TransferTarget as _TransferTarget,
     U512,
 };
+#[cfg(feature = "js")]
 use wasm_bindgen::prelude::*;
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 #[derive(Clone, Copy, Debug)]
 pub enum TransferTargetKind {
     PublicKey,
@@ -26,7 +27,7 @@ pub enum TransferTargetKind {
     URef,
 }
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 #[derive(Clone, Debug)]
 pub struct TransferTarget {
     kind: TransferTargetKind,
@@ -35,9 +36,9 @@ pub struct TransferTarget {
     uref: Option<URef>,
 }
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl TransferTarget {
-    #[wasm_bindgen(constructor)]
+    #[cfg_attr(feature = "js", wasm_bindgen(constructor))]
     pub fn new(
         kind: TransferTargetKind,
         public_key: Option<PublicKey>,
@@ -53,7 +54,7 @@ impl TransferTarget {
     }
 }
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 #[derive(Clone, Debug, Default)]
 pub struct TransactionBuilderParams {
     kind: TransactionKind,
@@ -83,7 +84,7 @@ pub struct TransactionBuilderParams {
     runtime: Option<TransactionRuntimeParams>,
 }
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 #[derive(Clone, Copy, Debug, Default)]
 pub enum TransactionKind {
     InvocableEntity,
@@ -100,9 +101,9 @@ pub enum TransactionKind {
     WithdrawBid,
 }
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl TransactionBuilderParams {
-    #[wasm_bindgen(js_name = "newSession")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "newSession"))]
     pub fn new_session(
         transaction_bytes: Option<Bytes>,
         is_install_upgrade: Option<bool>,
@@ -134,7 +135,7 @@ impl TransactionBuilderParams {
         }
     }
 
-    #[wasm_bindgen(js_name = "newTransfer")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "newTransfer"))]
     pub fn new_transfer(
         maybe_source: Option<URef>,
         target: TransferTarget,
@@ -169,7 +170,7 @@ impl TransactionBuilderParams {
         }
     }
 
-    #[wasm_bindgen(js_name = "newInvocableEntity")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "newInvocableEntity"))]
     pub fn new_invocable_entity(
         entity_hash: AddressableEntityHash,
         entry_point: &str,
@@ -201,7 +202,7 @@ impl TransactionBuilderParams {
         }
     }
 
-    #[wasm_bindgen(js_name = "newInvocableEntityAlias")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "newInvocableEntityAlias"))]
     pub fn new_invocable_entity_alias(
         entity_alias: &str,
         entry_point: &str,
@@ -233,7 +234,7 @@ impl TransactionBuilderParams {
         }
     }
 
-    #[wasm_bindgen(js_name = "newPackage")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "newPackage"))]
     pub fn new_package(
         package_hash: PackageHash,
         entry_point: &str,
@@ -242,7 +243,7 @@ impl TransactionBuilderParams {
         Self::new_package_with_major(package_hash, entry_point, maybe_entity_version, None)
     }
 
-    #[wasm_bindgen(js_name = "newPackageWithMajor")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "newPackageWithMajor"))]
     pub fn new_package_with_major(
         package_hash: PackageHash,
         entry_point: &str,
@@ -278,7 +279,7 @@ impl TransactionBuilderParams {
         }
     }
 
-    #[wasm_bindgen(js_name = "newPackageAlias")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "newPackageAlias"))]
     pub fn new_package_alias(
         package_alias: &str,
         entry_point: &str,
@@ -287,7 +288,7 @@ impl TransactionBuilderParams {
         Self::new_package_alias_with_major(package_alias, entry_point, maybe_entity_version, None)
     }
 
-    #[wasm_bindgen(js_name = "newPackageAliasWithMajor")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "newPackageAliasWithMajor"))]
     pub fn new_package_alias_with_major(
         package_alias: &str,
         entry_point: &str,
@@ -322,7 +323,7 @@ impl TransactionBuilderParams {
         }
     }
 
-    #[wasm_bindgen(js_name = "newAddBid")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "newAddBid"))]
     pub fn new_add_bid(
         public_key: PublicKey,
         delegation_rate: u8,
@@ -359,7 +360,7 @@ impl TransactionBuilderParams {
         }
     }
 
-    #[wasm_bindgen(js_name = "newDelegate")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "newDelegate"))]
     pub fn new_delegate(
         delegator: PublicKey,
         validator: PublicKey,
@@ -393,7 +394,7 @@ impl TransactionBuilderParams {
         }
     }
 
-    #[wasm_bindgen(js_name = "newUndelegate")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "newUndelegate"))]
     pub fn new_undelegate(
         delegator: PublicKey,
         validator: PublicKey,
@@ -428,7 +429,7 @@ impl TransactionBuilderParams {
         }
     }
 
-    #[wasm_bindgen(js_name = "newRedelegate")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "newRedelegate"))]
     pub fn new_redelegate(
         delegator: PublicKey,
         validator: PublicKey,
@@ -463,7 +464,7 @@ impl TransactionBuilderParams {
         }
     }
 
-    #[wasm_bindgen(js_name = "newWithdrawBid")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "newWithdrawBid"))]
     pub fn new_withdraw_bid(public_key: PublicKey, amount: &str) -> TransactionBuilderParams {
         let amount = convert_amount(amount);
         TransactionBuilderParams {
@@ -493,199 +494,199 @@ impl TransactionBuilderParams {
         }
     }
 
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
     pub fn kind(&self) -> TransactionKind {
         self.kind
     }
 
-    #[wasm_bindgen(setter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(setter))]
     pub fn set_kind(&mut self, kind: TransactionKind) {
         self.kind = kind;
     }
 
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
     pub fn transaction_bytes(&self) -> Option<Bytes> {
         self.transaction_bytes.clone()
     }
 
-    #[wasm_bindgen(setter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(setter))]
     pub fn set_transaction_bytes(&mut self, transaction_bytes: Bytes) {
         self.transaction_bytes = Some(transaction_bytes);
     }
 
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
     pub fn maybe_source(&self) -> Option<URef> {
         self.maybe_source.clone()
     }
 
-    #[wasm_bindgen(setter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(setter))]
     pub fn set_maybe_source(&mut self, maybe_source: URef) {
         self.maybe_source = Some(maybe_source);
     }
 
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
     pub fn target(&self) -> Option<TransferTarget> {
         self.target.clone()
     }
 
-    #[wasm_bindgen(setter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(setter))]
     pub fn set_target(&mut self, target: TransferTarget) {
         self.target = Some(target);
     }
 
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
     pub fn amount(&self) -> Option<String> {
         self.amount.map(|amount| amount.to_string())
     }
 
-    #[wasm_bindgen(setter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(setter))]
     pub fn set_amount(&mut self, amount: &str) {
         let amount = convert_amount(amount);
         self.amount = amount;
     }
 
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
     pub fn maybe_id(&self) -> Option<u64> {
         self.maybe_id
     }
 
-    #[wasm_bindgen(setter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(setter))]
     pub fn set_maybe_id(&mut self, id: u64) {
         self.maybe_id = Some(id);
     }
 
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
     pub fn entity_hash(&self) -> Option<AddressableEntityHash> {
         self.entity_hash
     }
 
-    #[wasm_bindgen(setter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(setter))]
     pub fn set_entity_hash(&mut self, entity_hash: AddressableEntityHash) {
         self.entity_hash = Some(entity_hash);
     }
 
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
     pub fn entity_alias(&self) -> Option<String> {
         self.entity_alias.clone()
     }
 
-    #[wasm_bindgen(setter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(setter))]
     pub fn set_entity_alias(&mut self, entity_alias: &str) {
         self.entity_alias = Some(entity_alias.to_string());
     }
 
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
     pub fn entry_point(&self) -> Option<String> {
         self.entry_point.clone()
     }
 
-    #[wasm_bindgen(setter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(setter))]
     pub fn set_entry_point(&mut self, entry_point: &str) {
         self.entry_point = Some(entry_point.to_string());
     }
 
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
     pub fn package_hash(&self) -> Option<PackageHash> {
         self.package_hash
     }
 
-    #[wasm_bindgen(setter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(setter))]
     pub fn set_package_hash(&mut self, package_hash: PackageHash) {
         self.package_hash = Some(package_hash);
     }
 
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
     pub fn package_alias(&self) -> Option<String> {
         self.package_alias.clone()
     }
 
-    #[wasm_bindgen(setter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(setter))]
     pub fn set_package_alias(&mut self, package_alias: &str) {
         self.package_alias = Some(package_alias.to_string());
     }
 
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
     pub fn public_key(&self) -> Option<PublicKey> {
         self.public_key.clone()
     }
 
-    #[wasm_bindgen(setter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(setter))]
     pub fn set_public_key(&mut self, public_key: PublicKey) {
         self.public_key = Some(public_key);
     }
 
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
     pub fn delegation_rate(&self) -> Option<u8> {
         self.delegation_rate
     }
 
-    #[wasm_bindgen(setter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(setter))]
     pub fn set_delegation_rate(&mut self, delegation_rate: u8) {
         self.delegation_rate = Some(delegation_rate);
     }
 
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
     pub fn delegator(&self) -> Option<PublicKey> {
         self.delegator.clone()
     }
 
-    #[wasm_bindgen(setter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(setter))]
     pub fn set_delegator(&mut self, delegator: PublicKey) {
         self.delegator = Some(delegator);
     }
 
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
     pub fn validator(&self) -> Option<PublicKey> {
         self.validator.clone()
     }
 
-    #[wasm_bindgen(setter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(setter))]
     pub fn set_validator(&mut self, validator: PublicKey) {
         self.validator = Some(validator);
     }
 
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
     pub fn new_validator(&self) -> Option<PublicKey> {
         self.new_validator.clone()
     }
 
-    #[wasm_bindgen(setter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(setter))]
     pub fn set_new_validator(&mut self, new_validator: PublicKey) {
         self.new_validator = Some(new_validator);
     }
 
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
     pub fn minimum_delegation_amount(&self) -> Option<u64> {
         self.minimum_delegation_amount.unwrap_or(None)
     }
 
-    #[wasm_bindgen(setter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(setter))]
     pub fn set_minimum_delegation_amount(&mut self, minimum_delegation_amount: Option<u64>) {
         self.minimum_delegation_amount = Some(minimum_delegation_amount);
     }
 
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
     pub fn maximum_delegation_amount(&self) -> Option<u64> {
         self.maximum_delegation_amount.unwrap_or(None)
     }
 
-    #[wasm_bindgen(setter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(setter))]
     pub fn set_maximum_delegation_amount(&mut self, maximum_delegation_amount: Option<u64>) {
         self.maximum_delegation_amount = Some(maximum_delegation_amount);
     }
 
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
     pub fn is_install_upgrade(&self) -> Option<bool> {
         self.is_install_upgrade
     }
 
-    #[wasm_bindgen(setter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(setter))]
     pub fn set_is_install_upgrade(&mut self, is_install_upgrade: bool) {
         self.is_install_upgrade = Some(is_install_upgrade);
     }
 
     /// True when runtime resolves to VmCasperV1.
-    #[wasm_bindgen(getter, js_name = "isRuntimeV1")]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter, js_name = "isRuntimeV1"))]
     pub fn is_runtime_v1(&self) -> bool {
         matches!(
             self.resolved_runtime(),
@@ -694,7 +695,7 @@ impl TransactionBuilderParams {
     }
 
     /// True when runtime resolves to VmCasperV2.
-    #[wasm_bindgen(getter, js_name = "isRuntimeV2")]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter, js_name = "isRuntimeV2"))]
     pub fn is_runtime_v2(&self) -> bool {
         matches!(
             self.resolved_runtime(),
@@ -703,7 +704,10 @@ impl TransactionBuilderParams {
     }
 
     /// V2 `transferred_value`, or 0 for V1.
-    #[wasm_bindgen(getter, js_name = "runtimeTransferredValue")]
+    #[cfg_attr(
+        feature = "js",
+        wasm_bindgen(getter, js_name = "runtimeTransferredValue")
+    )]
     pub fn runtime_transferred_value(&self) -> u64 {
         match self.resolved_runtime() {
             TransactionRuntimeParams::VmCasperV2 {
@@ -714,7 +718,7 @@ impl TransactionBuilderParams {
     }
 
     /// V2 installer seed bytes, if set.
-    #[wasm_bindgen(getter, js_name = "runtimeSeed")]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter, js_name = "runtimeSeed"))]
     pub fn runtime_seed(&self) -> Option<Vec<u8>> {
         match self.resolved_runtime() {
             TransactionRuntimeParams::VmCasperV2 {
@@ -725,13 +729,13 @@ impl TransactionBuilderParams {
     }
 
     /// Force VmCasperV1 (legacy).
-    #[wasm_bindgen(js_name = "setRuntimeV1")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "setRuntimeV1"))]
     pub fn set_runtime_v1(&mut self) {
         self.runtime = Some(TransactionRuntimeParams::VmCasperV1);
     }
 
     /// Set VmCasperV2. `seed` must be absent or exactly 32 bytes (invalid length is ignored).
-    #[wasm_bindgen(js_name = "setRuntimeV2")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "setRuntimeV2"))]
     pub fn set_runtime_v2(&mut self, transferred_value: u64, seed: Option<Vec<u8>>) {
         self.runtime = Some(runtime_v2(transferred_value, seed));
     }

--- a/src/types/transaction_params/transaction_str_params.rs
+++ b/src/types/transaction_params/transaction_str_params.rs
@@ -7,9 +7,10 @@ use crate::types::pricing_mode::PricingMode;
 use crate::types::runtime_args::RuntimeArgs;
 use casper_client::cli::TransactionStrParams as _TransactionStrParams;
 use once_cell::sync::OnceCell;
+#[cfg(feature = "js")]
 use wasm_bindgen::prelude::*;
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 #[derive(Debug, Clone, Default)]
 pub struct TransactionStrParams {
     secret_key: OnceCell<String>,
@@ -38,9 +39,9 @@ const DEFAULT_ADDITIONAL_COMPUTATION_FACTOR: u8 = 0;
 const DEFAULT_STANDARD_PAYMENT: bool = true;
 
 #[allow(clippy::too_many_arguments)]
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl TransactionStrParams {
-    #[wasm_bindgen(constructor)]
+    #[cfg_attr(feature = "js", wasm_bindgen(constructor))]
     pub fn new(
         chain_name: &str,
         initiator_addr: Option<String>,
@@ -114,7 +115,7 @@ impl TransactionStrParams {
         transaction_params
     }
 
-    #[wasm_bindgen]
+    #[cfg_attr(feature = "js", wasm_bindgen)]
     pub fn new_with_defaults(
         chain_name: &str,
         initiator_addr: Option<String>,
@@ -143,23 +144,23 @@ impl TransactionStrParams {
     }
 
     // Getter and setter for secret_key field
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
     pub fn secret_key(&self) -> Option<String> {
         self.secret_key.get().cloned()
     }
 
-    #[wasm_bindgen(setter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(setter))]
     pub fn set_secret_key(&self, secret_key: &str) {
         self.secret_key.set(secret_key.to_string()).unwrap();
     }
 
     // Getter and setter for timestamp field
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
     pub fn timestamp(&self) -> Option<String> {
         self.timestamp.get().cloned()
     }
 
-    #[wasm_bindgen(setter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(setter))]
     pub fn set_timestamp(&self, timestamp: Option<String>) {
         if let Some(mut timestamp) = timestamp {
             if timestamp.is_empty() {
@@ -172,19 +173,19 @@ impl TransactionStrParams {
         };
     }
 
-    #[wasm_bindgen(js_name = "setDefaultTimestamp")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "setDefaultTimestamp"))]
     pub fn set_default_timestamp(&self) {
         let current_timestamp = get_current_timestamp(None);
         self.timestamp.set(current_timestamp).unwrap();
     }
 
     // Getter and setter for ttl field
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
     pub fn ttl(&self) -> Option<String> {
         self.ttl.get().cloned()
     }
 
-    #[wasm_bindgen(setter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(setter))]
     pub fn set_ttl(&self, ttl: Option<String>) {
         if let Some(mut ttl) = ttl {
             if ttl.is_empty() {
@@ -197,52 +198,52 @@ impl TransactionStrParams {
         };
     }
 
-    #[wasm_bindgen(js_name = "setDefaultTTL")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "setDefaultTTL"))]
     pub fn set_default_ttl(&self) {
         let ttl = get_ttl_or_default(None);
         self.ttl.set(ttl).unwrap();
     }
 
     // Getter and setter for chain_name field
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
     pub fn chain_name(&self) -> Option<String> {
         self.chain_name.get().cloned()
     }
 
-    #[wasm_bindgen(setter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(setter))]
     pub fn set_chain_name(&self, chain_name: &str) {
         self.chain_name.set(chain_name.to_string()).unwrap();
     }
 
     // Getter and setter for initiator_addr field
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
     pub fn initiator_addr(&self) -> Option<String> {
         self.initiator_addr.get().cloned()
     }
 
-    #[wasm_bindgen(setter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(setter))]
     pub fn set_initiator_addr(&self, initiator_addr: &str) {
         self.initiator_addr.set(initiator_addr.to_string()).unwrap();
     }
 
     // Getter and setter for session_args_simple field
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
     pub fn session_args_simple(&self) -> Option<ArgsSimple> {
         self.session_args_simple.get().cloned()
     }
 
-    #[wasm_bindgen(setter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(setter))]
     pub fn set_session_args_simple(&mut self, session_args_simple: Vec<String>) {
         let args_simple = ArgsSimple::from(session_args_simple);
         self.session_args_simple.set(args_simple).unwrap();
     }
 
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
     pub fn session_args_json(&self) -> Option<String> {
         self.session_args_json.get().cloned()
     }
 
-    #[wasm_bindgen(setter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(setter))]
     pub fn set_session_args_json(&self, session_args_json: &str) {
         self.session_args_json
             .set(session_args_json.to_string())
@@ -257,106 +258,106 @@ impl TransactionStrParams {
         self.set_session_args_json(&json);
     }
 
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
     pub fn pricing_mode(&self) -> Option<PricingMode> {
         self.pricing_mode.get().cloned()
     }
 
-    #[wasm_bindgen(setter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(setter))]
     pub fn set_pricing_mode(&self, pricing_mode: PricingMode) {
         self.pricing_mode.set(pricing_mode).unwrap();
     }
 
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
     pub fn additional_computation_factor(&self) -> Option<String> {
         self.additional_computation_factor.get().cloned()
     }
 
-    #[wasm_bindgen(setter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(setter))]
     pub fn set_additional_computation_factor(&self, additional_computation_factor: &str) {
         self.additional_computation_factor
             .set(additional_computation_factor.to_string())
             .unwrap();
     }
 
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
     pub fn payment_amount(&self) -> Option<String> {
         self.payment_amount.get().cloned()
     }
 
-    #[wasm_bindgen(setter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(setter))]
     pub fn set_payment_amount(&self, payment_amount: &str) {
         self.payment_amount.set(payment_amount.to_string()).unwrap();
     }
 
     // Getter and setter for gas_price_tolerance field
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
     pub fn gas_price_tolerance(&self) -> Option<String> {
         self.gas_price_tolerance.get().cloned()
     }
 
-    #[wasm_bindgen(setter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(setter))]
     pub fn set_gas_price_tolerance(&self, gas_price_tolerance: &str) {
         self.gas_price_tolerance
             .set(gas_price_tolerance.to_string())
             .unwrap();
     }
 
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
     pub fn receipt(&self) -> Option<String> {
         self.receipt.get().cloned()
     }
 
-    #[wasm_bindgen(setter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(setter))]
     pub fn set_receipt(&self, receipt: &str) {
         self.receipt.set(receipt.to_string()).unwrap();
     }
 
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
     pub fn standard_payment(&self) -> Option<bool> {
         self.standard_payment.get().cloned()
     }
 
-    #[wasm_bindgen(setter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(setter))]
     pub fn set_standard_payment(&self, standard_payment: bool) {
         self.standard_payment.set(standard_payment).unwrap();
     }
 
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
     pub fn transferred_value(&self) -> Option<String> {
         self.transferred_value.get().cloned()
     }
 
-    #[wasm_bindgen(setter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(setter))]
     pub fn set_transferred_value(&self, transferred_value: &str) {
         self.transferred_value
             .set(transferred_value.to_string())
             .unwrap();
     }
 
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
     pub fn session_entry_point(&self) -> Option<String> {
         self.session_entry_point.get().cloned()
     }
 
-    #[wasm_bindgen(setter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(setter))]
     pub fn set_session_entry_point(&self, session_entry_point: &str) {
         self.session_entry_point
             .set(session_entry_point.to_string())
             .unwrap();
     }
 
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(getter))]
     pub fn chunked_args(&self) -> Option<Bytes> {
         self.chunked_args.get().cloned()
     }
 
-    #[wasm_bindgen(setter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(setter))]
     pub fn set_chunked_args(&self, chunked_args: Bytes) {
         self.chunked_args.set(chunked_args).unwrap();
     }
 
-    #[wasm_bindgen(setter)]
+    #[cfg_attr(feature = "js", wasm_bindgen(setter))]
     pub fn set_min_bid_override(&self, min_bid_override: bool) {
         self.min_bid_override.set(min_bid_override).unwrap();
     }

--- a/src/types/transfer.rs
+++ b/src/types/transfer.rs
@@ -1,13 +1,14 @@
 use crate::types::{hash::account_hash::AccountHash, uref::URef};
 use casper_types::TransferV1 as _TransferV1;
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use gloo_utils::format::JsValueSerdeExt;
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "js")]
 use wasm_bindgen::prelude::*;
 
 /// Wasm/native wrapper around [`casper_types::TransferV1`] (`StoredValue::Transfer`).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 pub struct Transfer(_TransferV1);
 
 impl Transfer {
@@ -48,50 +49,50 @@ impl Transfer {
     }
 }
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl Transfer {
-    #[wasm_bindgen(js_name = "deployHash")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "deployHash"))]
     pub fn deploy_hash_js(&self) -> String {
         self.deploy_hash()
     }
 
-    #[wasm_bindgen(js_name = "fromAccount")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "fromAccount"))]
     pub fn from_account_js(&self) -> AccountHash {
         self.from_account()
     }
 
-    #[wasm_bindgen(js_name = "to")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "to"))]
     pub fn to_js(&self) -> Option<AccountHash> {
         self.to()
     }
 
-    #[wasm_bindgen(js_name = "source")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "source"))]
     pub fn source_js(&self) -> URef {
         self.source()
     }
 
-    #[wasm_bindgen(js_name = "target")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "target"))]
     pub fn target_js(&self) -> URef {
         self.target()
     }
 
-    #[wasm_bindgen(js_name = "amount")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "amount"))]
     pub fn amount_js(&self) -> String {
         self.amount()
     }
 
-    #[wasm_bindgen(js_name = "gas")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "gas"))]
     pub fn gas_js(&self) -> String {
         self.gas()
     }
 
-    #[wasm_bindgen(js_name = "id")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "id"))]
     pub fn id_js(&self) -> Option<u64> {
         self.id()
     }
 
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(js_name = "toJson")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "toJson"))]
     pub fn to_json(&self) -> JsValue {
         JsValue::from_serde(&self.0).unwrap_or(JsValue::null())
     }

--- a/src/types/uref.rs
+++ b/src/types/uref.rs
@@ -1,12 +1,13 @@
 use crate::types::{access_rights::AccessRights, addr::uref_addr::URefAddr, sdk_error::SdkError};
 use casper_types::URef as _URef;
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "js", target_arch = "wasm32"))]
 use gloo_utils::format::JsValueSerdeExt;
 use serde::{Deserialize, Serialize};
 use std::ops::Deref;
+#[cfg(feature = "js")]
 use wasm_bindgen::prelude::*;
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 #[derive(Debug, Deserialize, Clone, Serialize, Ord, PartialOrd, Eq, PartialEq)]
 pub struct URef(_URef);
 
@@ -27,7 +28,9 @@ impl URef {
 
         let uref = _URef::new(
             uref_addr.into(),
-            AccessRights::new(access_rights).unwrap_or_default().into(),
+            AccessRights::try_from_u8(access_rights)
+                .unwrap_or_default()
+                .into(),
         );
 
         Ok(URef(uref))
@@ -44,17 +47,17 @@ impl URef {
     }
 }
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl URef {
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(constructor)]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(constructor))]
     pub fn new_js_alias(uref_hex_str: &str, access_rights: u8) -> Result<URef, JsError> {
         Self::new(uref_hex_str, access_rights)
             .map_err(|err| JsError::new(&format!("Failed to parse URef from hex string: {err:?}")))
     }
 
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(js_name = "fromFormattedStr")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "fromFormattedStr"))]
     pub fn from_formatted_str_js_alias(formatted_str: &str) -> Result<URef, JsError> {
         Self::from_formatted_str(formatted_str).map_err(|err| {
             JsError::new(&format!(
@@ -63,24 +66,26 @@ impl URef {
         })
     }
 
-    #[wasm_bindgen(js_name = "fromUint8Array")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "fromUint8Array"))]
     pub fn from_bytes(bytes: Vec<u8>, access_rights: u8) -> Self {
         let mut address_array = [0u8; 32];
         address_array[..bytes.len()].copy_from_slice(&bytes);
 
         URef(_URef::new(
             address_array,
-            AccessRights::new(access_rights).unwrap_or_default().into(),
+            AccessRights::try_from_u8(access_rights)
+                .unwrap_or_default()
+                .into(),
         ))
     }
 
-    #[wasm_bindgen(js_name = "toFormattedString")]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "toFormattedString"))]
     pub fn to_formatted_string(&self) -> String {
         self.0.to_formatted_string()
     }
 
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen(js_name = "toJson")]
+    #[cfg(all(feature = "js", target_arch = "wasm32"))]
+    #[cfg_attr(feature = "js", wasm_bindgen(js_name = "toJson"))]
     pub fn to_json(&self) -> JsValue {
         JsValue::from_serde(self).unwrap_or(JsValue::null())
     }

--- a/src/types/verbosity.rs
+++ b/src/types/verbosity.rs
@@ -1,9 +1,10 @@
 use casper_client::Verbosity as _Verbosity;
 use serde::{Deserialize, Deserializer, Serialize};
+#[cfg(feature = "js")]
 use wasm_bindgen::prelude::*;
 
 #[derive(Debug, Serialize, Clone, Copy, PartialEq)]
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 pub enum Verbosity {
     Low = 0,
     Medium = 1,

--- a/src/types/wallet/signature_response.rs
+++ b/src/types/wallet/signature_response.rs
@@ -1,8 +1,9 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+#[cfg(feature = "js")]
 use wasm_bindgen::prelude::*;
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 #[derive(Debug, Deserialize, Serialize)]
 pub struct SignatureResponse {
     cancelled: bool,
@@ -11,7 +12,7 @@ pub struct SignatureResponse {
     signature: Option<HashMap<String, u8>>,
 }
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 impl SignatureResponse {
     pub fn is_cancelled(&self) -> bool {
         self.cancelled


### PR DESCRIPTION
## Summary
- Add Cargo feature `js` (default on with `full`) so wasm-bindgen / js-sys / gloo-utils and all `#[wasm_bindgen]` exports are optional.
- Rust-only consumers (`default-features = false` without `js`: ceps, MCP, atatui, python, Tauri) link the Rust API only; foreign wasm packs no longer inherit SDK class exports.
- Makefile pack lanes and CI/clippy matrix cover `js` on and off (including ceps-shaped wasm32); docs feature table updated.

Closes #136

## Test plan
- [x] `make check-lint` (stable)
- [x] `cargo check` default + ceps-shaped features (native + wasm32)
- [x] mcp / casperatatui / ceps-client check
- [x] ceps `make nodejs`: `.d.ts` has Cep* only; no `SDK` / `Key` / `Transaction` bleed; wasm ~2.3MB
- [x] CI green on this PR
