### PR TITLE
ci: publish full GHCR trio for Hub images

### DIFF
--- a/.github/workflows/hub-images-dev.yml
+++ b/.github/workflows/hub-images-dev.yml
@@ -44,6 +44,36 @@ jobs:
             docker push "${{ secrets.DOCKER_USERNAME_ITC }}/${image}:dev"
           done
 
+      - name: Log in to GHCR (personal)
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_USERNAME }}
+          password: ${{ secrets.GHCR_PAT }}
+
+      - name: Tag and push personal GHCR :dev
+        run: |
+          for image in casper-webclient cors-anywhere ws-proxy casper-rust-wasm-sdk-mcp; do
+            docker tag "${image}:latest" "ghcr.io/groussac/${image}:dev"
+            docker push "ghcr.io/groussac/${image}:dev"
+          done
+
+      - name: Log in to GHCR (Interchouette / ITC)
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_USERNAME_ITC }}
+          password: ${{ secrets.GHCR_PAT_ITC }}
+
+      - name: Tag and push worker and org GHCR :dev
+        run: |
+          for image in casper-webclient cors-anywhere ws-proxy casper-rust-wasm-sdk-mcp; do
+            docker tag "${image}:latest" "ghcr.io/interchouette/${image}:dev"
+            docker tag "${image}:latest" "ghcr.io/interchouette-itc/${image}:dev"
+            docker push "ghcr.io/interchouette/${image}:dev"
+            docker push "ghcr.io/interchouette-itc/${image}:dev"
+          done
+
       - name: Trigger Render redeploy
         env:
           RENDER_DEPLOY_HOOK: ${{ secrets.RENDER_DEPLOY_HOOK }}

--- a/.github/workflows/hub-images-release.yml
+++ b/.github/workflows/hub-images-release.yml
@@ -86,6 +86,46 @@ jobs:
             docker push "${{ secrets.DOCKER_USERNAME_ITC }}/${image}:dev"
           done
 
+      - name: Log in to GHCR (personal)
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_USERNAME }}
+          password: ${{ secrets.GHCR_PAT }}
+
+      - name: Tag and push personal GHCR
+        run: |
+          APP_VERSION="${{ steps.ver.outputs.version }}"
+          for image in casper-webclient cors-anywhere ws-proxy casper-rust-wasm-sdk-mcp; do
+            docker tag "${image}:latest" "ghcr.io/groussac/${image}:${APP_VERSION}"
+            docker tag "${image}:latest" "ghcr.io/groussac/${image}:latest"
+            docker tag "${image}:latest" "ghcr.io/groussac/${image}:dev"
+            docker push "ghcr.io/groussac/${image}:${APP_VERSION}"
+            docker push "ghcr.io/groussac/${image}:latest"
+            docker push "ghcr.io/groussac/${image}:dev"
+          done
+
+      - name: Log in to GHCR (Interchouette / ITC)
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_USERNAME_ITC }}
+          password: ${{ secrets.GHCR_PAT_ITC }}
+
+      - name: Tag and push worker and org GHCR
+        run: |
+          APP_VERSION="${{ steps.ver.outputs.version }}"
+          for image in casper-webclient cors-anywhere ws-proxy casper-rust-wasm-sdk-mcp; do
+            for ns in interchouette interchouette-itc; do
+              docker tag "${image}:latest" "ghcr.io/${ns}/${image}:${APP_VERSION}"
+              docker tag "${image}:latest" "ghcr.io/${ns}/${image}:latest"
+              docker tag "${image}:latest" "ghcr.io/${ns}/${image}:dev"
+              docker push "ghcr.io/${ns}/${image}:${APP_VERSION}"
+              docker push "ghcr.io/${ns}/${image}:latest"
+              docker push "ghcr.io/${ns}/${image}:dev"
+            done
+          done
+
       - name: Trigger Render redeploy
         env:
           RENDER_DEPLOY_HOOK: ${{ secrets.RENDER_DEPLOY_HOOK }}


### PR DESCRIPTION
## Summary
- After Docker Hub pushes, also publish the same image tags to three GHCR namespaces (personal, worker, org).
- CI uses personal GHCR credentials for personal pushes, then ITC credentials for worker and org.
- Applies to tip (`:dev`) and release (`:version`, `:latest`, `:dev`) Hub image workflows.

## Test plan
- [ ] Confirm secrets `GHCR_USERNAME`, `GHCR_PAT`, `GHCR_USERNAME_ITC`, and `GHCR_PAT_ITC` exist on the workflow repo.
- [ ] Run `hub-images-dev` and verify all four images land on Hub plus three GHCR destinations at `:dev`.
- [ ] Spot-check `hub-images-release` YAML for personal then ITC login order.