### PR TITLE
ci(pages): rustSDK+ceps layout + JamesIves .git symlink

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,8 +1,11 @@
 # GitHub Pages only (rustdoc + typedoc under docs/).
-# Workspace member casperatatui path-deps sibling ceps-client; Cargo needs the
-# path present even when feature `ceps` is off.
-# Keep this repo at GITHUB_WORKSPACE so JamesIves/github-pages-deploy-action
-# finds a .git root (do not checkout into a subdirectory).
+#
+# Cargo layout (same as ci-test): workspace member casperatatui path-deps
+# sibling ceps-client, and ceps-client path-deps this SDK as ../rustSDK.
+# Checkout into path: rustSDK + path: ceps-rust-ts-client.
+#
+# JamesIves needs a .git at GITHUB_WORKSPACE: symlink rustSDK/.git there
+# before deploy (no Rust / workspace member changes).
 name: pages
 
 on:
@@ -15,6 +18,10 @@ on:
 permissions:
   contents: write
 
+defaults:
+  run:
+    working-directory: rustSDK
+
 jobs:
   build-and-deploy:
     strategy:
@@ -25,14 +32,14 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
+        with:
+          path: rustSDK
 
-      # Sibling of GITHUB_WORKSPACE: matches ../../../../ceps-rust-ts-client
-      # from examples/desktop/casperatatui (ci-test uses path: rustSDK instead).
       - name: Checkout sibling ceps-rust-ts-client
-        working-directory: ${{ github.workspace }}/..
-        run: |
-          rm -rf ceps-rust-ts-client
-          git clone --depth 1 https://github.com/Interchouette-ITC/ceps-rust-ts-client.git ceps-rust-ts-client
+        uses: actions/checkout@v5
+        with:
+          repository: Interchouette-ITC/ceps-rust-ts-client
+          path: ceps-rust-ts-client
 
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -48,8 +55,12 @@ jobs:
       - name: Doc
         run: make doc
 
+      - name: Expose .git at workspace root for JamesIves
+        working-directory: ${{ github.workspace }}
+        run: ln -sfn "${GITHUB_WORKSPACE}/rustSDK/.git" "${GITHUB_WORKSPACE}/.git"
+
       - name: Deploy GitHub Pages
         uses: JamesIves/github-pages-deploy-action@v4
         with:
-          folder: docs
+          folder: rustSDK/docs
           commit-message: "Deploy documentation for ${{ github.ref_name }}"


### PR DESCRIPTION
## Summary
- `#144` kept the repo at workspace root for JamesIves, but `ceps-client` path-deps the SDK as `../rustSDK`, so Doc failed looking for `/home/runner/work/.../rustSDK/Cargo.toml`.
- `#143` nested under `rustSDK/` fixed Cargo but broke JamesIves (`not in a git directory`).
- This PR only changes `pages.yml`: same checkout layout as `ci-test` (`rustSDK` + `ceps-rust-ts-client`), then `ln -s rustSDK/.git` at workspace root so JamesIves can deploy `rustSDK/docs`.
- **No** Cargo.toml / workspace / Rust changes.

## Test plan
- [ ] `pages` Doc step green
- [ ] `pages` Deploy step green


Made with [Cursor](https://cursor.com)