### PR TITLE
ci: hardcode Hub namespace for image pushes

### DIFF
--- a/.github/workflows/hub-images-dev.yml
+++ b/.github/workflows/hub-images-dev.yml
@@ -38,13 +38,13 @@ jobs:
           docker build -f mcp/Dockerfile -t casper-rust-wasm-sdk-mcp:latest .
 
           for image in casper-webclient cors-anywhere ws-proxy casper-rust-wasm-sdk-mcp; do
-            docker tag "${image}:latest" "${{ secrets.DOCKER_USERNAME_ITC }}/${image}:dev"
+            docker tag "${image}:latest" "interchouette/${image}:dev"
           done
 
       - name: Push Docker images to Docker Hub
         run: |
           for image in casper-webclient cors-anywhere ws-proxy casper-rust-wasm-sdk-mcp; do
-            docker push "${{ secrets.DOCKER_USERNAME_ITC }}/${image}:dev"
+            docker push "interchouette/${image}:dev"
           done
 
       - name: Log in to GHCR (personal)

--- a/.github/workflows/hub-images-release.yml
+++ b/.github/workflows/hub-images-release.yml
@@ -75,18 +75,18 @@ jobs:
           docker build -f mcp/Dockerfile -t casper-rust-wasm-sdk-mcp:latest .
 
           for image in casper-webclient cors-anywhere ws-proxy casper-rust-wasm-sdk-mcp; do
-            docker tag "${image}:latest" "${{ secrets.DOCKER_USERNAME_ITC }}/${image}:${APP_VERSION}"
-            docker tag "${image}:latest" "${{ secrets.DOCKER_USERNAME_ITC }}/${image}:latest"
-            docker tag "${image}:latest" "${{ secrets.DOCKER_USERNAME_ITC }}/${image}:dev"
+            docker tag "${image}:latest" "interchouette/${image}:${APP_VERSION}"
+            docker tag "${image}:latest" "interchouette/${image}:latest"
+            docker tag "${image}:latest" "interchouette/${image}:dev"
           done
 
       - name: Push Docker images to Docker Hub
         run: |
           APP_VERSION="${{ steps.ver.outputs.version }}"
           for image in casper-webclient cors-anywhere ws-proxy casper-rust-wasm-sdk-mcp; do
-            docker push "${{ secrets.DOCKER_USERNAME_ITC }}/${image}:${APP_VERSION}"
-            docker push "${{ secrets.DOCKER_USERNAME_ITC }}/${image}:latest"
-            docker push "${{ secrets.DOCKER_USERNAME_ITC }}/${image}:dev"
+            docker push "interchouette/${image}:${APP_VERSION}"
+            docker push "interchouette/${image}:latest"
+            docker push "interchouette/${image}:dev"
           done
 
       - name: Log in to GHCR (personal)


### PR DESCRIPTION
## Summary
- Remove `secrets.DOCKER_USERNAME_ITC` from Hub tag/push paths in `hub-images-dev` and `hub-images-release`
- Unblocks Hub pushes that were failing with DNS lookup of the masked namespace host, which also blocked GHCR (webclient / mcp worker)

## Test plan
- [ ] `hub-images-dev` green on merge
- [ ] Hub shows `interchouette/casper-webclient` (and siblings) `:dev` updated
- [ ] GHCR personal + worker + org receive the four images


Made with [Cursor](https://cursor.com)