### PR TITLE
chore: drop Cursor sandbox env wrappers from make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -214,24 +214,19 @@ mcp-test-live:
 # --- Casperatatui (examples/desktop/casperatatui) ---
 
 run-casperatatui:
-	env -u CARGO_TARGET_DIR -u PLAYWRIGHT_BROWSERS_PATH \
-		cargo run -p casperatatui -- --preset nctl $(CASPERATATUI_ARGS) $(TUI_ARGS)
+	cargo run -p casperatatui -- --preset nctl $(CASPERATATUI_ARGS) $(TUI_ARGS)
 
 # Needs network once to fetch Interchouette-ITC/ceps-rust-ts-client (git dep, branch dev).
 run-casperatatui-ceps:
-	env -u CARGO_TARGET_DIR -u PLAYWRIGHT_BROWSERS_PATH \
-		cargo run -p casperatatui --features ceps -- --preset nctl $(CASPERATATUI_ARGS) $(TUI_ARGS)
+	cargo run -p casperatatui --features ceps -- --preset nctl $(CASPERATATUI_ARGS) $(TUI_ARGS)
 
 build-casperatatui-release:
-	env -u CARGO_TARGET_DIR -u PLAYWRIGHT_BROWSERS_PATH \
-		cargo build -p casperatatui --release
+	cargo build -p casperatatui --release
 
 # Not part of root wasm clippy matrix.
 check-lint-casperatatui:
-	env -u CARGO_TARGET_DIR -u PLAYWRIGHT_BROWSERS_PATH \
-		cargo clippy -p casperatatui --all-targets --no-deps -- -D warnings
-	env -u CARGO_TARGET_DIR -u PLAYWRIGHT_BROWSERS_PATH \
-		cargo fmt -p casperatatui -- --check
+	cargo clippy -p casperatatui --all-targets --no-deps -- -D warnings
+	cargo fmt -p casperatatui -- --check
 
 # Short aliases (same recipes).
 run-tui: run-casperatatui
@@ -245,18 +240,14 @@ check-lint-tui: check-lint-casperatatui
 # --- Signing desk (examples/desktop/tauri) ---
 
 run-tauri:
-	env -u CARGO_TARGET_DIR -u PLAYWRIGHT_BROWSERS_PATH \
-		$(MAKE) -C examples/desktop/tauri run
+	$(MAKE) -C examples/desktop/tauri run
 
 build-tauri:
-	env -u CARGO_TARGET_DIR -u PLAYWRIGHT_BROWSERS_PATH \
-		$(MAKE) -C examples/desktop/tauri build
+	$(MAKE) -C examples/desktop/tauri build
 
 check-lint-tauri:
-	env -u CARGO_TARGET_DIR -u PLAYWRIGHT_BROWSERS_PATH \
-		cargo clippy -p casper-signing-desk --all-targets --no-deps -- -D warnings
-	env -u CARGO_TARGET_DIR -u PLAYWRIGHT_BROWSERS_PATH \
-		cargo fmt -p casper-signing-desk -- --check
+	cargo clippy -p casper-signing-desk --all-targets --no-deps -- -D warnings
+	cargo fmt -p casper-signing-desk -- --check
 
 .PHONY: run-tauri build-tauri check-lint-tauri
 

--- a/examples/desktop/casperatatui/README.md
+++ b/examples/desktop/casperatatui/README.md
@@ -6,14 +6,14 @@ Desktop example beside Electron / Node under `examples/desktop/`. JSON-RPC only 
 
 ## Run
 
-From the repo root (clears Cursor sandbox `CARGO_TARGET_DIR` if set):
+From the repo root:
 
 ```bash
 make run-casperatatui
 # alias:
 make run-tui
 # or
-env -u CARGO_TARGET_DIR cargo run -p casperatatui -- --preset nctl
+cargo run -p casperatatui -- --preset nctl
 ```
 
 CEP / CEPS Actions (optional [`ceps-client`](https://github.com/Interchouette-ITC/ceps-rust-ts-client)):
@@ -22,7 +22,7 @@ CEP / CEPS Actions (optional [`ceps-client`](https://github.com/Interchouette-IT
 make run-casperatatui-ceps
 # alias: make run-tui-ceps
 # or
-env -u CARGO_TARGET_DIR cargo run -p casperatatui --features ceps -- --preset nctl
+cargo run -p casperatatui --features ceps -- --preset nctl
 ```
 
 Feature `ceps` pulls `ceps-client` from that repo (`branch = "dev"`). Default build stays green without it. SDK feature `js` stays off for both default and `ceps`.

--- a/examples/desktop/tauri/README.md
+++ b/examples/desktop/tauri/README.md
@@ -58,14 +58,14 @@ https://v2.tauri.app/start/prerequisites/
 
 ## Run
 
-From the repo root (clears Cursor sandbox `CARGO_TARGET_DIR` if set):
+From the repo root:
 
 ```bash
 make run-tauri
 # or
 cd examples/desktop/tauri
 npm install
-env -u CARGO_TARGET_DIR npm run tauri -- dev
+npm run tauri -- dev
 ```
 
 Presets: `nctl` (default), `testnet`, `mainnet`. Override RPC / events in the forms when needed.


### PR DESCRIPTION
## Summary
- Remove Cursor sandbox `env -u CARGO_TARGET_DIR` / `PLAYWRIGHT_BROWSERS_PATH` wrappers from Make and desktop example READMEs.
- Prefer plain `cargo` / `make` into the repo tree.

## Test plan
- [ ] `make run-casperatatui` / `make run-tauri` recipes still work
- [ ] Builds land under repo `target/`

Made with [Cursor](https://cursor.com)