### PR TITLE
chore(examples): pull SDK and ceps-client via git

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -780,11 +780,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "casper-rust-wasm-sdk"
+version = "2.2.2"
+source = "git+https://github.com/casper-ecosystem/casper-rust-wasm-sdk?branch=dev#89164b14939e5b2ee7829eb90e6bde8190db0822"
+dependencies = [
+ "async-trait",
+ "base16",
+ "base64 0.22.1",
+ "bigdecimal",
+ "blake2 0.10.6",
+ "casper-client",
+ "casper-types",
+ "chrono",
+ "futures-util",
+ "getrandom 0.3.4",
+ "hex",
+ "humantime",
+ "num-traits",
+ "once_cell",
+ "rand 0.9.5",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.19",
+ "tokio",
+]
+
+[[package]]
 name = "casper-rust-wasm-sdk-mcp"
 version = "2.2.2"
 dependencies = [
  "anyhow",
- "casper-rust-wasm-sdk",
+ "casper-rust-wasm-sdk 2.2.2",
  "casper-types",
  "clap",
  "hex",
@@ -802,7 +829,7 @@ name = "casper-signing-desk"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "casper-rust-wasm-sdk",
+ "casper-rust-wasm-sdk 2.2.2 (git+https://github.com/casper-ecosystem/casper-rust-wasm-sdk?branch=dev)",
  "casper-types",
  "hex",
  "serde",
@@ -859,7 +886,7 @@ name = "casperatatui"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "casper-rust-wasm-sdk",
+ "casper-rust-wasm-sdk 2.2.2 (git+https://github.com/casper-ecosystem/casper-rust-wasm-sdk?branch=dev)",
  "ceps-client",
  "clap",
  "crossterm",
@@ -892,10 +919,11 @@ dependencies = [
 [[package]]
 name = "ceps-client"
 version = "1.0.0"
+source = "git+https://github.com/Interchouette-ITC/ceps-rust-ts-client?branch=dev#202c7263affe59c702590064428fa4efda253e19"
 dependencies = [
  "base64 0.22.1",
  "blake2 0.10.6",
- "casper-rust-wasm-sdk",
+ "casper-rust-wasm-sdk 2.2.2 (git+https://github.com/casper-ecosystem/casper-rust-wasm-sdk?branch=dev)",
  "casper-types",
  "hex",
  "reqwest 0.12.28",
@@ -5144,7 +5172,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 name = "sdk_tests"
 version = "2.2.2"
 dependencies = [
- "casper-rust-wasm-sdk",
+ "casper-rust-wasm-sdk 2.2.2",
  "chrono",
  "dotenvy",
  "serde_json",

--- a/Makefile
+++ b/Makefile
@@ -217,7 +217,7 @@ run-casperatatui:
 	env -u CARGO_TARGET_DIR -u PLAYWRIGHT_BROWSERS_PATH \
 		cargo run -p casperatatui -- --preset nctl $(CASPERATATUI_ARGS) $(TUI_ARGS)
 
-# Needs sibling checkout ../../ceps-rust-ts-client (from repo root).
+# Needs network once to fetch Interchouette-ITC/ceps-rust-ts-client (git dep, branch dev).
 run-casperatatui-ceps:
 	env -u CARGO_TARGET_DIR -u PLAYWRIGHT_BROWSERS_PATH \
 		cargo run -p casperatatui --features ceps -- --preset nctl $(CASPERATATUI_ARGS) $(TUI_ARGS)

--- a/examples/desktop/casperatatui/COVERAGE.md
+++ b/examples/desktop/casperatatui/COVERAGE.md
@@ -28,7 +28,7 @@ Screen to SDK / MCP symbols used by Casperatatui today.
 cargo run -p casperatatui --example smoke_status
 # optional write+wait (needs PEM path in env, never commit keys):
 # CASPER_SECRET_KEY=/path/to/secret_key.pem cargo run -p casperatatui --example smoke_write_wait
-# CEP (sibling ceps-rust-ts-client + --features ceps):
+# CEP (--features ceps; ceps-client from git):
 # cargo run -p casperatatui --features ceps --example smoke_ceps_query
 # CASPER_SECRET_KEY=… CEPS_CEP18_WASM=…/cep18.wasm \
 #   cargo run -p casperatatui --features ceps --example smoke_ceps_install

--- a/examples/desktop/casperatatui/Cargo.toml
+++ b/examples/desktop/casperatatui/Cargo.toml
@@ -18,20 +18,18 @@ path = "src/lib.rs"
 
 [features]
 default = []
-# Sibling path-dep: ../../../../ceps-rust-ts-client/ceps-client (from this crate).
-# Does not enable SDK feature `js`.
 ceps = ["dep:ceps-client"]
 
 [dependencies]
 anyhow = "1"
-casper-rust-wasm-sdk = { path = "../../..", default-features = false, features = [
+casper-rust-wasm-sdk = { git = "https://github.com/casper-ecosystem/casper-rust-wasm-sdk", branch = "dev", default-features = false, features = [
   "transaction",
   "contract",
   "helpers",
   "watcher",
   "SSE",
 ] }
-ceps-client = { path = "../../../../ceps-rust-ts-client/ceps-client", optional = true }
+ceps-client = { git = "https://github.com/Interchouette-ITC/ceps-rust-ts-client", branch = "dev", optional = true }
 clap = { version = "4", features = ["derive", "env"] }
 crossterm = "0.29"
 ctrlc = "3"
@@ -52,5 +50,3 @@ required-features = ["ceps"]
 [[example]]
 name = "smoke_ceps_install"
 required-features = ["ceps"]
-
-# TestBackend ships with ratatui 0.30 (no extra feature).

--- a/examples/desktop/casperatatui/README.md
+++ b/examples/desktop/casperatatui/README.md
@@ -16,7 +16,7 @@ make run-tui
 env -u CARGO_TARGET_DIR cargo run -p casperatatui -- --preset nctl
 ```
 
-CEP Actions (optional sibling `ceps-rust-ts-client`):
+CEP / CEPS Actions (optional [`ceps-client`](https://github.com/Interchouette-ITC/ceps-rust-ts-client)):
 
 ```bash
 make run-casperatatui-ceps
@@ -25,7 +25,7 @@ make run-casperatatui-ceps
 env -u CARGO_TARGET_DIR cargo run -p casperatatui --features ceps -- --preset nctl
 ```
 
-Feature `ceps` path-deps `../../../../ceps-rust-ts-client/ceps-client` (from this crate). Default build stays green without that checkout. SDK feature `js` stays off for both default and `ceps`.
+Feature `ceps` pulls `ceps-client` from that repo (`branch = "dev"`). Default build stays green without it. SDK feature `js` stays off for both default and `ceps`.
 
 Extra args: `CASPERATATUI_ARGS` or `TUI_ARGS` (e.g. `make run-tui TUI_ARGS='--preset testnet'`).
 
@@ -48,7 +48,7 @@ Non-interactive smoke:
 cargo run -p casperatatui --example smoke_status
 # SSE collect always; put+wait when CASPER_SECRET_KEY is set:
 cargo run -p casperatatui --example smoke_write_wait
-# CEP (needs --features ceps + sibling checkout):
+# CEP (needs --features ceps; fetches ceps-client from git):
 cargo run -p casperatatui --features ceps --example smoke_ceps_query
 # install needs NCTL + PEM + WASM path (CEPS_CEP18_WASM or wasm_path):
 # CASPER_SECRET_KEY=… CEPS_CEP18_WASM=…/cep18.wasm \
@@ -68,27 +68,27 @@ CI: path-filtered [ci-casperatatui](../../../.github/workflows/ci-casperatatui.y
 
 ## Keys
 
-| Key              | Action                                            |
-| ---------------- | ------------------------------------------------- |
-| `q`              | Quit and **restore the terminal**                 |
-| Esc              | Back (detail / form); never quits                 |
-| Ctrl+Esc         | Quit (same as `q`)                                |
-| `r`              | Network seance; on Validators reloads auction     |
-| `e`              | Edit RPC URL (Enter applies + refreshes)          |
-| `1`–`9` / `h`    | Network…Wait / Help                               |
-| `l`              | (Blocks) load latest N blocks                     |
-| `/`              | Focus lookup / filter / Wait form                 |
-| `w`              | (Accounts/Validators) reward; (Wait) wait/collect |
-| `o` / `x`        | Load / unload session PEM (`--enable-writes`)     |
-| `b` / `s` / `p`  | (Writes) build / sign / put                       |
-| `t`              | (Writes) one-shot transfer                        |
-| Space            | (Wait SSE) toggle event name                      |
+| Key              | Action                                                                                       |
+| ---------------- | -------------------------------------------------------------------------------------------- |
+| `q`              | Quit and **restore the terminal**                                                            |
+| Esc              | Back (detail / form); never quits                                                            |
+| Ctrl+Esc         | Quit (same as `q`)                                                                           |
+| `r`              | Network seance; on Validators reloads auction                                                |
+| `e`              | Edit RPC URL (Enter applies + refreshes)                                                     |
+| `1`–`9` / `h`    | Network…Wait / Help                                                                          |
+| `l`              | (Blocks) load latest N blocks                                                                |
+| `/`              | Focus lookup / filter / Wait form                                                            |
+| `w`              | (Accounts/Validators) reward; (Wait) wait/collect                                            |
+| `o` / `x`        | Load / unload session PEM (`--enable-writes`)                                                |
+| `b` / `s` / `p`  | (Writes) build / sign / put                                                                  |
+| `t`              | (Writes) one-shot transfer                                                                   |
+| Space            | (Wait SSE) toggle event name                                                                 |
 | Tab / Left/Right | Cycle views (Left/Right always leave Actions; Tab cycles Actions panes / in-screen sections) |
-| `j` `k` / arrows | Scroll body / move lists                          |
-| Enter            | Open / fetch / start form action                  |
-| `:`              | Command palette                                   |
-| mouse select     | Works: mouse capture is **off**                   |
-| Ctrl-C           | Same as quit (signal handler restores TTY)        |
+| `j` `k` / arrows | Scroll body / move lists                                                                     |
+| Enter            | Open / fetch / start form action                                                             |
+| `:`              | Command palette                                                                              |
+| mouse select     | Works: mouse capture is **off**                                                              |
+| Ctrl-C           | Same as quit (signal handler restores TTY)                                                   |
 
 ## Writes (key `8`)
 
@@ -123,7 +123,7 @@ Requires `--enable-writes`. Load a PEM with `--secret-key` or `o`. Flow: Tab kin
 
 ## Actions (key `7`)
 
-RPC + helpers catalog; write methods appear when writes enabled and PEM loaded. With `--features ceps`, a `ceps` group adds CEP-18/78/85/95 info, queries, and installs (sibling `ceps-client`; WASM via action arg or `CEPS_CEP*_WASM` / `CEPS_WASM_PATH`).
+RPC + helpers catalog; write methods appear when writes enabled and PEM loaded. With `--features ceps`, a `ceps` group adds CEP-18/78/85/95 info, queries, and installs (`ceps-client` via git; WASM via action arg or `CEPS_CEP*_WASM` / `CEPS_WASM_PATH`).
 
 ## Command palette (`:`)
 

--- a/examples/desktop/casperatatui/src/ceps_actions.rs
+++ b/examples/desktop/casperatatui/src/ceps_actions.rs
@@ -1,4 +1,4 @@
-//! CEP Actions behind feature `ceps` (ceps-client path-dep).
+//! CEP Actions behind feature `ceps` (ceps-client git dep).
 
 use casper_rust_wasm_sdk::helpers::public_key_from_secret_key;
 use casper_rust_wasm_sdk::types::verbosity::Verbosity;
@@ -7,8 +7,8 @@ use ceps_client::cep78::InstallArgs as Cep78InstallArgs;
 use ceps_client::cep85::InstallArgs as Cep85InstallArgs;
 use ceps_client::cep95::InstallArgs as Cep95InstallArgs;
 use ceps_client::{
-    CallResult, Cep18Client, Cep78Client, Cep85Client, Cep95Client, EventsMode, EventsMode78,
-    TransactionParams,
+    CEP18Client, CEP78Client, CEP85Client, CEP95Client, CallResult, EventsMode, EventsMode78,
+    TransactionParams, Verbosity as CepsVerbosity,
 };
 use serde_json::{json, Value};
 use std::collections::HashMap;
@@ -187,20 +187,52 @@ fn chain_opt(ctx: &CepsCtx<'_>) -> Option<String> {
     }
 }
 
-fn cep18_client(ctx: &CepsCtx<'_>) -> Result<Cep18Client, String> {
-    Cep18Client::new(ctx.rpc, sse_opt(ctx), chain_opt(ctx), Some(ctx.verbosity)).map_err(ceps_err)
+fn cep18_client(ctx: &CepsCtx<'_>) -> Result<CEP18Client, String> {
+    CEP18Client::new(
+        ctx.rpc,
+        sse_opt(ctx),
+        chain_opt(ctx),
+        Some(ceps_verbosity(ctx.verbosity)),
+    )
+    .map_err(ceps_err)
 }
 
-fn cep78_client(ctx: &CepsCtx<'_>) -> Result<Cep78Client, String> {
-    Cep78Client::new(ctx.rpc, sse_opt(ctx), chain_opt(ctx), Some(ctx.verbosity)).map_err(ceps_err)
+fn cep78_client(ctx: &CepsCtx<'_>) -> Result<CEP78Client, String> {
+    CEP78Client::new(
+        ctx.rpc,
+        sse_opt(ctx),
+        chain_opt(ctx),
+        Some(ceps_verbosity(ctx.verbosity)),
+    )
+    .map_err(ceps_err)
 }
 
-fn cep85_client(ctx: &CepsCtx<'_>) -> Result<Cep85Client, String> {
-    Cep85Client::new(ctx.rpc, sse_opt(ctx), chain_opt(ctx), Some(ctx.verbosity)).map_err(ceps_err)
+fn cep85_client(ctx: &CepsCtx<'_>) -> Result<CEP85Client, String> {
+    CEP85Client::new(
+        ctx.rpc,
+        sse_opt(ctx),
+        chain_opt(ctx),
+        Some(ceps_verbosity(ctx.verbosity)),
+    )
+    .map_err(ceps_err)
 }
 
-fn cep95_client(ctx: &CepsCtx<'_>) -> Result<Cep95Client, String> {
-    Cep95Client::new(ctx.rpc, sse_opt(ctx), chain_opt(ctx), Some(ctx.verbosity)).map_err(ceps_err)
+fn cep95_client(ctx: &CepsCtx<'_>) -> Result<CEP95Client, String> {
+    CEP95Client::new(
+        ctx.rpc,
+        sse_opt(ctx),
+        chain_opt(ctx),
+        Some(ceps_verbosity(ctx.verbosity)),
+    )
+    .map_err(ceps_err)
+}
+
+fn ceps_verbosity(v: Verbosity) -> CepsVerbosity {
+    match v {
+        Verbosity::Low => CepsVerbosity::Low,
+        Verbosity::Medium => CepsVerbosity::Medium,
+        Verbosity::High => CepsVerbosity::High,
+    }
 }
 
 fn endpoints_json(cep: &str, rpc: &str, sse: Option<&str>, chain: &str) -> Value {
@@ -218,28 +250,28 @@ fn package_opt(args: &HashMap<String, String>) -> Option<String> {
         .filter(|s| !s.is_empty())
 }
 
-fn bind_contract(client: &mut Cep18Client, args: &HashMap<String, String>) -> Result<(), String> {
+fn bind_contract(client: &mut CEP18Client, args: &HashMap<String, String>) -> Result<(), String> {
     let hash = required(args, "contract_hash")?;
     client
         .set_contract_hash(&hash, package_opt(args).as_deref())
         .map_err(ceps_err)
 }
 
-fn bind_contract78(client: &mut Cep78Client, args: &HashMap<String, String>) -> Result<(), String> {
+fn bind_contract78(client: &mut CEP78Client, args: &HashMap<String, String>) -> Result<(), String> {
     let hash = required(args, "contract_hash")?;
     client
         .set_contract_hash(&hash, package_opt(args).as_deref())
         .map_err(ceps_err)
 }
 
-fn bind_contract85(client: &mut Cep85Client, args: &HashMap<String, String>) -> Result<(), String> {
+fn bind_contract85(client: &mut CEP85Client, args: &HashMap<String, String>) -> Result<(), String> {
     let hash = required(args, "contract_hash")?;
     client
         .set_contract_hash(&hash, package_opt(args).as_deref())
         .map_err(ceps_err)
 }
 
-fn bind_contract95(client: &mut Cep95Client, args: &HashMap<String, String>) -> Result<(), String> {
+fn bind_contract95(client: &mut CEP95Client, args: &HashMap<String, String>) -> Result<(), String> {
     let hash = required(args, "contract_hash")?;
     client
         .set_contract_hash(&hash, package_opt(args).as_deref())
@@ -258,7 +290,7 @@ async fn cep18_install(args: &HashMap<String, String>, ctx: &CepsCtx<'_>) -> Res
 
     let client = cep18_client(ctx)?;
     let install_args = Cep18InstallArgs::new(&name, &symbol, decimals, &total_supply)
-        .with_events_mode(EventsMode::Ces)
+        .with_events_mode(EventsMode::CES)
         .with_mint_and_burn(true);
     let tx = transaction_params(pem, &payment, ctx);
     let put = client
@@ -270,12 +302,10 @@ async fn cep18_install(args: &HashMap<String, String>, ctx: &CepsCtx<'_>) -> Res
     if let Ok(pk) = public_key_from_secret_key(pem) {
         let mut client = client;
         if let Ok(contract) = client
-            .core()
             .get_account_named_key(&pk, &format!("cep18_contract_hash_{name}"))
             .await
         {
             let package = client
-                .core()
                 .get_account_named_key(&pk, &format!("cep18_contract_package_{name}"))
                 .await
                 .ok();
@@ -301,7 +331,7 @@ async fn cep78_install(args: &HashMap<String, String>, ctx: &CepsCtx<'_>) -> Res
 
     let client = cep78_client(ctx)?;
     let install_args =
-        Cep78InstallArgs::new(&name, &symbol, supply).with_events_mode(EventsMode78::Ces);
+        Cep78InstallArgs::new(&name, &symbol, supply).with_events_mode(EventsMode78::CES);
     let tx = transaction_params(pem, &payment, ctx);
     let put = client
         .install(&install_args, &wasm, &tx)
@@ -312,12 +342,10 @@ async fn cep78_install(args: &HashMap<String, String>, ctx: &CepsCtx<'_>) -> Res
     if let Ok(pk) = public_key_from_secret_key(pem) {
         let mut client = client;
         if let Ok(contract) = client
-            .core()
             .get_account_named_key(&pk, &format!("cep78_contract_hash_{name}"))
             .await
         {
             let package = client
-                .core()
                 .get_account_named_key(&pk, &format!("cep78_contract_package_{name}"))
                 .await
                 .ok();
@@ -342,7 +370,7 @@ async fn cep85_install(args: &HashMap<String, String>, ctx: &CepsCtx<'_>) -> Res
 
     let client = cep85_client(ctx)?;
     let install_args = Cep85InstallArgs::new(&name, &uri)
-        .with_events_mode(EventsMode::Ces)
+        .with_events_mode(EventsMode::CES)
         .with_enable_burn(true);
     let tx = transaction_params(pem, &payment, ctx);
     let put = client
@@ -354,12 +382,10 @@ async fn cep85_install(args: &HashMap<String, String>, ctx: &CepsCtx<'_>) -> Res
     if let Ok(pk) = public_key_from_secret_key(pem) {
         let mut client = client;
         if let Ok(contract) = client
-            .core()
             .get_account_named_key(&pk, &format!("cep85_contract_hash_{name}"))
             .await
         {
             let package = client
-                .core()
                 .get_account_named_key(&pk, &format!("cep85_contract_package_{name}"))
                 .await
                 .ok();

--- a/examples/desktop/casperatatui/src/views/help.rs
+++ b/examples/desktop/casperatatui/src/views/help.rs
@@ -68,7 +68,7 @@ pub fn draw_help(frame: &mut Frame, area: Rect, model: &AppModel) {
                 .fg(Color::Cyan)
                 .add_modifier(Modifier::BOLD),
         )),
-        Line::from("  Build with --features ceps (sibling ceps-rust-ts-client/ceps-client)."),
+        Line::from("  Build with --features ceps (ceps-client from git, branch dev)."),
         Line::from("  SDK feature js stays off. CEP install needs --enable-writes + PEM + policy."),
         Line::from(""),
         Line::from(Span::styled(

--- a/examples/desktop/tauri/src-tauri/Cargo.toml
+++ b/examples/desktop/tauri/src-tauri/Cargo.toml
@@ -2,7 +2,6 @@
 name = "casper-signing-desk"
 version = "0.1.0"
 description = "Casper signing desk: native PEM sign/verify, transfer/stake, multisig approvals"
-authors = ["casper-ecosystem"]
 edition = "2021"
 rust-version = "1.88"
 license = "Apache-2.0"
@@ -21,7 +20,7 @@ tauri-build = { version = "2", features = [] }
 
 [dependencies]
 anyhow = "1"
-casper-rust-wasm-sdk = { path = "../../../..", default-features = false, features = [
+casper-rust-wasm-sdk = { git = "https://github.com/casper-ecosystem/casper-rust-wasm-sdk", branch = "dev", default-features = false, features = [
   "transaction",
   "helpers",
   "watcher",


### PR DESCRIPTION
## Summary
- Point `casperatatui` and Signing Desk (`casper-signing-desk`) at `casper-rust-wasm-sdk` from git (`casper-ecosystem`, `branch = "dev"`) instead of in-tree path deps.
- Point optional `casperatatui` feature `ceps` at `ceps-client` from git (`Interchouette-ITC/ceps-rust-ts-client`, `branch = "dev"`).
- Sync tip CEP client API usage (`CEP*Client`, `EventsMode::CES`, public `get_account_named_key`) and map `Verbosity` at the CEPS boundary so path/git SDK crates do not need a workspace `[patch]`.

## Test plan
- [x] `cargo check -p casperatatui --features ceps`
- [x] `cargo check -p casper-signing-desk`
- [x] `make check-lint-casperatatui`
- [x] `cargo clippy -p casperatatui --all-targets --features ceps --no-deps -- -D warnings`


Made with [Cursor](https://cursor.com)