### PR TITLE
docs: drop plan-tracking jargon from shipped text

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -103,11 +103,11 @@ This will create a `pkg` and `pkg-nodejs` containing the Typescript interfaces. 
 
 Default is `full` + `js` (today's JS/wasm API) for both the wasm package and the Rust `rlib`. Slim builds drop optional surfaces. Omit `js` for Rust-only consumers so wasm-bindgen exports are not linked into a foreign pack.
 
-| Profile                 | Make target                | Cargo flags                                                              |
-| ----------------------- | -------------------------- | ------------------------------------------------------------------------ |
-| full + SSE (wasm packs) | `make web` / `make nodejs` | default features + `--features SSE` (SSEClient + CESParser; `js` on)     |
-| read-only               | `make web-read-only`       | `--no-default-features --features js`                                    |
-| transaction (no deploy) | `make web-transaction`     | `--no-default-features --features transaction,helpers,watcher,js`        |
+| Profile                 | Make target                | Cargo flags                                                          |
+| ----------------------- | -------------------------- | -------------------------------------------------------------------- |
+| full + SSE (wasm packs) | `make web` / `make nodejs` | default features + `--features SSE` (SSEClient + CESParser; `js` on) |
+| read-only               | `make web-read-only`       | `--no-default-features --features js`                                |
+| transaction (no deploy) | `make web-transaction`     | `--no-default-features --features transaction,helpers,watcher,js`    |
 
 Optional features: `js` (wasm-bindgen / js-sys surface; default on), `transaction`, `deploy`, `contract`, `binary-port`, `watcher` (wait/watch), `SSE` (node SSE client + CES; enables `watcher`), `helpers`. Core JSON-RPC reads stay available without them. `binary-port` pulls optional `casper-binary-port*` crates. Domain feature `full` does not include `js`.
 
@@ -2733,8 +2733,6 @@ The workspace package [`python/`](../python/) (`casper-rust-wasm-sdk-py`) is a P
 - Install / develop: see [Python Project](#python-project) under Install above, or [`python/README.md`](../python/README.md)
 - CI: path-filtered `python-bindings` (offline unit + Hub NCTL `:dev`)
 - Make: `make python-test`, `make python-test-nctl`
-
-Initial face: [#117](https://github.com/casper-ecosystem/casper-rust-wasm-sdk/pull/117). Parity waves 1–4: [#121](https://github.com/casper-ecosystem/casper-rust-wasm-sdk/pull/121) (closes [#120](https://github.com/casper-ecosystem/casper-rust-wasm-sdk/issues/120)). Epic [#9](https://github.com/casper-ecosystem/casper-rust-wasm-sdk/issues/9) is **closed**. Deploy APIs, binary-port, and PyPI publish remain out of that epic.
 
 ## Rust API
 

--- a/examples/desktop/casperatatui/examples/smoke_status.rs
+++ b/examples/desktop/casperatatui/examples/smoke_status.rs
@@ -1,4 +1,4 @@
-//! One-shot smoke: Network + Blocks/Txs + Accounts (Phase 1-3 paths).
+//! One-shot smoke: Network + Blocks/Txs + Accounts paths.
 
 use anyhow::Result;
 use casper_rust_wasm_sdk::types::verbosity::Verbosity;

--- a/examples/desktop/casperatatui/src/views/contracts.rs
+++ b/examples/desktop/casperatatui/src/views/contracts.rs
@@ -344,7 +344,7 @@ fn draw_writes(frame: &mut Frame, area: Rect, model: &AppModel) {
                     .add_modifier(Modifier::BOLD),
             )),
             Line::from(""),
-            Line::from("install / call_entrypoint need a session PEM (Phase 6)."),
+            Line::from("install / call_entrypoint need a session PEM (press o, or --secret-key)."),
             Line::from("Until then, use Actions for read queries, or expect SDK errors here."),
             Line::from(""),
             Line::from(format!(
@@ -362,7 +362,7 @@ fn draw_writes(frame: &mut Frame, area: Rect, model: &AppModel) {
             )),
             Line::from(""),
             Line::from("Restart with --enable-writes to show install / call_entrypoint."),
-            Line::from("PEM load + put policy arrive in Phase 6."),
+            Line::from("Then load a PEM with o or --secret-key."),
         ]
     };
     frame.render_widget(

--- a/python/src/meta.rs
+++ b/python/src/meta.rs
@@ -48,7 +48,7 @@ impl PySdk {
         self.inner.get_node_address(node_address)
     }
 
-    /// Set stored node address (binary-port not exposed in this epic).
+    /// Set stored node address (binary-port is not exposed on this binding).
     #[pyo3(signature = (node_address=None))]
     fn set_node_address(&mut self, node_address: Option<String>) -> PyResult<()> {
         self.inner.set_node_address(node_address).map_err(py_err)


### PR DESCRIPTION
## Summary
- Remove epic / PR-wave status prose from `docs/README.md`
- Replace Phase / epic wording in Python rustdoc and Casperatatui UI / smoke docs with current behavior

## Test plan
- [ ] Diff review only (docs + comment/UI string changes)
- [ ] Confirm no remaining Phase / epic / parity-wave wording in touched files


Made with [Cursor](https://cursor.com)