### PR TITLE
ci: checkout ceps-client sibling for workspace cargo loads

### DIFF
--- a/.github/workflows/ci-signing-desk.yml
+++ b/.github/workflows/ci-signing-desk.yml
@@ -31,9 +31,19 @@ jobs:
             patchelf
 
       - uses: actions/checkout@v5
+        with:
+          path: rustSDK
+
+      - name: Checkout sibling ceps-rust-ts-client
+        uses: actions/checkout@v5
+        with:
+          repository: Interchouette-ITC/ceps-rust-ts-client
+          path: ceps-rust-ts-client
 
       - name: Swatinem cache
         uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: rustSDK
 
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -43,14 +53,16 @@ jobs:
         with:
           node-version: "22"
           cache: npm
-          cache-dependency-path: examples/desktop/tauri/package-lock.json
+          cache-dependency-path: rustSDK/examples/desktop/tauri/package-lock.json
 
       - name: npm install
-        working-directory: examples/desktop/tauri
+        working-directory: rustSDK/examples/desktop/tauri
         run: npm ci
 
       - name: Lint signing desk
+        working-directory: rustSDK
         run: make check-lint-tauri
 
       - name: Unit tests
+        working-directory: rustSDK
         run: cargo test -p casper-signing-desk --lib

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,4 +1,6 @@
 # GitHub Pages only (rustdoc + typedoc under docs/).
+# Workspace member casperatatui path-deps sibling ceps-client; Cargo needs the
+# path present even when feature `ceps` is off (same layout as ci-test).
 name: pages
 
 on:
@@ -11,6 +13,10 @@ on:
 permissions:
   contents: write
 
+defaults:
+  run:
+    working-directory: rustSDK
+
 jobs:
   build-and-deploy:
     strategy:
@@ -21,6 +27,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
+        with:
+          path: rustSDK
+
+      - name: Checkout sibling ceps-rust-ts-client
+        uses: actions/checkout@v5
+        with:
+          repository: Interchouette-ITC/ceps-rust-ts-client
+          path: ceps-rust-ts-client
+
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
@@ -38,5 +53,5 @@ jobs:
       - name: Deploy GitHub Pages
         uses: JamesIves/github-pages-deploy-action@v4
         with:
-          folder: docs
+          folder: rustSDK/docs
           commit-message: "Deploy documentation for ${{ github.ref_name }}"

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -9,14 +9,28 @@ on:
         required: false
         type: string
 
+# Workspace member casperatatui path-deps sibling ceps-client; Cargo needs the
+# path present to load the workspace (same layout as ci-test).
 jobs:
   publish:
     runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: rustSDK
 
     steps:
       - uses: actions/checkout@v5
         with:
           ref: ${{ inputs.ref || github.ref }}
+          path: rustSDK
+
+      - name: Checkout sibling ceps-rust-ts-client
+        uses: actions/checkout@v5
+        with:
+          repository: Interchouette-ITC/ceps-rust-ts-client
+          path: ceps-rust-ts-client
+
       - uses: dtolnay/rust-toolchain@stable
 
       - name: Crate Publish


### PR DESCRIPTION
## Summary
- Fix [pages failure](https://github.com/casper-ecosystem/casper-rust-wasm-sdk/actions/runs/31407182147/job/93516253725): `make doc` loads workspace member `casperatatui`, which path-deps sibling `ceps-client` even with `ceps` off.
- Align `pages.yml` with the `ci-test` checkout layout (`rustSDK` + `ceps-rust-ts-client`).
- Same sibling checkout for `ci-signing-desk` and `publish-crates` (same workspace load hazard).

## Test plan
- [ ] Re-run `pages` on `dev` after merge (or `workflow_dispatch`)
- [ ] Confirm Doc step finds `ceps-client` and rustdoc completes


Made with [Cursor](https://cursor.com)