### PR TITLE
feat(casperatatui): optional ceps-client Actions for CEP info/query/install

### DIFF
--- a/.github/workflows/ci-casperatatui.yml
+++ b/.github/workflows/ci-casperatatui.yml
@@ -1,4 +1,6 @@
 # Path-filtered Casperatatui gate. Opt-in package (not default-members / Hub).
+# Checkout layout: sibling ceps-rust-ts-client next to rustSDK so optional path-dep
+# in Cargo.toml resolves (Cargo requires the path even when feature `ceps` is off).
 name: ci-casperatatui
 
 on:
@@ -14,6 +16,10 @@ on:
       - ".github/workflows/ci-casperatatui.yml"
   workflow_dispatch:
 
+defaults:
+  run:
+    working-directory: rustSDK
+
 jobs:
   casperatatui:
     name: Lint test smoke Casperatatui
@@ -21,14 +27,25 @@ jobs:
 
     steps:
       - name: Install dependencies
+        working-directory: ${{ github.workspace }}
         run: |
           sudo apt-get update
           sudo apt-get install -y pkg-config libssl-dev
 
       - uses: actions/checkout@v5
+        with:
+          path: rustSDK
+
+      - name: Checkout sibling ceps-rust-ts-client
+        uses: actions/checkout@v5
+        with:
+          repository: Interchouette-ITC/ceps-rust-ts-client
+          path: ceps-rust-ts-client
 
       - name: Swatinem cache
         uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: rustSDK
 
       - uses: dtolnay/rust-toolchain@stable
         with:

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -13,6 +13,12 @@ on:
       - "**.md"
       - "examples/desktop/casperatatui/**"
 
+# Workspace member casperatatui optional-deps sibling ceps-client; Cargo needs the
+# path present even when feature `ceps` is off. Layout matches local sibling checkouts.
+defaults:
+  run:
+    working-directory: rustSDK
+
 jobs:
   build_and_test:
     strategy:
@@ -23,14 +29,25 @@ jobs:
 
     steps:
       - name: Install dependencies
+        working-directory: ${{ github.workspace }}
         run: |
           sudo apt-get update
           sudo apt-get install -y pkg-config libssl-dev
 
       - uses: actions/checkout@v5
+        with:
+          path: rustSDK
+
+      - name: Checkout sibling ceps-rust-ts-client
+        uses: actions/checkout@v5
+        with:
+          repository: Interchouette-ITC/ceps-rust-ts-client
+          path: ceps-rust-ts-client
 
       - name: Swatinem cache
         uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: rustSDK
 
       - uses: dtolnay/rust-toolchain@stable
         with:

--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -6,6 +6,10 @@ on:
     - cron: "0 0 * * *"
   workflow_dispatch:
 
+defaults:
+  run:
+    working-directory: rustSDK
+
 jobs:
   nightly-make-test:
     strategy:
@@ -16,13 +20,23 @@ jobs:
 
     steps:
       - name: Install dependencies
+        working-directory: ${{ github.workspace }}
         run: |
           sudo apt-get update
           sudo apt-get install -y pkg-config libssl-dev
 
       - uses: actions/checkout@v5
+        with:
+          path: rustSDK
+
+      - name: Checkout sibling ceps-rust-ts-client
+        uses: actions/checkout@v5
+        with:
+          repository: Interchouette-ITC/ceps-rust-ts-client
+          path: ceps-rust-ts-client
 
       - name: Free up disk space
+        working-directory: ${{ github.workspace }}
         run: |
           sudo rm -rf /usr/share/dotnet
           sudo rm -rf /usr/local/lib/android
@@ -34,6 +48,8 @@ jobs:
 
       - name: Swatinem cache
         uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: rustSDK
 
       - uses: dtolnay/rust-toolchain@stable
         with:

--- a/.github/workflows/release-github-assets.yml
+++ b/.github/workflows/release-github-assets.yml
@@ -22,13 +22,25 @@ jobs:
     name: Build and upload desktop + MCP + Casperatatui assets
     runs-on: ubuntu-latest
 
+    defaults:
+      run:
+        working-directory: rustSDK
+
     steps:
       - name: Checkout
         uses: actions/checkout@v5
         with:
           ref: ${{ inputs.ref }}
+          path: rustSDK
+
+      - name: Checkout sibling ceps-rust-ts-client
+        uses: actions/checkout@v5
+        with:
+          repository: Interchouette-ITC/ceps-rust-ts-client
+          path: ceps-rust-ts-client
 
       - name: Install system dependencies
+        working-directory: ${{ github.workspace }}
         run: |
           sudo apt-get update
           sudo apt-get install -y pkg-config libssl-dev fuse libfuse2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -860,6 +860,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "casper-rust-wasm-sdk",
+ "ceps-client",
  "clap",
  "crossterm",
  "ctrlc",
@@ -886,6 +887,22 @@ checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
 dependencies = [
  "find-msvc-tools",
  "shlex",
+]
+
+[[package]]
+name = "ceps-client"
+version = "1.0.0"
+dependencies = [
+ "base64 0.22.1",
+ "blake2 0.10.6",
+ "casper-rust-wasm-sdk",
+ "casper-types",
+ "hex",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.19",
+ "url",
 ]
 
 [[package]]

--- a/Makefile
+++ b/Makefile
@@ -214,6 +214,11 @@ run-casperatatui:
 	env -u CARGO_TARGET_DIR -u PLAYWRIGHT_BROWSERS_PATH \
 		cargo run -p casperatatui -- --preset nctl $(CASPERATATUI_ARGS) $(TUI_ARGS)
 
+# Needs sibling checkout ../../ceps-rust-ts-client (from repo root).
+run-casperatatui-ceps:
+	env -u CARGO_TARGET_DIR -u PLAYWRIGHT_BROWSERS_PATH \
+		cargo run -p casperatatui --features ceps -- --preset nctl $(CASPERATATUI_ARGS) $(TUI_ARGS)
+
 build-casperatatui-release:
 	env -u CARGO_TARGET_DIR -u PLAYWRIGHT_BROWSERS_PATH \
 		cargo build -p casperatatui --release
@@ -227,11 +232,12 @@ check-lint-casperatatui:
 
 # Short aliases (same recipes).
 run-tui: run-casperatatui
+run-tui-ceps: run-casperatatui-ceps
 build-tui-release: build-casperatatui-release
 check-lint-tui: check-lint-casperatatui
 
-.PHONY: run-casperatatui build-casperatatui-release check-lint-casperatatui \
-	run-tui build-tui-release check-lint-tui
+.PHONY: run-casperatatui run-casperatatui-ceps build-casperatatui-release check-lint-casperatatui \
+	run-tui run-tui-ceps build-tui-release check-lint-tui
 
 # --- Signing desk (examples/desktop/tauri) ---
 

--- a/docker/Dockerfile.cicd
+++ b/docker/Dockerfile.cicd
@@ -13,16 +13,18 @@ RUN apt-get update \
     binutils \
   && rm -rf /var/lib/apt/lists/*
 
-WORKDIR /src
-# Workspace members: ., mcp, casperatatui, tauri/src-tauri (+ sdk_tests path-dep).
-# Do not COPY python/.
-COPY Cargo.toml Cargo.lock ./
-COPY src ./src
-COPY mcp ./mcp
-COPY examples/desktop/casperatatui ./examples/desktop/casperatatui
-COPY examples/desktop/tauri/src-tauri ./examples/desktop/tauri/src-tauri
-COPY tests/integration/rust ./tests/integration/rust
+# Sibling layout: casperatatui optional-deps ceps-client (path must exist for Cargo).
+WORKDIR /work
+COPY Cargo.toml Cargo.lock ./rustSDK/
+COPY src ./rustSDK/src
+COPY mcp ./rustSDK/mcp
+COPY examples/desktop/casperatatui ./rustSDK/examples/desktop/casperatatui
+COPY examples/desktop/tauri/src-tauri ./rustSDK/examples/desktop/tauri/src-tauri
+COPY tests/integration/rust ./rustSDK/tests/integration/rust
+RUN git clone --depth 1 https://github.com/Interchouette-ITC/ceps-rust-ts-client.git \
+  /work/ceps-rust-ts-client
 
+WORKDIR /work/rustSDK
 RUN cargo build -p casper-rust-wasm-sdk-mcp --release \
   && strip -s target/release/casper-rust-wasm-sdk-mcp \
   && cp target/release/casper-rust-wasm-sdk-mcp /casper-rust-wasm-sdk-mcp

--- a/examples/desktop/casperatatui/COVERAGE.md
+++ b/examples/desktop/casperatatui/COVERAGE.md
@@ -10,7 +10,7 @@ Screen to SDK / MCP symbols used by Casperatatui today.
 | Accounts     | `4`, `/`, `w`                  | `get_entity` (fallback `get_account` when AE off), `query_balance`, `query_balance_details`, `get_auction_info`, `get_reward` | -                                                                                                     |
 | Validators   | `5`, `r`, `/`, `w`, Tab, Enter | `get_auction_info`, `get_reward`; `auction_view::{list_validators,list_bidders,get_validator}`                                | `sdk_list_validators`, `sdk_get_validator`, `sdk_list_bidders`                                        |
 | Contracts    | `6`, `/`                       | `query_global_state`, `query_contract_key`, `query_contract_dict`                                                             | -                                                                                                     |
-| Actions      | `7`                            | Catalog of RPC + helpers; write subset when `--enable-writes` + PEM                                                           | -                                                                                                     |
+| Actions      | `7`                            | Catalog of RPC + helpers; write subset when `--enable-writes` + PEM; with `--features ceps`: CEP info/query/install via `ceps-client` (SDK `js` off) | -                                                                                                     |
 | Writes       | `8`, `o`/`x`, `b`/`s`/`p`/`t`  | `make_transfer_transaction`, `make_transaction` (stake), `sign_transaction`, `put_transaction`, `transfer_transaction`        | `sdk_make_delegate_transaction`, `sdk_make_undelegate_transaction`, `sdk_make_redelegate_transaction` |
 | Wait         | `9`, `/`, `w`, Space           | `wait_transaction`, `SSEClient::collect`                                                                                      | `sdk_wait_transaction`, `sdk_SSE_collect`                                                             |
 | Help         | `h`                            | -                                                                                                                             | -                                                                                                     |
@@ -20,6 +20,7 @@ Screen to SDK / MCP symbols used by Casperatatui today.
 - Gate: `--enable-writes` (no PEM UI / Sign / Put when off)
 - Session PEM: `--secret-key` and/or in-app `o`; unload with `x`
 - Put fail-closed via `policy.rs` + `--policy-path` (sample: `policy.sample.json`)
+- CEP installs (`cep18_install`, `cep78_install`, `cep85_install`, `cep95_install`) use the same Put gate and explicit `allowed_ops` names
 
 ## Smoke
 
@@ -27,4 +28,8 @@ Screen to SDK / MCP symbols used by Casperatatui today.
 cargo run -p casperatatui --example smoke_status
 # optional write+wait (needs PEM path in env, never commit keys):
 # CASPER_SECRET_KEY=/path/to/secret_key.pem cargo run -p casperatatui --example smoke_write_wait
+# CEP (sibling ceps-rust-ts-client + --features ceps):
+# cargo run -p casperatatui --features ceps --example smoke_ceps_query
+# CASPER_SECRET_KEY=… CEPS_CEP18_WASM=…/cep18.wasm \
+#   cargo run -p casperatatui --features ceps --example smoke_ceps_install
 ```

--- a/examples/desktop/casperatatui/Cargo.toml
+++ b/examples/desktop/casperatatui/Cargo.toml
@@ -16,6 +16,12 @@ path = "src/main.rs"
 name = "casperatatui"
 path = "src/lib.rs"
 
+[features]
+default = []
+# Sibling path-dep: ../../../../ceps-rust-ts-client/ceps-client (from this crate).
+# Does not enable SDK feature `js`.
+ceps = ["dep:ceps-client"]
+
 [dependencies]
 anyhow = "1"
 casper-rust-wasm-sdk = { path = "../../..", default-features = false, features = [
@@ -25,6 +31,7 @@ casper-rust-wasm-sdk = { path = "../../..", default-features = false, features =
   "watcher",
   "SSE",
 ] }
+ceps-client = { path = "../../../../ceps-rust-ts-client/ceps-client", optional = true }
 clap = { version = "4", features = ["derive", "env"] }
 crossterm = "0.29"
 ctrlc = "3"
@@ -37,5 +44,13 @@ tokio = { version = "1", features = [
   "sync",
   "time",
 ] }
+
+[[example]]
+name = "smoke_ceps_query"
+required-features = ["ceps"]
+
+[[example]]
+name = "smoke_ceps_install"
+required-features = ["ceps"]
 
 # TestBackend ships with ratatui 0.30 (no extra feature).

--- a/examples/desktop/casperatatui/README.md
+++ b/examples/desktop/casperatatui/README.md
@@ -16,6 +16,17 @@ make run-tui
 env -u CARGO_TARGET_DIR cargo run -p casperatatui -- --preset nctl
 ```
 
+CEP Actions (optional sibling `ceps-rust-ts-client`):
+
+```bash
+make run-casperatatui-ceps
+# alias: make run-tui-ceps
+# or
+env -u CARGO_TARGET_DIR cargo run -p casperatatui --features ceps -- --preset nctl
+```
+
+Feature `ceps` path-deps `../../../../ceps-rust-ts-client/ceps-client` (from this crate). Default build stays green without that checkout. SDK feature `js` stays off for both default and `ceps`.
+
 Extra args: `CASPERATATUI_ARGS` or `TUI_ARGS` (e.g. `make run-tui TUI_ARGS='--preset testnet'`).
 
 Presets: `nctl` (default), `testnet`, `mainnet`.
@@ -37,6 +48,11 @@ Non-interactive smoke:
 cargo run -p casperatatui --example smoke_status
 # SSE collect always; put+wait when CASPER_SECRET_KEY is set:
 cargo run -p casperatatui --example smoke_write_wait
+# CEP (needs --features ceps + sibling checkout):
+cargo run -p casperatatui --features ceps --example smoke_ceps_query
+# install needs NCTL + PEM + WASM path (CEPS_CEP18_WASM or wasm_path):
+# CASPER_SECRET_KEY=… CEPS_CEP18_WASM=…/cep18.wasm \
+#   cargo run -p casperatatui --features ceps --example smoke_ceps_install
 ```
 
 ## Release binary
@@ -107,7 +123,7 @@ Requires `--enable-writes`. Load a PEM with `--secret-key` or `o`. Flow: Tab kin
 
 ## Actions (key `7`)
 
-RPC + helpers catalog; write methods appear when writes enabled and PEM loaded.
+RPC + helpers catalog; write methods appear when writes enabled and PEM loaded. With `--features ceps`, a `ceps` group adds CEP-18/78/85/95 info, queries, and installs (sibling `ceps-client`; WASM via action arg or `CEPS_CEP*_WASM` / `CEPS_WASM_PATH`).
 
 ## Command palette (`:`)
 

--- a/examples/desktop/casperatatui/examples/smoke_ceps_install.rs
+++ b/examples/desktop/casperatatui/examples/smoke_ceps_install.rs
@@ -1,0 +1,81 @@
+//! Smoke CEP-18 install (feature `ceps`). Needs NCTL, PEM, and tip WASM.
+
+use anyhow::{bail, Result};
+use casper_rust_wasm_sdk::helpers::public_key_from_secret_key;
+use casper_rust_wasm_sdk::types::verbosity::Verbosity;
+use casperatatui::model::RpcEvent;
+use casperatatui::policy::WritePolicy;
+use casperatatui::sdk_client::{ActionWriteCtx, SdkClient};
+use std::collections::HashMap;
+use std::path::Path;
+use std::time::{SystemTime, UNIX_EPOCH};
+use tokio::sync::mpsc;
+use tokio::time::{timeout, Duration};
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let rpc = std::env::var("CASPER_RPC_URL").unwrap_or_else(|_| "http://127.0.0.1:11101".into());
+    let events = std::env::var("CASPER_EVENTS_URL")
+        .unwrap_or_else(|_| "http://127.0.0.1:18101/events".into());
+    let chain = std::env::var("CASPER_CHAIN_NAME").unwrap_or_else(|_| "casper-net-1".into());
+
+    let pem_path = match std::env::var("CASPER_SECRET_KEY") {
+        Ok(p) if !p.trim().is_empty() => p,
+        _ => {
+            println!("skip install: set CASPER_SECRET_KEY to a PEM path");
+            println!("also set CEPS_CEP18_WASM (or wasm_path) to tip cep18.wasm");
+            return Ok(());
+        }
+    };
+    let pem = std::fs::read_to_string(&pem_path)?.trim().to_string();
+    let public_key = public_key_from_secret_key(&pem).map_err(|e| anyhow::anyhow!(e))?;
+
+    let wasm_path = match std::env::var("CEPS_CEP18_WASM")
+        .or_else(|_| std::env::var("CEPS_WASM_PATH"))
+    {
+        Ok(p) if !p.trim().is_empty() => p.trim().to_string(),
+        _ => {
+            println!("skip install: set CEPS_CEP18_WASM or CEPS_WASM_PATH to cep18.wasm");
+            println!("tip: in ceps-rust-ts-client run `make wasm-from-ceps` then point at tests/wasm/cep18/cep18.wasm");
+            return Ok(());
+        }
+    };
+
+    let policy = WritePolicy::load(Path::new(
+        "examples/desktop/casperatatui/policy.sample.json",
+    ))
+    .or_else(|_| WritePolicy::load(Path::new("policy.sample.json")))
+    .map_err(|e| anyhow::anyhow!(e))?;
+
+    let client = SdkClient::new(rpc, Verbosity::Low);
+    let write = ActionWriteCtx {
+        pem: Some(pem),
+        public_key,
+        chain_name: chain,
+        events_url: events,
+        policy,
+    };
+    let (tx, mut rx) = mpsc::unbounded_channel();
+
+    let nonce = SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs();
+    let mut args = HashMap::new();
+    args.insert("name".into(), format!("TuiCep18{nonce}"));
+    args.insert("symbol".into(), "TUI".into());
+    args.insert("wasm_path".into(), wasm_path);
+
+    println!("cep18_install …");
+    client.spawn_action_with_write("cep18_install", args, write, tx);
+    match timeout(Duration::from_secs(180), rx.recv()).await {
+        Ok(Some(RpcEvent::Action { result: Ok(v), .. })) => {
+            println!("cep18_install OK | {v}");
+            if v.get("transaction_hash").and_then(|h| h.as_str()).is_none() {
+                bail!("missing transaction_hash in result");
+            }
+        }
+        Ok(Some(RpcEvent::Action { result: Err(e), .. })) => bail!("cep18_install failed: {e}"),
+        other => bail!("cep18_install unexpected: {other:?}"),
+    }
+
+    println!("smoke_ceps_install done");
+    Ok(())
+}

--- a/examples/desktop/casperatatui/examples/smoke_ceps_query.rs
+++ b/examples/desktop/casperatatui/examples/smoke_ceps_query.rs
@@ -1,0 +1,71 @@
+//! Smoke CEP info + queries (feature `ceps`). Needs live RPC for queries when contract hashes are set.
+
+use anyhow::{bail, Result};
+use casper_rust_wasm_sdk::types::verbosity::Verbosity;
+use casperatatui::model::RpcEvent;
+use casperatatui::sdk_client::{ActionWriteCtx, SdkClient};
+use std::collections::HashMap;
+use tokio::sync::mpsc;
+use tokio::time::{timeout, Duration};
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let rpc = std::env::var("CASPER_RPC_URL").unwrap_or_else(|_| "http://127.0.0.1:11101".into());
+    let events = std::env::var("CASPER_EVENTS_URL")
+        .unwrap_or_else(|_| "http://127.0.0.1:18101/events".into());
+    let chain = std::env::var("CASPER_CHAIN_NAME").unwrap_or_else(|_| "casper-net-1".into());
+
+    let client = SdkClient::new(rpc, Verbosity::Low);
+    let write = ActionWriteCtx {
+        events_url: events,
+        chain_name: chain,
+        ..ActionWriteCtx::default()
+    };
+    let (tx, mut rx) = mpsc::unbounded_channel();
+
+    for method in ["cep18_info", "cep78_info", "cep85_info", "cep95_info"] {
+        client.spawn_action_with_write(method, HashMap::new(), write.clone(), tx.clone());
+        match timeout(Duration::from_secs(30), rx.recv()).await {
+            Ok(Some(RpcEvent::Action {
+                method: m,
+                result: Ok(v),
+            })) => {
+                println!("{m} OK | {v}");
+            }
+            Ok(Some(RpcEvent::Action {
+                method: m,
+                result: Err(e),
+            })) => bail!("{m} failed: {e}"),
+            other => bail!("{method} unexpected: {other:?}"),
+        }
+    }
+
+    if let Ok(hash) = std::env::var("CEPS_CEP18_CONTRACT_HASH") {
+        let hash = hash.trim().to_string();
+        if !hash.is_empty() {
+            let mut args = HashMap::new();
+            args.insert("contract_hash".into(), hash);
+            if let Ok(pkg) = std::env::var("CEPS_CEP18_PACKAGE_HASH") {
+                let pkg = pkg.trim().to_string();
+                if !pkg.is_empty() {
+                    args.insert("package_hash".into(), pkg);
+                }
+            }
+            client.spawn_action_with_write("cep18_name", args, write.clone(), tx.clone());
+            match timeout(Duration::from_secs(30), rx.recv()).await {
+                Ok(Some(RpcEvent::Action { result: Ok(v), .. })) => {
+                    println!("cep18_name OK | {v}");
+                }
+                Ok(Some(RpcEvent::Action { result: Err(e), .. })) => {
+                    bail!("cep18_name failed: {e}");
+                }
+                other => bail!("cep18_name unexpected: {other:?}"),
+            }
+        }
+    } else {
+        println!("skip cep18_name: set CEPS_CEP18_CONTRACT_HASH to exercise a query");
+    }
+
+    println!("smoke_ceps_query done");
+    Ok(())
+}

--- a/examples/desktop/casperatatui/policy.sample.json
+++ b/examples/desktop/casperatatui/policy.sample.json
@@ -10,6 +10,10 @@
     "install",
     "call_entrypoint",
     "put_transaction",
-    "make_transaction"
+    "make_transaction",
+    "cep18_install",
+    "cep78_install",
+    "cep85_install",
+    "cep95_install"
   ]
 }

--- a/examples/desktop/casperatatui/src/actions_catalog.rs
+++ b/examples/desktop/casperatatui/src/actions_catalog.rs
@@ -4,6 +4,8 @@
 pub enum ActionGroup {
     Rpc,
     Helpers,
+    #[cfg(feature = "ceps")]
+    Ceps,
 }
 
 impl ActionGroup {
@@ -11,6 +13,8 @@ impl ActionGroup {
         match self {
             Self::Rpc => "rpc",
             Self::Helpers => "helpers",
+            #[cfg(feature = "ceps")]
+            Self::Ceps => "ceps",
         }
     }
 }
@@ -61,6 +65,22 @@ const fn write_action(
         args,
         requires_writes: true,
         requires_pem,
+    }
+}
+
+#[cfg(feature = "ceps")]
+const fn ceps_write_action(
+    id: &'static str,
+    blurb: &'static str,
+    args: &'static [ArgSpec],
+) -> ActionSpec {
+    ActionSpec {
+        id,
+        group: ActionGroup::Ceps,
+        blurb,
+        args,
+        requires_writes: true,
+        requires_pem: true,
     }
 }
 
@@ -368,14 +388,407 @@ pub const ACTIONS: &[ActionSpec] = &[
     ),
 ];
 
+#[cfg(feature = "ceps")]
+pub const CEPS_ACTIONS: &[ActionSpec] = &[
+    action(
+        "cep18_info",
+        ActionGroup::Ceps,
+        "CEP-18 client endpoints",
+        &[],
+    ),
+    action(
+        "cep18_name",
+        ActionGroup::Ceps,
+        "CEP-18 token name",
+        &[
+            ArgSpec {
+                name: "contract_hash",
+                hint: "hash-… / entity-…",
+                required: true,
+            },
+            ArgSpec {
+                name: "package_hash",
+                hint: "optional package",
+                required: false,
+            },
+        ],
+    ),
+    action(
+        "cep18_symbol",
+        ActionGroup::Ceps,
+        "CEP-18 token symbol",
+        &[
+            ArgSpec {
+                name: "contract_hash",
+                hint: "hash-… / entity-…",
+                required: true,
+            },
+            ArgSpec {
+                name: "package_hash",
+                hint: "optional package",
+                required: false,
+            },
+        ],
+    ),
+    action(
+        "cep18_decimals",
+        ActionGroup::Ceps,
+        "CEP-18 decimals",
+        &[
+            ArgSpec {
+                name: "contract_hash",
+                hint: "hash-… / entity-…",
+                required: true,
+            },
+            ArgSpec {
+                name: "package_hash",
+                hint: "optional package",
+                required: false,
+            },
+        ],
+    ),
+    action(
+        "cep18_balance_of",
+        ActionGroup::Ceps,
+        "CEP-18 balance_of",
+        &[
+            ArgSpec {
+                name: "contract_hash",
+                hint: "hash-… / entity-…",
+                required: true,
+            },
+            ArgSpec {
+                name: "package_hash",
+                hint: "optional package",
+                required: false,
+            },
+            ArgSpec {
+                name: "account",
+                hint: "account-hash-… / hash-… / entity-…",
+                required: true,
+            },
+        ],
+    ),
+    ceps_write_action(
+        "cep18_install",
+        "install CEP-18 from WASM path",
+        &[
+            ArgSpec {
+                name: "name",
+                hint: "token name",
+                required: true,
+            },
+            ArgSpec {
+                name: "symbol",
+                hint: "default TUI",
+                required: false,
+            },
+            ArgSpec {
+                name: "decimals",
+                hint: "default 9",
+                required: false,
+            },
+            ArgSpec {
+                name: "total_supply",
+                hint: "default 1000",
+                required: false,
+            },
+            ArgSpec {
+                name: "wasm_path",
+                hint: "or CEPS_CEP18_WASM / CEPS_WASM_PATH",
+                required: false,
+            },
+            ArgSpec {
+                name: "payment_amount",
+                hint: "motes (default 400000000000)",
+                required: false,
+            },
+        ],
+    ),
+    action(
+        "cep78_info",
+        ActionGroup::Ceps,
+        "CEP-78 client endpoints",
+        &[],
+    ),
+    action(
+        "cep78_name",
+        ActionGroup::Ceps,
+        "CEP-78 collection_name",
+        &[
+            ArgSpec {
+                name: "contract_hash",
+                hint: "hash-… / entity-…",
+                required: true,
+            },
+            ArgSpec {
+                name: "package_hash",
+                hint: "optional package",
+                required: false,
+            },
+        ],
+    ),
+    action(
+        "cep78_balance",
+        ActionGroup::Ceps,
+        "CEP-78 balance_of",
+        &[
+            ArgSpec {
+                name: "contract_hash",
+                hint: "hash-… / entity-…",
+                required: true,
+            },
+            ArgSpec {
+                name: "package_hash",
+                hint: "optional package",
+                required: false,
+            },
+            ArgSpec {
+                name: "account",
+                hint: "owner key",
+                required: true,
+            },
+        ],
+    ),
+    ceps_write_action(
+        "cep78_install",
+        "install CEP-78 from WASM path",
+        &[
+            ArgSpec {
+                name: "collection_name",
+                hint: "collection name",
+                required: true,
+            },
+            ArgSpec {
+                name: "collection_symbol",
+                hint: "default T78",
+                required: false,
+            },
+            ArgSpec {
+                name: "total_token_supply",
+                hint: "default 50",
+                required: false,
+            },
+            ArgSpec {
+                name: "wasm_path",
+                hint: "or CEPS_CEP78_WASM / CEPS_WASM_PATH",
+                required: false,
+            },
+            ArgSpec {
+                name: "payment_amount",
+                hint: "motes (default 600000000000)",
+                required: false,
+            },
+        ],
+    ),
+    action(
+        "cep85_info",
+        ActionGroup::Ceps,
+        "CEP-85 client endpoints",
+        &[],
+    ),
+    action(
+        "cep85_name",
+        ActionGroup::Ceps,
+        "CEP-85 collection_name",
+        &[
+            ArgSpec {
+                name: "contract_hash",
+                hint: "hash-… / entity-…",
+                required: true,
+            },
+            ArgSpec {
+                name: "package_hash",
+                hint: "optional package",
+                required: false,
+            },
+        ],
+    ),
+    action(
+        "cep85_balance",
+        ActionGroup::Ceps,
+        "CEP-85 balance_of(account, id)",
+        &[
+            ArgSpec {
+                name: "contract_hash",
+                hint: "hash-… / entity-…",
+                required: true,
+            },
+            ArgSpec {
+                name: "package_hash",
+                hint: "optional package",
+                required: false,
+            },
+            ArgSpec {
+                name: "account",
+                hint: "owner key",
+                required: true,
+            },
+            ArgSpec {
+                name: "id",
+                hint: "token id",
+                required: true,
+            },
+        ],
+    ),
+    ceps_write_action(
+        "cep85_install",
+        "install CEP-85 from WASM path",
+        &[
+            ArgSpec {
+                name: "name",
+                hint: "collection name",
+                required: true,
+            },
+            ArgSpec {
+                name: "uri",
+                hint: "metadata URI template",
+                required: false,
+            },
+            ArgSpec {
+                name: "wasm_path",
+                hint: "or CEPS_CEP85_WASM / CEPS_WASM_PATH",
+                required: false,
+            },
+            ArgSpec {
+                name: "payment_amount",
+                hint: "motes (default 550000000000)",
+                required: false,
+            },
+        ],
+    ),
+    action(
+        "cep95_info",
+        ActionGroup::Ceps,
+        "CEP-95 client endpoints",
+        &[],
+    ),
+    action(
+        "cep95_name",
+        ActionGroup::Ceps,
+        "CEP-95 name",
+        &[
+            ArgSpec {
+                name: "contract_hash",
+                hint: "hash-… / entity-…",
+                required: true,
+            },
+            ArgSpec {
+                name: "package_hash",
+                hint: "optional package",
+                required: false,
+            },
+        ],
+    ),
+    action(
+        "cep95_symbol",
+        ActionGroup::Ceps,
+        "CEP-95 symbol",
+        &[
+            ArgSpec {
+                name: "contract_hash",
+                hint: "hash-… / entity-…",
+                required: true,
+            },
+            ArgSpec {
+                name: "package_hash",
+                hint: "optional package",
+                required: false,
+            },
+        ],
+    ),
+    action(
+        "cep95_owner_of",
+        ActionGroup::Ceps,
+        "CEP-95 owner_of(token_id)",
+        &[
+            ArgSpec {
+                name: "contract_hash",
+                hint: "hash-… / entity-…",
+                required: true,
+            },
+            ArgSpec {
+                name: "package_hash",
+                hint: "optional package",
+                required: false,
+            },
+            ArgSpec {
+                name: "token_id",
+                hint: "token id string",
+                required: true,
+            },
+        ],
+    ),
+    action(
+        "cep95_balance",
+        ActionGroup::Ceps,
+        "CEP-95 balance_of",
+        &[
+            ArgSpec {
+                name: "contract_hash",
+                hint: "hash-… / entity-…",
+                required: true,
+            },
+            ArgSpec {
+                name: "package_hash",
+                hint: "optional package",
+                required: false,
+            },
+            ArgSpec {
+                name: "account",
+                hint: "owner key",
+                required: true,
+            },
+        ],
+    ),
+    ceps_write_action(
+        "cep95_install",
+        "install CEP-95 + bind_odra_install",
+        &[
+            ArgSpec {
+                name: "name",
+                hint: "collection name",
+                required: true,
+            },
+            ArgSpec {
+                name: "symbol",
+                hint: "default T95",
+                required: false,
+            },
+            ArgSpec {
+                name: "package_key_name",
+                hint: "account named key for package",
+                required: true,
+            },
+            ArgSpec {
+                name: "wasm_path",
+                hint: "or CEPS_CEP95_WASM / CEPS_WASM_PATH",
+                required: false,
+            },
+            ArgSpec {
+                name: "payment_amount",
+                hint: "motes (default 600000000000)",
+                required: false,
+            },
+        ],
+    ),
+];
+
+#[cfg(not(feature = "ceps"))]
+pub const CEPS_ACTIONS: &[ActionSpec] = &[];
+
+/// All catalog entries (base + optional CEP group).
+pub fn all_actions() -> impl Iterator<Item = &'static ActionSpec> {
+    ACTIONS.iter().chain(CEPS_ACTIONS.iter())
+}
+
 pub fn find_action(id: &str) -> Option<&'static ActionSpec> {
-    ACTIONS.iter().find(|a| a.id == id)
+    all_actions().find(|a| a.id == id)
 }
 
 /// Filter catalog by write gate and loaded PEM.
 pub fn visible_actions(enable_writes: bool, has_pem: bool) -> Vec<&'static ActionSpec> {
-    ACTIONS
-        .iter()
+    all_actions()
         .filter(|a| {
             if a.requires_writes && !enable_writes {
                 return false;

--- a/examples/desktop/casperatatui/src/ceps_actions.rs
+++ b/examples/desktop/casperatatui/src/ceps_actions.rs
@@ -1,0 +1,484 @@
+//! CEP Actions behind feature `ceps` (ceps-client path-dep).
+
+use casper_rust_wasm_sdk::helpers::public_key_from_secret_key;
+use casper_rust_wasm_sdk::types::verbosity::Verbosity;
+use ceps_client::cep18::InstallArgs as Cep18InstallArgs;
+use ceps_client::cep78::InstallArgs as Cep78InstallArgs;
+use ceps_client::cep85::InstallArgs as Cep85InstallArgs;
+use ceps_client::cep95::InstallArgs as Cep95InstallArgs;
+use ceps_client::{
+    CallResult, Cep18Client, Cep78Client, Cep85Client, Cep95Client, DeployParams, EventsMode,
+    EventsMode78,
+};
+use serde_json::{json, Value};
+use std::collections::HashMap;
+use std::fs;
+use std::path::PathBuf;
+
+use crate::policy::WritePolicy;
+
+const DEFAULT_CEP18_PAYMENT: &str = "400000000000";
+const DEFAULT_CEP78_PAYMENT: &str = "600000000000";
+const DEFAULT_CEP85_PAYMENT: &str = "550000000000";
+const DEFAULT_CEP95_PAYMENT: &str = "600000000000";
+
+/// Endpoints + session bits shared by CEP action handlers.
+pub struct CepsCtx<'a> {
+    pub rpc: &'a str,
+    pub events_url: &'a str,
+    pub chain_name: &'a str,
+    pub verbosity: Verbosity,
+    pub pem: Option<&'a str>,
+    pub policy: &'a WritePolicy,
+}
+
+/// Dispatch a `cep*` catalog action.
+pub async fn run_ceps_action(
+    method: &str,
+    args: &HashMap<String, String>,
+    ctx: &CepsCtx<'_>,
+) -> Result<Value, String> {
+    match method {
+        "cep18_info" => {
+            let c = cep18_client(ctx)?;
+            Ok(endpoints_json(
+                "cep18",
+                c.rpc_url(),
+                c.sse_url(),
+                c.chain_name(),
+            ))
+        }
+        "cep18_name" => {
+            let mut c = cep18_client(ctx)?;
+            bind_contract(&mut c, args)?;
+            Ok(json!({ "name": c.name().await.map_err(ceps_err)? }))
+        }
+        "cep18_symbol" => {
+            let mut c = cep18_client(ctx)?;
+            bind_contract(&mut c, args)?;
+            Ok(json!({ "symbol": c.symbol().await.map_err(ceps_err)? }))
+        }
+        "cep18_decimals" => {
+            let mut c = cep18_client(ctx)?;
+            bind_contract(&mut c, args)?;
+            Ok(json!({ "decimals": c.decimals().await.map_err(ceps_err)? }))
+        }
+        "cep18_balance_of" => {
+            let mut c = cep18_client(ctx)?;
+            bind_contract(&mut c, args)?;
+            let account = required(args, "account")?;
+            Ok(json!({
+                "account": account,
+                "balance": c.balance_of(&account).await.map_err(ceps_err)?,
+            }))
+        }
+        "cep18_install" => cep18_install(args, ctx).await,
+
+        "cep78_info" => {
+            let c = cep78_client(ctx)?;
+            Ok(endpoints_json(
+                "cep78",
+                c.rpc_url(),
+                c.sse_url(),
+                c.chain_name(),
+            ))
+        }
+        "cep78_name" => {
+            let mut c = cep78_client(ctx)?;
+            bind_contract78(&mut c, args)?;
+            Ok(json!({ "name": c.collection_name().await.map_err(ceps_err)? }))
+        }
+        "cep78_balance" => {
+            let mut c = cep78_client(ctx)?;
+            bind_contract78(&mut c, args)?;
+            let account = required(args, "account")?;
+            Ok(json!({
+                "account": account,
+                "balance": c.balance_of(&account).await.map_err(ceps_err)?,
+            }))
+        }
+        "cep78_install" => cep78_install(args, ctx).await,
+
+        "cep85_info" => {
+            let c = cep85_client(ctx)?;
+            Ok(endpoints_json(
+                "cep85",
+                c.rpc_url(),
+                c.sse_url(),
+                c.chain_name(),
+            ))
+        }
+        "cep85_name" => {
+            let mut c = cep85_client(ctx)?;
+            bind_contract85(&mut c, args)?;
+            Ok(json!({ "name": c.collection_name().await.map_err(ceps_err)? }))
+        }
+        "cep85_balance" => {
+            let mut c = cep85_client(ctx)?;
+            bind_contract85(&mut c, args)?;
+            let account = required(args, "account")?;
+            let id = required(args, "id")?;
+            Ok(json!({
+                "account": account,
+                "id": id,
+                "balance": c.balance_of(&account, &id).await.map_err(ceps_err)?,
+            }))
+        }
+        "cep85_install" => cep85_install(args, ctx).await,
+
+        "cep95_info" => {
+            let c = cep95_client(ctx)?;
+            Ok(endpoints_json(
+                "cep95",
+                c.rpc_url(),
+                c.sse_url(),
+                c.chain_name(),
+            ))
+        }
+        "cep95_name" => {
+            let mut c = cep95_client(ctx)?;
+            bind_contract95(&mut c, args)?;
+            Ok(json!({ "name": c.name().await.map_err(ceps_err)? }))
+        }
+        "cep95_symbol" => {
+            let mut c = cep95_client(ctx)?;
+            bind_contract95(&mut c, args)?;
+            Ok(json!({ "symbol": c.symbol().await.map_err(ceps_err)? }))
+        }
+        "cep95_owner_of" => {
+            let mut c = cep95_client(ctx)?;
+            bind_contract95(&mut c, args)?;
+            let token_id = required(args, "token_id")?;
+            Ok(json!({
+                "token_id": token_id,
+                "owner": c.owner_of(&token_id).await.map_err(ceps_err)?,
+            }))
+        }
+        "cep95_balance" => {
+            let mut c = cep95_client(ctx)?;
+            bind_contract95(&mut c, args)?;
+            let account = required(args, "account")?;
+            Ok(json!({
+                "account": account,
+                "balance": c.balance_of(&account).await.map_err(ceps_err)?,
+            }))
+        }
+        "cep95_install" => cep95_install(args, ctx).await,
+
+        other => Err(format!("unknown ceps action `{other}`")),
+    }
+}
+
+fn sse_opt(ctx: &CepsCtx<'_>) -> Option<String> {
+    let s = ctx.events_url.trim();
+    if s.is_empty() {
+        None
+    } else {
+        Some(s.to_string())
+    }
+}
+
+fn chain_opt(ctx: &CepsCtx<'_>) -> Option<String> {
+    let s = ctx.chain_name.trim();
+    if s.is_empty() {
+        None
+    } else {
+        Some(s.to_string())
+    }
+}
+
+fn cep18_client(ctx: &CepsCtx<'_>) -> Result<Cep18Client, String> {
+    Cep18Client::new(ctx.rpc, sse_opt(ctx), chain_opt(ctx), Some(ctx.verbosity)).map_err(ceps_err)
+}
+
+fn cep78_client(ctx: &CepsCtx<'_>) -> Result<Cep78Client, String> {
+    Cep78Client::new(ctx.rpc, sse_opt(ctx), chain_opt(ctx), Some(ctx.verbosity)).map_err(ceps_err)
+}
+
+fn cep85_client(ctx: &CepsCtx<'_>) -> Result<Cep85Client, String> {
+    Cep85Client::new(ctx.rpc, sse_opt(ctx), chain_opt(ctx), Some(ctx.verbosity)).map_err(ceps_err)
+}
+
+fn cep95_client(ctx: &CepsCtx<'_>) -> Result<Cep95Client, String> {
+    Cep95Client::new(ctx.rpc, sse_opt(ctx), chain_opt(ctx), Some(ctx.verbosity)).map_err(ceps_err)
+}
+
+fn endpoints_json(cep: &str, rpc: &str, sse: Option<&str>, chain: &str) -> Value {
+    json!({
+        "cep": cep,
+        "rpc_url": rpc,
+        "sse_url": sse,
+        "chain_name": chain,
+    })
+}
+
+fn package_opt(args: &HashMap<String, String>) -> Option<String> {
+    args.get("package_hash")
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
+fn bind_contract(client: &mut Cep18Client, args: &HashMap<String, String>) -> Result<(), String> {
+    let hash = required(args, "contract_hash")?;
+    client
+        .set_contract_hash(&hash, package_opt(args).as_deref())
+        .map_err(ceps_err)
+}
+
+fn bind_contract78(client: &mut Cep78Client, args: &HashMap<String, String>) -> Result<(), String> {
+    let hash = required(args, "contract_hash")?;
+    client
+        .set_contract_hash(&hash, package_opt(args).as_deref())
+        .map_err(ceps_err)
+}
+
+fn bind_contract85(client: &mut Cep85Client, args: &HashMap<String, String>) -> Result<(), String> {
+    let hash = required(args, "contract_hash")?;
+    client
+        .set_contract_hash(&hash, package_opt(args).as_deref())
+        .map_err(ceps_err)
+}
+
+fn bind_contract95(client: &mut Cep95Client, args: &HashMap<String, String>) -> Result<(), String> {
+    let hash = required(args, "contract_hash")?;
+    client
+        .set_contract_hash(&hash, package_opt(args).as_deref())
+        .map_err(ceps_err)
+}
+
+async fn cep18_install(args: &HashMap<String, String>, ctx: &CepsCtx<'_>) -> Result<Value, String> {
+    ctx.policy.check_put_generic("cep18_install")?;
+    let pem = require_pem(ctx)?;
+    let name = required(args, "name")?;
+    let symbol = optional_or(args, "symbol", "TUI");
+    let decimals = parse_u8(&optional_or(args, "decimals", "9"))?;
+    let total_supply = optional_or(args, "total_supply", "1000");
+    let payment = optional_or(args, "payment_amount", DEFAULT_CEP18_PAYMENT);
+    let wasm = read_wasm(args, &["CEPS_CEP18_WASM", "CEPS_WASM_PATH"])?;
+
+    let client = cep18_client(ctx)?;
+    let install_args = Cep18InstallArgs::new(&name, &symbol, decimals, &total_supply)
+        .with_events_mode(EventsMode::Ces)
+        .with_mint_and_burn(true);
+    let deploy = deploy_params(pem, &payment, ctx);
+    let put = client
+        .install(&install_args, &wasm, &deploy)
+        .await
+        .map_err(ceps_err)?;
+
+    let mut out = call_result_json(&put);
+    if let Ok(pk) = public_key_from_secret_key(pem) {
+        let mut client = client;
+        if let Ok(contract) = client
+            .core()
+            .get_account_named_key(&pk, &format!("cep18_contract_hash_{name}"))
+            .await
+        {
+            let package = client
+                .core()
+                .get_account_named_key(&pk, &format!("cep18_contract_package_{name}"))
+                .await
+                .ok();
+            let _ = client.set_contract_hash(&contract, package.as_deref());
+            out["contract_hash"] = json!(contract);
+            if let Some(p) = package {
+                out["package_hash"] = json!(p);
+            }
+        }
+        out["installer"] = json!(pk);
+    }
+    Ok(out)
+}
+
+async fn cep78_install(args: &HashMap<String, String>, ctx: &CepsCtx<'_>) -> Result<Value, String> {
+    ctx.policy.check_put_generic("cep78_install")?;
+    let pem = require_pem(ctx)?;
+    let name = required(args, "collection_name")?;
+    let symbol = optional_or(args, "collection_symbol", "T78");
+    let supply = parse_u64(&optional_or(args, "total_token_supply", "50"))?;
+    let payment = optional_or(args, "payment_amount", DEFAULT_CEP78_PAYMENT);
+    let wasm = read_wasm(args, &["CEPS_CEP78_WASM", "CEPS_WASM_PATH"])?;
+
+    let client = cep78_client(ctx)?;
+    let install_args =
+        Cep78InstallArgs::new(&name, &symbol, supply).with_events_mode(EventsMode78::Ces);
+    let deploy = deploy_params(pem, &payment, ctx);
+    let put = client
+        .install(&install_args, &wasm, &deploy)
+        .await
+        .map_err(ceps_err)?;
+
+    let mut out = call_result_json(&put);
+    if let Ok(pk) = public_key_from_secret_key(pem) {
+        let mut client = client;
+        if let Ok(contract) = client
+            .core()
+            .get_account_named_key(&pk, &format!("cep78_contract_hash_{name}"))
+            .await
+        {
+            let package = client
+                .core()
+                .get_account_named_key(&pk, &format!("cep78_contract_package_{name}"))
+                .await
+                .ok();
+            let _ = client.set_contract_hash(&contract, package.as_deref());
+            out["contract_hash"] = json!(contract);
+            if let Some(p) = package {
+                out["package_hash"] = json!(p);
+            }
+        }
+        out["installer"] = json!(pk);
+    }
+    Ok(out)
+}
+
+async fn cep85_install(args: &HashMap<String, String>, ctx: &CepsCtx<'_>) -> Result<Value, String> {
+    ctx.policy.check_put_generic("cep85_install")?;
+    let pem = require_pem(ctx)?;
+    let name = required(args, "name")?;
+    let uri = optional_or(args, "uri", "https://example.com/metadata/{id}.json");
+    let payment = optional_or(args, "payment_amount", DEFAULT_CEP85_PAYMENT);
+    let wasm = read_wasm(args, &["CEPS_CEP85_WASM", "CEPS_WASM_PATH"])?;
+
+    let client = cep85_client(ctx)?;
+    let install_args = Cep85InstallArgs::new(&name, &uri)
+        .with_events_mode(EventsMode::Ces)
+        .with_enable_burn(true);
+    let deploy = deploy_params(pem, &payment, ctx);
+    let put = client
+        .install(&install_args, &wasm, &deploy)
+        .await
+        .map_err(ceps_err)?;
+
+    let mut out = call_result_json(&put);
+    if let Ok(pk) = public_key_from_secret_key(pem) {
+        let mut client = client;
+        if let Ok(contract) = client
+            .core()
+            .get_account_named_key(&pk, &format!("cep85_contract_hash_{name}"))
+            .await
+        {
+            let package = client
+                .core()
+                .get_account_named_key(&pk, &format!("cep85_contract_package_{name}"))
+                .await
+                .ok();
+            let _ = client.set_contract_hash(&contract, package.as_deref());
+            out["contract_hash"] = json!(contract);
+            if let Some(p) = package {
+                out["package_hash"] = json!(p);
+            }
+        }
+        out["installer"] = json!(pk);
+    }
+    Ok(out)
+}
+
+async fn cep95_install(args: &HashMap<String, String>, ctx: &CepsCtx<'_>) -> Result<Value, String> {
+    ctx.policy.check_put_generic("cep95_install")?;
+    let pem = require_pem(ctx)?;
+    let name = required(args, "name")?;
+    let symbol = optional_or(args, "symbol", "T95");
+    let package_key = required(args, "package_key_name")?;
+    let payment = optional_or(args, "payment_amount", DEFAULT_CEP95_PAYMENT);
+    let wasm = read_wasm(args, &["CEPS_CEP95_WASM", "CEPS_WASM_PATH"])?;
+
+    let mut client = cep95_client(ctx)?;
+    let install_args = Cep95InstallArgs::new(&name, &symbol, &package_key);
+    let deploy = deploy_params(pem, &payment, ctx);
+    let put = client
+        .install(&install_args, &wasm, &deploy)
+        .await
+        .map_err(ceps_err)?;
+
+    let mut out = call_result_json(&put);
+    let pk = public_key_from_secret_key(pem).map_err(|e| e.to_string())?;
+    let (contract, package) = client
+        .bind_odra_install(&pk, &package_key)
+        .await
+        .map_err(ceps_err)?;
+    out["contract_hash"] = json!(contract);
+    out["package_hash"] = json!(package);
+    out["installer"] = json!(pk);
+    Ok(out)
+}
+
+fn deploy_params(pem: &str, payment: &str, ctx: &CepsCtx<'_>) -> DeployParams {
+    let mut d = DeployParams::new(pem, payment);
+    if !ctx.chain_name.trim().is_empty() {
+        d = d.with_chain_name(ctx.chain_name.trim());
+    }
+    d
+}
+
+fn require_pem<'a>(ctx: &CepsCtx<'a>) -> Result<&'a str, String> {
+    ctx.pem
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| "secret_key is missing | press o to load a PEM".to_string())
+}
+
+fn read_wasm(args: &HashMap<String, String>, env_keys: &[&str]) -> Result<Vec<u8>, String> {
+    let path = resolve_wasm_path(args, env_keys)?;
+    fs::read(&path).map_err(|e| format!("read wasm {}: {e}", path.display()))
+}
+
+fn resolve_wasm_path(args: &HashMap<String, String>, env_keys: &[&str]) -> Result<PathBuf, String> {
+    if let Some(p) = args
+        .get("wasm_path")
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+    {
+        return Ok(PathBuf::from(p));
+    }
+    for key in env_keys {
+        if let Ok(p) = std::env::var(key) {
+            let p = p.trim().to_string();
+            if !p.is_empty() {
+                return Ok(PathBuf::from(p));
+            }
+        }
+    }
+    Err(format!(
+        "missing wasm_path (arg or env {}); tip WASM via ceps-rust-ts-client make wasm-from-ceps",
+        env_keys.join(" / ")
+    ))
+}
+
+fn call_result_json(put: &CallResult) -> Value {
+    json!({
+        "transaction_hash": put.transaction_hash,
+        "put_result": put.put_result,
+        "execution_result": put.execution_result,
+    })
+}
+
+fn required(args: &HashMap<String, String>, name: &str) -> Result<String, String> {
+    args.get(name)
+        .cloned()
+        .filter(|s| !s.trim().is_empty())
+        .ok_or_else(|| format!("missing required arg `{name}`"))
+}
+
+fn optional_or(args: &HashMap<String, String>, name: &str, default: &str) -> String {
+    args.get(name)
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| default.to_string())
+}
+
+fn parse_u8(s: &str) -> Result<u8, String> {
+    s.trim()
+        .parse::<u8>()
+        .map_err(|_| format!("invalid u8 `{s}`"))
+}
+
+fn parse_u64(s: &str) -> Result<u64, String> {
+    s.trim()
+        .parse::<u64>()
+        .map_err(|_| format!("invalid u64 `{s}`"))
+}
+
+fn ceps_err(e: impl std::fmt::Display) -> String {
+    e.to_string()
+}

--- a/examples/desktop/casperatatui/src/lib.rs
+++ b/examples/desktop/casperatatui/src/lib.rs
@@ -6,6 +6,8 @@ pub mod account_view;
 pub mod actions_catalog;
 pub mod auction_view;
 pub mod block_view;
+#[cfg(feature = "ceps")]
+pub mod ceps_actions;
 pub mod command;
 pub mod config;
 pub mod contract_view;

--- a/examples/desktop/casperatatui/src/main.rs
+++ b/examples/desktop/casperatatui/src/main.rs
@@ -1145,6 +1145,7 @@ fn action_write_ctx(model: &AppModel) -> ActionWriteCtx {
         pem: model.secret_key_pem.clone(),
         public_key: model.public_key.clone(),
         chain_name: model.chain_name.clone(),
+        events_url: model.events_url.clone(),
         policy: model.policy.clone(),
     }
 }

--- a/examples/desktop/casperatatui/src/sdk_client.rs
+++ b/examples/desktop/casperatatui/src/sdk_client.rs
@@ -29,6 +29,7 @@ pub struct ActionWriteCtx {
     pub pem: Option<String>,
     pub public_key: String,
     pub chain_name: String,
+    pub events_url: String,
     pub policy: WritePolicy,
 }
 
@@ -778,6 +779,22 @@ async fn run_action(
         "install" | "call_entrypoint" => Err(format!(
             "`{method}` needs a loaded PEM; transfer/stake live on Writes (8), install/call forms still WIP"
         )),
+        #[cfg(feature = "ceps")]
+        method if method.starts_with("cep") => {
+            crate::ceps_actions::run_ceps_action(
+                method,
+                args,
+                &crate::ceps_actions::CepsCtx {
+                    rpc,
+                    events_url: &write.events_url,
+                    chain_name: &write.chain_name,
+                    verbosity,
+                    pem: write.pem.as_deref(),
+                    policy: &write.policy,
+                },
+            )
+            .await
+        }
         other => Err(format!(
             "unknown action `{other}` · the catalog is confused"
         )),

--- a/examples/desktop/casperatatui/src/views/help.rs
+++ b/examples/desktop/casperatatui/src/views/help.rs
@@ -6,7 +6,7 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Paragraph, Wrap};
 use ratatui::Frame;
 
-use crate::actions_catalog::ACTIONS;
+use crate::actions_catalog::all_actions;
 use crate::command::COMMANDS;
 use crate::model::AppModel;
 
@@ -63,6 +63,15 @@ pub fn draw_help(frame: &mut Frame, area: Rect, model: &AppModel) {
         Line::from("  SSE collect: toggle names, max_events, timeout → SSEClient::collect"),
         Line::from(""),
         Line::from(Span::styled(
+            "CEP Actions (feature ceps)",
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        )),
+        Line::from("  Build with --features ceps (sibling ceps-rust-ts-client/ceps-client)."),
+        Line::from("  SDK feature js stays off. CEP install needs --enable-writes + PEM + policy."),
+        Line::from(""),
+        Line::from(Span::styled(
             "Command palette",
             Style::default()
                 .fg(Color::Cyan)
@@ -92,7 +101,7 @@ pub fn draw_help(frame: &mut Frame, area: Rect, model: &AppModel) {
             .fg(Color::Cyan)
             .add_modifier(Modifier::BOLD),
     )));
-    for action in ACTIONS {
+    for action in all_actions() {
         lines.push(Line::from(format!(
             "  [{:<7}] {}",
             action.group.label(),

--- a/mcp/Dockerfile
+++ b/mcp/Dockerfile
@@ -17,16 +17,18 @@ RUN apt-get update \
     binutils \
   && rm -rf /var/lib/apt/lists/*
 
-WORKDIR /src
-# Workspace members: ., mcp, casperatatui, tauri/src-tauri (+ sdk_tests path-dep).
-# Do not COPY python/.
-COPY Cargo.toml Cargo.lock ./
-COPY src ./src
-COPY mcp ./mcp
-COPY examples/desktop/casperatatui ./examples/desktop/casperatatui
-COPY examples/desktop/tauri/src-tauri ./examples/desktop/tauri/src-tauri
-COPY tests/integration/rust ./tests/integration/rust
+# Sibling layout: casperatatui optional-deps ceps-client (path must exist for Cargo).
+WORKDIR /work
+COPY Cargo.toml Cargo.lock ./rustSDK/
+COPY src ./rustSDK/src
+COPY mcp ./rustSDK/mcp
+COPY examples/desktop/casperatatui ./rustSDK/examples/desktop/casperatatui
+COPY examples/desktop/tauri/src-tauri ./rustSDK/examples/desktop/tauri/src-tauri
+COPY tests/integration/rust ./rustSDK/tests/integration/rust
+RUN git clone --depth 1 https://github.com/Interchouette-ITC/ceps-rust-ts-client.git \
+  /work/ceps-rust-ts-client
 
+WORKDIR /work/rustSDK
 RUN cargo build -p casper-rust-wasm-sdk-mcp --release \
   && strip -s target/release/casper-rust-wasm-sdk-mcp \
   && cp target/release/casper-rust-wasm-sdk-mcp /casper-rust-wasm-sdk-mcp


### PR DESCRIPTION
## Summary
- Optional feature `ceps` wires sibling `ceps-client` into Casperatatui Actions (CEP-18/78/85/95 info, queries, installs); SDK feature `js` stays off.
- Adds `ceps_actions`, catalog/policy/docs/Makefile target, and `smoke_ceps_query` / `smoke_ceps_install` examples.
- Updates `ci-casperatatui` to check out public `ceps-rust-ts-client` as a sibling so the path-dep resolves without enabling `--features ceps` in default CI.

Closes #138

## Test plan
- [x] `cargo check -p casperatatui` (default)
- [x] `cargo check -p casperatatui --features ceps`
- [x] `make check-lint-casperatatui` and clippy with `--features ceps`
- [x] NCTL `make start dev` (sibling): `smoke_ceps_query` (info + `cep18_name` after install)
- [x] NCTL faucet PEM + tip `cep18.wasm`: `smoke_ceps_install` returned `transaction_hash` + contract/package hashes
- [ ] CI `ci-casperatatui` green on this PR