### PR TITLE
fix(ci): restore dev-preview assets + Signing Desk

### DIFF
--- a/.github/workflows/release-github-assets.yml
+++ b/.github/workflows/release-github-assets.yml
@@ -1,4 +1,4 @@
-# Build Electron demos + MCP + Casperatatui binaries and attach them to a GitHub Release.
+# Build Electron + MCP + Casperatatui (+ tip Signing Desk) and attach to a GitHub Release.
 # Callers: release-github-stable (Latest) and release-github-preview (tip Pre-release).
 name: release-github-assets
 
@@ -18,6 +18,11 @@ on:
         required: false
         type: boolean
         default: true
+      include_signing_desk:
+        description: Build and stage Tauri Casper Signing Desk (tip / dev-preview)
+        required: false
+        type: boolean
+        default: false
       artifact_name:
         description: actions/upload-artifact name for staged release files
         required: false
@@ -53,7 +58,10 @@ jobs:
         working-directory: ${{ github.workspace }}
         run: |
           sudo apt-get update
-          sudo apt-get install -y pkg-config libssl-dev fuse libfuse2
+          sudo apt-get install -y \
+            pkg-config libssl-dev fuse libfuse2 \
+            libwebkit2gtk-4.1-dev libgtk-3-dev librsvg2-dev \
+            libayatana-appindicator3-dev libdbus-1-dev patchelf
           sudo snap install snapcraft --classic
 
       - name: Setup Rust
@@ -93,9 +101,18 @@ jobs:
       - name: Build Casperatatui release binary
         run: make build-casperatatui-release
 
+      - name: Build Tauri Signing Desk (AppImage)
+        if: ${{ inputs.include_signing_desk }}
+        working-directory: examples/desktop/tauri
+        run: |
+          npm ci
+          # Workspace cargo target; AppImage only (linux runner).
+          env -u CARGO_TARGET_DIR npm run tauri -- build --bundles appimage
+
       - name: Stage release asset filenames
         env:
           TAG: ${{ inputs.tag }}
+          INCLUDE_SIGNING_DESK: ${{ inputs.include_signing_desk }}
         run: |
           set -euo pipefail
           RELEASE_DIR="examples/desktop/electron/release"
@@ -133,6 +150,26 @@ jobs:
           cp "$CASPERATATUI_SRC" "$STAGE/casperatatui-${ASSET_LABEL}-linux-x86_64"
           chmod +x "$STAGE/casper-rust-wasm-sdk-mcp-${ASSET_LABEL}-linux-x86_64"
           chmod +x "$STAGE/casperatatui-${ASSET_LABEL}-linux-x86_64"
+
+          if [ "$INCLUDE_SIGNING_DESK" = "true" ]; then
+            SIGNING_BIN="target/release/casper-signing-desk"
+            # Tauri 2 workspace: AppImage under target/release/bundle/appimage/
+            mapfile -t SIGNING_APPIMAGES < <(find target/release/bundle/appimage -type f -name '*.AppImage' 2>/dev/null | sort)
+            if [[ ! -f "$SIGNING_BIN" ]]; then
+              echo "Missing Signing Desk binary: $SIGNING_BIN"
+              ls -la target/release || true
+              exit 1
+            fi
+            if [[ ${#SIGNING_APPIMAGES[@]} -lt 1 ]]; then
+              echo "Missing Signing Desk AppImage under target/release/bundle/appimage"
+              find target/release/bundle -type f 2>/dev/null | head -50 || true
+              exit 1
+            fi
+            cp "$SIGNING_BIN" "$STAGE/casper-signing-desk-${ASSET_LABEL}-linux-x86_64"
+            cp "${SIGNING_APPIMAGES[0]}" "$STAGE/Casper.SigningDesk-${ASSET_LABEL}.AppImage"
+            chmod +x "$STAGE/casper-signing-desk-${ASSET_LABEL}-linux-x86_64"
+            chmod +x "$STAGE/Casper.SigningDesk-${ASSET_LABEL}.AppImage"
+          fi
 
           ls -la "$STAGE"
 

--- a/.github/workflows/release-github-assets.yml
+++ b/.github/workflows/release-github-assets.yml
@@ -6,13 +6,23 @@ on:
   workflow_call:
     inputs:
       tag:
-        description: GitHub Release tag to upload into
+        description: GitHub Release tag to upload into (ignored when attach_to_release is false)
         required: true
         type: string
       ref:
         description: Git ref to build (tag or commit SHA)
         required: true
         type: string
+      attach_to_release:
+        description: If true, upload built files to the GitHub Release for inputs.tag
+        required: false
+        type: boolean
+        default: true
+      artifact_name:
+        description: actions/upload-artifact name for staged release files
+        required: false
+        type: string
+        default: desktop-mcp-casperatatui
 
 permissions:
   contents: write
@@ -83,9 +93,8 @@ jobs:
       - name: Build Casperatatui release binary
         run: make build-casperatatui-release
 
-      - name: Upload assets to release
+      - name: Stage release asset filenames
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ inputs.tag }}
         run: |
           set -euo pipefail
@@ -93,6 +102,8 @@ jobs:
           # electron-builder output names come from examples/desktop/electron/package.json version.
           PKG_VERSION=$(jq -r .version examples/desktop/electron/package.json)
           ASSET_LABEL=${TAG#v}
+          STAGE=release-assets
+          mkdir -p "$STAGE"
 
           # Stable semver Releases must match package.json (GitHub Release files, not Render).
           if [[ "$ASSET_LABEL" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] && [ "$ASSET_LABEL" != "$PKG_VERSION" ]; then
@@ -104,9 +115,7 @@ jobs:
           APPIMAGE="$RELEASE_DIR/Casper Webclient-${PKG_VERSION}.AppImage"
           SNAP="$RELEASE_DIR/casper-webclient_${PKG_VERSION}_amd64.snap"
           MCP_SRC="target/release/casper-rust-wasm-sdk-mcp"
-          MCP_DST="casper-rust-wasm-sdk-mcp-${ASSET_LABEL}-linux-x86_64"
           CASPERATATUI_SRC="target/release/casperatatui"
-          CASPERATATUI_DST="casperatatui-${ASSET_LABEL}-linux-x86_64"
 
           for f in "$EXE" "$APPIMAGE" "$SNAP" "$MCP_SRC" "$CASPERATATUI_SRC"; do
             if [[ ! -f "$f" ]]; then
@@ -117,15 +126,29 @@ jobs:
             fi
           done
 
-          cp "$MCP_SRC" "$MCP_DST"
-          chmod +x "$MCP_DST"
-          cp "$CASPERATATUI_SRC" "$CASPERATATUI_DST"
-          chmod +x "$CASPERATATUI_DST"
+          cp "$EXE" "$STAGE/Casper.Webclient.${ASSET_LABEL}.exe"
+          cp "$APPIMAGE" "$STAGE/Casper.Webclient-${ASSET_LABEL}.AppImage"
+          cp "$SNAP" "$STAGE/casper-webclient_${ASSET_LABEL}_amd64.snap"
+          cp "$MCP_SRC" "$STAGE/casper-rust-wasm-sdk-mcp-${ASSET_LABEL}-linux-x86_64"
+          cp "$CASPERATATUI_SRC" "$STAGE/casperatatui-${ASSET_LABEL}-linux-x86_64"
+          chmod +x "$STAGE/casper-rust-wasm-sdk-mcp-${ASSET_LABEL}-linux-x86_64"
+          chmod +x "$STAGE/casperatatui-${ASSET_LABEL}-linux-x86_64"
 
-          gh release upload "$TAG" \
-            "$EXE#Casper.Webclient.${ASSET_LABEL}.exe" \
-            "$APPIMAGE#Casper.Webclient-${ASSET_LABEL}.AppImage" \
-            "$SNAP#casper-webclient_${ASSET_LABEL}_amd64.snap" \
-            "$MCP_DST" \
-            "$CASPERATATUI_DST" \
-            --clobber
+          ls -la "$STAGE"
+
+      - name: Upload staged assets as workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.artifact_name }}
+          path: rustSDK/release-assets/*
+          if-no-files-found: error
+          retention-days: 3
+
+      - name: Upload assets to release
+        if: ${{ inputs.attach_to_release }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          gh release upload "$TAG" release-assets/* --clobber

--- a/.github/workflows/release-github-preview.yml
+++ b/.github/workflows/release-github-preview.yml
@@ -32,7 +32,7 @@ jobs:
 
   # Build before any release delete so a failed make pack keeps the previous assets.
   build-assets:
-    name: Build Electron + MCP + Casperatatui assets
+    name: Build Electron + MCP + Casperatatui + Signing Desk assets
     needs: prepare
     if: needs.prepare.result == 'success'
     uses: ./.github/workflows/release-github-assets.yml
@@ -40,6 +40,7 @@ jobs:
       tag: dev-preview
       ref: ${{ needs.prepare.outputs.sha }}
       attach_to_release: false
+      include_signing_desk: true
       artifact_name: desktop-mcp-casperatatui-dev-preview
     secrets: inherit
 
@@ -72,12 +73,14 @@ jobs:
 
           Overwritten on each successful [nightly-test](https://github.com/${{ github.repository }}/actions/workflows/nightly-test.yml). Not Latest - that remains the node-aligned semver release (e.g. v2.2.2).
 
-          ## Desktop / MCP / Casperatatui assets
+          ## Desktop / MCP / Casperatatui / Signing Desk assets
           - \`Casper.Webclient.dev-preview.exe\`
           - \`Casper.Webclient-dev-preview.AppImage\`
           - \`casper-webclient_dev-preview_amd64.snap\`
           - \`casper-rust-wasm-sdk-mcp-dev-preview-linux-x86_64\`
           - \`casperatatui-dev-preview-linux-x86_64\`
+          - \`Casper.SigningDesk-dev-preview.AppImage\`
+          - \`casper-signing-desk-dev-preview-linux-x86_64\`
           "
 
           if gh release view "$TAG" >/dev/null 2>&1; then
@@ -117,12 +120,14 @@ jobs:
             casper-webclient_dev-preview_amd64.snap
             casper-rust-wasm-sdk-mcp-dev-preview-linux-x86_64
             casperatatui-dev-preview-linux-x86_64
+            Casper.SigningDesk-dev-preview.AppImage
+            casper-signing-desk-dev-preview-linux-x86_64
           )
           for f in "${expected[@]}"; do
             test -f "release-assets/$f" || { echo "Missing staged asset: $f" >&2; exit 1; }
           done
           gh release upload "$TAG" release-assets/* --clobber
-          # Fail the job if GitHub still shows fewer than the five desktop/MCP/TUI files.
+          # Fail the job if any expected tip desktop/MCP/TUI/Signing Desk file is missing.
           mapfile -t uploaded < <(gh release view "$TAG" --json assets --jq '.assets[].name' | sort)
           echo "Uploaded asset names:"
           printf '%s\n' "${uploaded[@]}"

--- a/.github/workflows/release-github-preview.yml
+++ b/.github/workflows/release-github-preview.yml
@@ -1,4 +1,5 @@
-# Overnight tip Pre-release. Assets uploaded in this run (GITHUB_TOKEN cannot chain on: release).
+# Overnight tip Pre-release. Build assets first; only then overwrite the tag so a
+# failed pack/build cannot leave an empty Pre-release (source archives only).
 name: release-github-preview
 
 on:
@@ -11,15 +12,14 @@ permissions:
   contents: write
 
 jobs:
-  overwrite-prerelease:
-    name: Overwrite GitHub Pre-release dev-preview
+  prepare:
+    name: Resolve SHA for preview
     if: >
       github.event_name == 'workflow_dispatch' ||
       github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     outputs:
       sha: ${{ steps.sha.outputs.sha }}
-
     steps:
       - name: Resolve SHA
         id: sha
@@ -30,17 +30,38 @@ jobs:
             echo "sha=${{ github.sha }}" >> "$GITHUB_OUTPUT"
           fi
 
+  # Build before any release delete so a failed make pack keeps the previous assets.
+  build-assets:
+    name: Build Electron + MCP + Casperatatui assets
+    needs: prepare
+    if: needs.prepare.result == 'success'
+    uses: ./.github/workflows/release-github-assets.yml
+    with:
+      tag: dev-preview
+      ref: ${{ needs.prepare.outputs.sha }}
+      attach_to_release: false
+      artifact_name: desktop-mcp-casperatatui-dev-preview
+    secrets: inherit
+
+  overwrite-prerelease:
+    name: Overwrite GitHub Pre-release dev-preview
+    needs: [prepare, build-assets]
+    if: >
+      needs.prepare.result == 'success' &&
+      needs.build-assets.result == 'success'
+    runs-on: ubuntu-latest
+    steps:
       - name: Checkout tested commit
         uses: actions/checkout@v5
         with:
-          ref: ${{ steps.sha.outputs.sha }}
+          ref: ${{ needs.prepare.outputs.sha }}
           fetch-depth: 0
 
       - name: Move tag and overwrite Pre-release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: dev-preview
-          SHA: ${{ steps.sha.outputs.sha }}
+          SHA: ${{ needs.prepare.outputs.sha }}
         run: |
           set -euo pipefail
           git config user.name "github-actions[bot]"
@@ -49,7 +70,7 @@ jobs:
           SHORT=$(git rev-parse --short "$SHA")
           NOTES="Nightly-green tip of \`dev\` @ \`${SHORT}\` (\`${SHA}\`).
 
-          Overwritten on each successful [nightly-test](https://github.com/${{ github.repository }}/actions/workflows/nightly-test.yml). Not Latest — that remains the node-aligned semver release (e.g. v2.2.2).
+          Overwritten on each successful [nightly-test](https://github.com/${{ github.repository }}/actions/workflows/nightly-test.yml). Not Latest - that remains the node-aligned semver release (e.g. v2.2.2).
 
           ## Desktop / MCP / Casperatatui assets
           - \`Casper.Webclient.dev-preview.exe\`
@@ -71,21 +92,52 @@ jobs:
             --notes "$NOTES" \
             --target "$SHA"
 
-  upload-assets:
-    name: Upload Electron + MCP + Casperatatui assets
-    needs: overwrite-prerelease
+  attach-assets:
+    name: Attach built assets to Pre-release
+    needs: [overwrite-prerelease]
     if: needs.overwrite-prerelease.result == 'success'
-    uses: ./.github/workflows/release-github-assets.yml
-    with:
-      tag: dev-preview
-      ref: ${{ needs.overwrite-prerelease.outputs.sha }}
-    secrets: inherit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download staged assets
+        uses: actions/download-artifact@v4
+        with:
+          name: desktop-mcp-casperatatui-dev-preview
+          path: release-assets
+
+      - name: Upload assets to release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: dev-preview
+        run: |
+          set -euo pipefail
+          ls -la release-assets
+          expected=(
+            Casper.Webclient.dev-preview.exe
+            Casper.Webclient-dev-preview.AppImage
+            casper-webclient_dev-preview_amd64.snap
+            casper-rust-wasm-sdk-mcp-dev-preview-linux-x86_64
+            casperatatui-dev-preview-linux-x86_64
+          )
+          for f in "${expected[@]}"; do
+            test -f "release-assets/$f" || { echo "Missing staged asset: $f" >&2; exit 1; }
+          done
+          gh release upload "$TAG" release-assets/* --clobber
+          # Fail the job if GitHub still shows fewer than the five desktop/MCP/TUI files.
+          mapfile -t uploaded < <(gh release view "$TAG" --json assets --jq '.assets[].name' | sort)
+          echo "Uploaded asset names:"
+          printf '%s\n' "${uploaded[@]}"
+          for f in "${expected[@]}"; do
+            printf '%s\n' "${uploaded[@]}" | grep -Fxq "$f" || {
+              echo "Release $TAG missing asset after upload: $f" >&2
+              exit 1
+            }
+          done
 
   # Pull latest Hub :dev on Render after overnight-green tip (or manual preview run).
   render-redeploy:
     name: Trigger Render redeploy
-    needs: overwrite-prerelease
-    if: needs.overwrite-prerelease.result == 'success'
+    needs: attach-assets
+    if: needs.attach-assets.result == 'success'
     runs-on: ubuntu-latest
     steps:
       - name: Trigger Render redeploy

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+# Recipes use bash (pipefail, etc.). Ubuntu CI /bin/sh is dash and rejects -o pipefail.
+SHELL := /bin/bash
+
 prepare:
 	rustup target add wasm32-unknown-unknown
 


### PR DESCRIPTION
## Summary
- Fix `make pack` on Ubuntu CI: `SHELL := /bin/bash` (dash rejects `pipefail`).
- Build preview assets **before** wiping `dev-preview`, then attach and verify.
- Tip Pre-release now includes **Tauri Casper Signing Desk**:
  - `Casper.SigningDesk-dev-preview.AppImage`
  - `casper-signing-desk-dev-preview-linux-x86_64`
- Expected tip set: Electron (exe/AppImage/snap) + MCP + Casperatatui + Signing Desk.

## Test plan
- [ ] Dispatch `release-github-preview`
- [ ] Confirm job order: build (with Signing Desk) → overwrite → attach verify → Render
- [ ] Confirm `dev-preview` lists all seven tip assets including both Signing Desk files