### PR TITLE
chore(deps): migrate MCP to rmcp 3.1.2 and bump SDK crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,15 +3,6 @@
 version = 4
 
 [[package]]
-name = "addr2line"
-version = "0.25.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
-dependencies = [
- "gimli",
-]
-
-[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -92,7 +83,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -103,7 +94,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -236,28 +227,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-stream"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
-dependencies = [
- "async-stream-impl",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-stream-impl"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
 name = "async-task"
 version = "4.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -326,7 +295,6 @@ checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
  "bytes",
- "form_urlencoded",
  "futures-util",
  "http",
  "http-body",
@@ -342,13 +310,11 @@ dependencies = [
  "serde_core",
  "serde_json",
  "serde_path_to_error",
- "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tower 0.5.3",
+ "tower",
  "tower-layer",
  "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -367,31 +333,6 @@ dependencies = [
  "sync_wrapper",
  "tower-layer",
  "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "backtrace"
-version = "0.3.76"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
-dependencies = [
- "addr2line",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
- "windows-link 0.2.1",
-]
-
-[[package]]
-name = "backtrace-ext"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "537beee3be4a18fb023b570f80e3ae28003db9167a751266b259926e25539d50"
-dependencies = [
- "backtrace",
 ]
 
 [[package]]
@@ -423,6 +364,12 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
 
 [[package]]
 name = "base64ct"
@@ -706,7 +653,7 @@ dependencies = [
  "casper-binary-port",
  "casper-types",
  "futures",
- "gloo-utils",
+ "gloo-utils 0.2.0",
  "js-sys",
  "thiserror 2.0.19",
  "tokio",
@@ -750,7 +697,7 @@ version = "2.2.2"
 dependencies = [
  "async-trait",
  "base16",
- "base64 0.22.1",
+ "base64 0.23.1",
  "bigdecimal",
  "blake2 0.10.6",
  "casper-binary-port",
@@ -758,18 +705,18 @@ dependencies = [
  "casper-client",
  "casper-types",
  "chrono",
- "ctor 1.0.12",
+ "ctor 1.0.13",
  "dotenvy",
  "futures-util",
- "getrandom 0.3.4",
- "gloo-utils",
+ "getrandom 0.4.3",
+ "gloo-utils 0.3.0",
  "hex",
  "humantime",
  "js-sys",
  "num-traits",
  "once_cell",
- "rand 0.9.5",
- "reqwest 0.12.28",
+ "rand 0.10.2",
+ "reqwest 0.13.4",
  "sdk_tests",
  "serde",
  "serde_json",
@@ -811,12 +758,13 @@ name = "casper-rust-wasm-sdk-mcp"
 version = "2.2.2"
 dependencies = [
  "anyhow",
+ "axum",
  "casper-rust-wasm-sdk 2.2.2",
  "casper-types",
  "clap",
  "hex",
- "mcpkit",
- "mcpkit-axum",
+ "rmcp",
+ "schemars 1.2.2",
  "serde",
  "serde_json",
  "tokio",
@@ -1315,9 +1263,9 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d83cb7e7a873830708d6b02a78cd36a592c6fa14bf267b68725103b85c0d77f"
+checksum = "914a755b7c2d4af2bdcff7ce1739e2db9a1b81a9b07123d8015786ae03c0980d"
 dependencies = [
  "link-section",
  "linktime-proc-macro",
@@ -1369,16 +1317,6 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
-dependencies = [
- "darling_core 0.20.11",
- "darling_macro 0.20.11",
-]
-
-[[package]]
-name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
@@ -1395,20 +1333,6 @@ checksum = "88490bf1b990d87eaaa7ac8aa887f629a08e7359765b4911faf63c3763347d23"
 dependencies = [
  "darling_core 0.24.0",
  "darling_macro 0.24.0",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn 2.0.119",
 ]
 
 [[package]]
@@ -1439,17 +1363,6 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
-dependencies = [
- "darling_core 0.20.11",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
-name = "darling_macro"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
@@ -1468,20 +1381,6 @@ dependencies = [
  "darling_core 0.24.0",
  "quote",
  "syn 3.0.3",
-]
-
-[[package]]
-name = "dashmap"
-version = "6.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
- "hashbrown 0.14.5",
- "lock_api",
- "once_cell",
- "parking_lot_core",
 ]
 
 [[package]]
@@ -1623,7 +1522,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1894,7 +1793,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2342,12 +2241,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gimli"
-version = "0.32.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
-
-[[package]]
 name = "gio"
 version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2437,6 +2330,19 @@ name = "gloo-utils"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b5555354113b18c547c1d3a98fbf7fb32a9ff4f6fa112ce823a21641a0ba3aa"
+dependencies = [
+ "js-sys",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "gloo-utils"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4202275d95a142fa209a1e35e91c250a710c5600731372cd3464a39ed01573d6"
 dependencies = [
  "js-sys",
  "serde",
@@ -2543,12 +2449,6 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-
-[[package]]
-name = "hashbrown"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
@@ -2984,12 +2884,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "is_ci"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7655c9839580ee829dfacba1d1278c2b7883e50a277ff7541299489d6bdfdc45"
-
-[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3097,9 +2991,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.103"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
+checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -3259,15 +3153,15 @@ dependencies = [
 
 [[package]]
 name = "link-section"
-version = "0.19.2"
+version = "0.19.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee1a0d6e252afe82e7bc2db42fba60e02ddf3b1accaf8cb21d96e34ba61f3d4"
+checksum = "39c29a617ce3df32c08497bdc1ab6e2376e0b17948ac166a2fbe5977c5954cd9"
 
 [[package]]
 name = "linktime-proc-macro"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "348d0075b1fc163b26d72a7f75fc5141daf2fd1bdf128d873cbaf6785d495bdf"
+checksum = "7e57c38c1e860fd37c604281cdfb1dd2216977fd76a50f85ba2f388ef3219616"
 
 [[package]]
 name = "linux-raw-sys"
@@ -3354,129 +3248,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
-name = "mcpkit"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "611987760f629f10e9ed341e17257f06d9d84a2d4a1fb5f51ad5494ee949a64f"
-dependencies = [
- "mcpkit-client",
- "mcpkit-core",
- "mcpkit-macros",
- "mcpkit-server",
- "mcpkit-transport",
-]
-
-[[package]]
-name = "mcpkit-axum"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "857b0619fafbd36edbfb38eae4e0ce7b5b0d72fa6ed732a6cba50225878a09c1"
-dependencies = [
- "async-stream",
- "axum",
- "dashmap",
- "futures",
- "mcpkit-core",
- "mcpkit-server",
- "mcpkit-transport",
- "serde",
- "serde_json",
- "thiserror 2.0.19",
- "tokio",
- "tower 0.4.13",
- "tower-http 0.5.2",
- "tracing",
- "uuid",
-]
-
-[[package]]
-name = "mcpkit-client"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01f0933987f0e47cf3ed8ed5f66e668709fda49fb1b53d52a2896acbbf3c1fae"
-dependencies = [
- "async-lock",
- "futures",
- "mcpkit-core",
- "mcpkit-transport",
- "serde",
- "serde_json",
- "thiserror 2.0.19",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "mcpkit-core"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56b6092b7d3accd451fd3b985915c8bab18825d8509e2086316fdc596fd81090"
-dependencies = [
- "base64 0.22.1",
- "chrono",
- "event-listener",
- "getrandom 0.2.17",
- "miette",
- "rand 0.8.7",
- "serde",
- "serde_json",
- "sha2",
- "thiserror 2.0.19",
- "url",
- "uuid",
-]
-
-[[package]]
-name = "mcpkit-macros"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17d18e85040a2e5ba06bf506fa8ce3575ec2e2a8c0d6fa5669b538f5a7615aba"
-dependencies = [
- "darling 0.20.11",
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
-name = "mcpkit-server"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "864e40f35b80805cc99e2a311d839f02fa3f24c9c980e6bcebb66a76e864d08d"
-dependencies = [
- "futures",
- "mcpkit-core",
- "mcpkit-transport",
- "serde",
- "serde_json",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "mcpkit-transport"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97ca03ba82a2a6c3cf4d5723609467ac41d4bf885a795513b8a62feeae2a5a43"
-dependencies = [
- "async-lock",
- "async-trait",
- "bytes",
- "event-listener",
- "futures",
- "mcpkit-core",
- "pin-project-lite",
- "rand 0.8.7",
- "reqwest 0.12.28",
- "serde",
- "serde_json",
- "thiserror 2.0.19",
- "tokio",
- "tracing",
- "url",
-]
-
-[[package]]
 name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3495,36 +3266,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "miette"
-version = "7.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f98efec8807c63c752b5bd61f862c165c115b0a35685bdcfd9238c7aeb592b7"
-dependencies = [
- "backtrace",
- "backtrace-ext",
- "cfg-if",
- "miette-derive",
- "owo-colors",
- "supports-color",
- "supports-hyperlinks",
- "supports-unicode",
- "terminal_size",
- "textwrap",
- "unicode-width 0.1.14",
-]
-
-[[package]]
-name = "miette-derive"
-version = "7.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
 ]
 
 [[package]]
@@ -3579,7 +3320,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.19",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3670,7 +3411,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3991,15 +3732,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "object"
-version = "0.37.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4097,12 +3829,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "owo-colors"
-version = "4.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
-
-[[package]]
 name = "palette"
 version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4188,6 +3914,12 @@ dependencies = [
  "smallvec",
  "windows-link 0.2.1",
 ]
+
+[[package]]
+name = "pastey"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
 name = "pem"
@@ -4598,7 +4330,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4742,7 +4474,7 @@ dependencies = [
  "thiserror 2.0.19",
  "unicode-segmentation",
  "unicode-truncate",
- "unicode-width 0.2.2",
+ "unicode-width",
 ]
 
 [[package]]
@@ -4805,7 +4537,7 @@ dependencies = [
  "strum 0.28.0",
  "time",
  "unicode-segmentation",
- "unicode-width 0.2.2",
+ "unicode-width",
 ]
 
 [[package]]
@@ -4919,8 +4651,8 @@ dependencies = [
  "tokio-native-tls",
  "tokio-rustls",
  "tokio-util 0.7.19",
- "tower 0.5.3",
- "tower-http 0.6.11",
+ "tower",
+ "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -4954,8 +4686,8 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-util 0.7.19",
- "tower 0.5.3",
- "tower-http 0.6.11",
+ "tower",
+ "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -5013,10 +4745,48 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustc-demangle"
-version = "0.1.28"
+name = "rmcp"
+version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b74b56ffa8bb2830709a538c2cbcae9aa062db0d2a42563bfb09bdaae44020eb"
+checksum = "c8dddc5b1924b9a59fba420166160ca2c4663a4e01803e52eda33070f56d63c8"
+dependencies = [
+ "async-trait",
+ "base64 0.23.1",
+ "bytes",
+ "chrono",
+ "futures",
+ "http",
+ "http-body",
+ "http-body-util",
+ "pastey",
+ "pin-project-lite",
+ "rand 0.10.2",
+ "rmcp-macros",
+ "schemars 1.2.2",
+ "serde",
+ "serde_json",
+ "sse-stream",
+ "thiserror 2.0.19",
+ "tokio",
+ "tokio-stream",
+ "tokio-util 0.7.19",
+ "tower-service",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "rmcp-macros"
+version = "3.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6898e24cd16342b59bfa8a53c2c04b9cf62fc8a2cfea57b9c038b09984bfc521"
+dependencies = [
+ "darling 0.24.0",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn 3.0.3",
+]
 
 [[package]]
 name = "rustc-hash"
@@ -5043,7 +4813,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5119,7 +4889,7 @@ checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
 dependencies = [
  "dyn-clone",
  "indexmap 1.9.3",
- "schemars_derive",
+ "schemars_derive 0.8.22",
  "serde",
  "serde_json",
  "url",
@@ -5144,8 +4914,10 @@ version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "687274d293b6cdc6e73e0fee520bf2049650090d7164f87672d212a3c530cf4a"
 dependencies = [
+ "chrono",
  "dyn-clone",
  "ref-cast",
+ "schemars_derive 1.2.2",
  "serde",
  "serde_json",
 ]
@@ -5158,8 +4930,20 @@ checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
 dependencies = [
  "proc-macro2",
  "quote",
- "serde_derive_internals",
+ "serde_derive_internals 0.29.1",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98c67716b46af2f0b8cf752abc930f6f9aecfbf671ecfb531db8a31dbe4e2ba"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals 0.30.0",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -5315,6 +5099,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f852137cce035d6a4df67ccce505ff6b3e9fd3a10e3e52b24dc71e650bb1a9bd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -5544,7 +5339,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5603,6 +5398,19 @@ checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
  "der",
+]
+
+[[package]]
+name = "sse-stream"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c123f296ade4ec4b8b0f6162116e6629f5146922ca5ab40ca9d3c2e73ab4761e"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http-body",
+ "http-body-util",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -5691,27 +5499,6 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
-
-[[package]]
-name = "supports-color"
-version = "3.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c64fc7232dd8d2e4ac5ce4ef302b1d81e0b80d055b9d77c7c4f51f6aa4c867d6"
-dependencies = [
- "is_ci",
-]
-
-[[package]]
-name = "supports-hyperlinks"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e396b6523b11ccb83120b115a0b7366de372751aa6edf19844dfb13a6af97e91"
-
-[[package]]
-name = "supports-unicode"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
 
 [[package]]
 name = "swift-rs"
@@ -6181,7 +5968,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6203,17 +5990,7 @@ dependencies = [
  "parking_lot",
  "rustix",
  "signal-hook",
- "windows-sys 0.60.2",
-]
-
-[[package]]
-name = "terminal_size"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
-dependencies = [
- "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6277,16 +6054,6 @@ dependencies = [
  "wezterm-dynamic",
  "wezterm-input-types",
  "winapi",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
-dependencies = [
- "unicode-linebreak",
- "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -6440,6 +6207,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3d06f0b082ba57c26b79407372e57cf2a1e28124f78e9479fe80322cf53420b"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
  "tokio",
 ]
 
@@ -6611,17 +6389,6 @@ checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "tower"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
-dependencies = [
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
@@ -6633,24 +6400,6 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tower-http"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
-dependencies = [
- "bitflags 2.13.1",
- "bytes",
- "http",
- "http-body",
- "http-body-util",
- "pin-project-lite",
- "tower-layer",
- "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -6665,7 +6414,7 @@ dependencies = [
  "http",
  "http-body",
  "pin-project-lite",
- "tower 0.5.3",
+ "tower",
  "tower-layer",
  "tower-service",
  "url",
@@ -6689,7 +6438,6 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
- "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -6764,7 +6512,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.19",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6799,7 +6547,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6862,12 +6610,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
-name = "unicode-linebreak"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
-
-[[package]]
 name = "unicode-segmentation"
 version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6881,14 +6623,8 @@ checksum = "16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5"
 dependencies = [
  "itertools 0.14.0",
  "unicode-segmentation",
- "unicode-width 0.2.2",
+ "unicode-width",
 ]
-
-[[package]]
-name = "unicode-width"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"
@@ -7047,9 +6783,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
+checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -7060,9 +6796,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.76"
+version = "0.4.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
+checksum = "6b7777d5cc23d0e91404e53ce2d5e8ec7acae3026b16233dba62cd3246457950"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -7070,9 +6806,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
+checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -7080,9 +6816,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
+checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -7093,9 +6829,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
+checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
 dependencies = [
  "unicode-ident",
 ]
@@ -7128,9 +6864,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.103"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
+checksum = "c435338968042f4f59a557f690a253676d47ce13ceb55d70100e7facf6620a30"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -7341,7 +7077,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,14 +72,14 @@ casper-types = { version = "7.1.1", default-features = false, features = [
 casper-client = { version = "5", default-features = false }
 casper-binary-port = { version = "1.2.1", optional = true }
 casper-binary-port-access = { version = "0.1.0", optional = true }
-rand = { version = "0.9.2", default-features = false, features = [
+rand = { version = "0.10", default-features = false, features = [
   "thread_rng",
 ] }
-getrandom = { version = "0.3.3", default-features = false }
-wasm-bindgen = { version = "0.2.104", optional = true }
-wasm-bindgen-futures = { version = "*", optional = true }
-js-sys = { version = "*", optional = true }
-gloo-utils = { version = "0.2", optional = true, default-features = false, features = [
+getrandom = { version = "0.4", default-features = false }
+wasm-bindgen = { version = "0.2.127", optional = true }
+wasm-bindgen-futures = { version = "0.4", optional = true }
+js-sys = { version = "0.3", optional = true }
+gloo-utils = { version = "0.3", optional = true, default-features = false, features = [
   "serde",
 ] }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
@@ -90,18 +90,18 @@ num-traits = "0.2"
 humantime = "2"
 thiserror = "2"
 base16 = "0.2"
-base64 = { version = "0.22", default-features = false, features = ["alloc"] }
+base64 = { version = "0.23", default-features = false, features = ["alloc"] }
 hex = { version = "0.4", default-features = false }
 bigdecimal = "0.4"
 blake2 = { version = "0.10", default-features = false }
-reqwest = { version = "0.12.12", default-features = false, features = [
+reqwest = { version = "0.13", default-features = false, features = [
   "stream",
 ] }
-futures-util = "*"
+futures-util = "0.3"
 async-trait = "0.1"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-getrandom = { version = "0.3.3", default-features = false, features = [
+getrandom = { version = "0.4", default-features = false, features = [
   "wasm_js",
 ] }
 
@@ -133,7 +133,7 @@ wasm-opt = ["-O", "-all"]
 [dev-dependencies]
 sdk_tests = { path = "tests/integration/rust" }
 tokio = { version = "1", features = ["full"] }
-ctor = "*"
+ctor = "1"
 dotenvy = "0.15.7"
 
 [patch.crates-io]

--- a/mcp/Cargo.toml
+++ b/mcp/Cargo.toml
@@ -2,7 +2,7 @@
 name = "casper-rust-wasm-sdk-mcp"
 version = "2.2.2"
 edition = "2021"
-rust-version = "1.85"
+rust-version = "1.88"
 license = "Apache-2.0"
 description = "MCP server for casper-rust-wasm-sdk (stdio + Streamable HTTP)"
 readme = "README.md"
@@ -41,14 +41,24 @@ SSE = ["watcher", "casper-rust-wasm-sdk/SSE"]
 
 [dependencies]
 anyhow = "1"
+axum = { version = "0.8", default-features = false, features = [
+  "http1",
+  "tokio",
+  "json",
+] }
 casper-rust-wasm-sdk = { path = "..", default-features = false }
-casper-types = { version = "7.0.0", default-features = false, features = [
+casper-types = { version = "7.1.1", default-features = false, features = [
   "datasize",
 ] }
 clap = { version = "4", features = ["derive", "env"] }
 hex = "0.4"
-mcpkit = "0.7"
-mcpkit-axum = "0.7"
+rmcp = { version = "3.1.2", default-features = false, features = [
+  "server",
+  "macros",
+  "transport-io",
+  "transport-streamable-http-server",
+] }
+schemars = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/mcp/PATTERNS.md
+++ b/mcp/PATTERNS.md
@@ -1,6 +1,6 @@
 # MCP patterns
 
-How this product’s `mcp/` crate is laid out, built, and run.
+How this product's `mcp/` crate is laid out, built, and run.
 
 ---
 
@@ -16,13 +16,14 @@ mcp/
   src/
     main.rs             # clap + init_logging + run/run_http
     lib.rs              # mods + re-exports
-    server.rs           # #[mcp_server] + handlers + version test
+    server.rs           # #[tool_router] + ServerHandler + version test
+    tool_args.rs        # Parameters<T> JSON-schema structs
     sdk_handle.rs       # SDK::new from env
-    format.rs           # Result → ToolOutput
+    format.rs           # Result → CallToolResult
     tools/              # feature-gated tool modules
 ```
 
-Keep mcpkit **out** of the root wasm SDK `Cargo.toml`.
+Keep rmcp **out** of the root wasm SDK `Cargo.toml`.
 
 ---
 
@@ -30,12 +31,19 @@ Keep mcpkit **out** of the root wasm SDK `Cargo.toml`.
 
 ```toml
 edition = "2021"
-rust-version = "1.85"
+rust-version = "1.88"
 
 anyhow = "1"
+axum = { version = "0.8", default-features = false, features = ["http1", "tokio", "json"] }
 clap = { version = "4", features = ["derive", "env"] }
-mcpkit = "0.7"
-mcpkit-axum = "0.7"
+rmcp = { version = "3.1.2", default-features = false, features = [
+  "server",
+  "macros",
+  "transport-io",
+  "transport-streamable-http-server",
+] }
+schemars = "1"
+serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 tracing = "0.1"
@@ -44,9 +52,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 casper-rust-wasm-sdk = { path = ".." }
 ```
 
-Features: `default = ["full"]`, `full = ["rpc", "binary-port", "transaction", "deploy", "contract", "helpers", "write"]`.
-
-Release profile (family): `lto`, `codegen-units=1`, `panic=abort`, `strip=symbols`, `opt-level=s`.
+Features: `default = ["full"]`, `full = ["rpc", "binary-port", "transaction", "deploy", "contract", "helpers", "write", "watcher"]`.
 
 **Workspace:** root must be a workspace with `members = [".", "mcp"]` so `[patch.crates-io]` applies.
 
@@ -56,7 +62,7 @@ Release profile (family): `lto`, `codegen-units=1`, `panic=abort`, `strip=symbol
 
 | Flag       | Env                   | Default        |
 | ---------- | --------------------- | -------------- |
-| `--http`   | `MCP_HTTP` | false (stdio)  |
+| `--http`   | `MCP_HTTP`            | false (stdio)  |
 | `--listen` | `CASPER_SDK_MCP_ADDR` | `0.0.0.0:5790` |
 
 SDK env: `CASPER_RPC_URL`, `CASPER_NODE_URL`, `CASPER_VERBOSITY`, `RUST_LOG`.
@@ -69,51 +75,51 @@ HTTP MCP for this product: **`5790`**. Webclient SPA proxies `/mcp` on **`8080`*
 
 - Writer: **stderr**
 - Default filter: **warn** (`RUST_LOG` override)
-- `with_ansi(false)` — avoid ANSI so clients do not treat colored stderr as errors
+- `with_ansi(false)` - avoid ANSI so clients do not treat colored stderr as errors
 
 ---
 
 ## Transports
 
 ```rust
-pub async fn run() -> Result<(), McpError> {
-    let transport = StdioTransport::new();
-    let server = ServerBuilder::new(Handle)
-        .with_tools(Handle)
-        .build();
-    server.serve(transport).await
+pub async fn run() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let server = CasperSdkMcp;
+    let service = server.serve(stdio()).await?;
+    service.waiting().await?;
+    Ok(())
 }
 
 pub async fn run_http(addr: &str) -> std::io::Result<()> {
-    McpRouter::new(Handle).serve(addr).await
+    let service = StreamableHttpService::new(|| Ok(CasperSdkMcp), /* session mgr */, config);
+    let app = axum::Router::new()
+        .route("/mcp", axum::routing::any_service(service));
+    axum::serve(listener, app).await
 }
 ```
 
-Stub empty `ResourceHandler` / `PromptHandler` (`invalid_params` on unknown).
+Tools only (`ServerHandler::get_info` enables tools). No resource/prompt handlers.
 
 ---
 
 ## Version sync test
 
 ```rust
-let needle = format!(
-    r#"#[mcp_server(name = "casper-rust-wasm-sdk", version = "{}")]"#,
-    env!("CARGO_PKG_VERSION")
-);
-assert!(include_str!("server.rs").contains(&needle));
+let info = CasperSdkMcp.get_info();
+assert_eq!(info.server_info.version, env!("CARGO_PKG_VERSION"));
+assert_eq!(info.server_info.name.as_ref(), "casper-rust-wasm-sdk");
 ```
 
 ---
 
 ## Makefile targets
 
-| Target | Role |
-| --- | --- |
-| `mcp-build` | release build of mcp package |
-| `run-mcp` | stdio (host cargo) |
-| `mcp-http` | slim Docker → `http://127.0.0.1:5790/mcp` |
-| `run-mcp-http` | host cargo HTTP on `127.0.0.1:5790` |
-| `mcp-test` | `cargo test -p casper-rust-wasm-sdk-mcp` |
+| Target         | Role                                      |
+| -------------- | ----------------------------------------- |
+| `mcp-build`    | release build of mcp package              |
+| `run-mcp`      | stdio (host cargo)                        |
+| `mcp-http`     | slim Docker → `http://127.0.0.1:5790/mcp` |
+| `run-mcp-http` | host cargo HTTP on `127.0.0.1:5790`       |
+| `mcp-test`     | `cargo test -p casper-rust-wasm-sdk-mcp`  |
 
 Cursor/agents image: `interchouette/casper-rust-wasm-sdk-mcp:{dev,latest,$APP_VERSION}`. SPA embeds the same binary: `interchouette/casper-webclient`. See [mcp.json.example](mcp.json.example).
 
@@ -121,11 +127,11 @@ Cursor/agents image: `interchouette/casper-rust-wasm-sdk-mcp:{dev,latest,$APP_VE
 
 ## Layout notes
 
-| Choice | Why |
-| --- | --- |
-| Separate `mcp/` crate, mcpkit | keep mcpkit off the wasm root crate |
-| Path-dep on SDK lib | in-process tools, not an HTTP proxy of the SDK |
-| clap `--http` / `--listen` | stdio or Streamable HTTP from one binary |
-| Slim Hub image for agents | Cursor pulls MCP without SPA/Node layers |
+| Choice                         | Why                                               |
+| ------------------------------ | ------------------------------------------------- |
+| Separate `mcp/` crate, rmcp    | keep rmcp off the wasm root crate                 |
+| Path-dep on SDK lib            | in-process tools, not an HTTP proxy of the SDK    |
+| clap `--http` / `--listen`     | stdio or Streamable HTTP from one binary          |
+| Slim Hub image for agents      | Cursor pulls MCP without SPA/Node layers          |
 | MCP also embedded in webclient | SPA `:8080` + loopback MCP `:5790` + `/mcp` proxy |
-| stderr warn logging | quiet default for MCP clients |
+| stderr warn logging            | quiet default for MCP clients                     |

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -1,6 +1,6 @@
 # MCP server for casper-rust-wasm-sdk
 
-Rust **mcpkit** crate (`casper-rust-wasm-sdk-mcp`) exposing the native SDK API as MCP tools (in-process path dependency, not an HTTP proxy of the SDK).
+Rust **rmcp** crate (`casper-rust-wasm-sdk-mcp`) exposing the native SDK API as MCP tools (in-process path dependency, not an HTTP proxy of the SDK).
 
 Points at **your** Casper JSON-RPC / binary-port endpoints (`CASPER_RPC_URL`, `CASPER_NODE_URL`). No cloud indexer, no API key for chain data.
 

--- a/mcp/TOOLS.md
+++ b/mcp/TOOLS.md
@@ -254,5 +254,5 @@ Prefer dual-gate with domain feature where applicable (e.g. `transaction` + `wri
 1. Prefer transaction-path tools over deprecated deploy/contract aliases.
 2. Gate `write` and secret-key tools behind explicit approval UX.
 3. Complex structs (`TransactionStrParams`, `DeployStrParams`, `QueryGlobalStateParams`, …) accept JSON strings.
-4. Responses: pretty JSON via `format.rs`; map `SdkError` → `ToolOutput::error`.
+4. Responses: pretty JSON via `format.rs`; map `SdkError` → `CallToolResult::error`.
 5. Binary-port tools need `CASPER_NODE_URL`, not only RPC.

--- a/mcp/src/compose/auction.rs
+++ b/mcp/src/compose/auction.rs
@@ -1,6 +1,6 @@
 //! Auction composition: normalize get_auction_info for Validators / Bidders.
 
-use mcpkit::prelude::ToolOutput;
+use rmcp::model::CallToolResult;
 use serde::Serialize;
 use serde_json::{json, Value};
 
@@ -45,7 +45,10 @@ struct ValidatorDetail {
 }
 
 /// Active validators (`inactive == false`), sorted by total stake descending.
-pub async fn list_validators(verbosity: Option<String>, rpc_address: Option<String>) -> ToolOutput {
+pub async fn list_validators(
+    verbosity: Option<String>,
+    rpc_address: Option<String>,
+) -> CallToolResult {
     match fetch_auction(verbosity, rpc_address).await {
         Ok(auction) => {
             let rows: Vec<ValidatorRow> = list_bidders_rows(&auction)
@@ -59,7 +62,10 @@ pub async fn list_validators(verbosity: Option<String>, rpc_address: Option<Stri
 }
 
 /// All auction bids, sorted by total stake descending.
-pub async fn list_bidders(verbosity: Option<String>, rpc_address: Option<String>) -> ToolOutput {
+pub async fn list_bidders(
+    verbosity: Option<String>,
+    rpc_address: Option<String>,
+) -> CallToolResult {
     match fetch_auction(verbosity, rpc_address).await {
         Ok(auction) => {
             let rows = list_bidders_rows(&auction);
@@ -74,7 +80,7 @@ pub async fn get_validator(
     public_key: String,
     verbosity: Option<String>,
     rpc_address: Option<String>,
-) -> ToolOutput {
+) -> CallToolResult {
     let want = public_key.trim().to_ascii_lowercase();
     if want.is_empty() {
         return format::err("public_key is required");

--- a/mcp/src/compose/blocks.rs
+++ b/mcp/src/compose/blocks.rs
@@ -2,7 +2,7 @@
 
 use casper_rust_wasm_sdk::types::hash::transaction_hash::TransactionHash;
 use casper_rust_wasm_sdk::types::identifier::block_identifier::BlockIdentifierInput;
-use mcpkit::prelude::ToolOutput;
+use rmcp::model::CallToolResult;
 use serde_json::{json, Value};
 
 use crate::format;
@@ -34,7 +34,7 @@ pub async fn get_latest_blocks(
     count: Option<u32>,
     verbosity: Option<String>,
     rpc_address: Option<String>,
-) -> ToolOutput {
+) -> CallToolResult {
     let count = count.unwrap_or(10).clamp(1, 50) as usize;
     let sdk = sdk_handle::sdk_snapshot();
 
@@ -90,7 +90,7 @@ pub async fn get_block_transactions(
     expand: Option<bool>,
     verbosity: Option<String>,
     rpc_address: Option<String>,
-) -> ToolOutput {
+) -> CallToolResult {
     let sdk = sdk_handle::sdk_snapshot();
     let block = match sdk
         .get_block(

--- a/mcp/src/compose/stake.rs
+++ b/mcp/src/compose/stake.rs
@@ -2,7 +2,7 @@
 
 use casper_rust_wasm_sdk::types::public_key::PublicKey;
 use casper_rust_wasm_sdk::types::transaction_params::transaction_builder_params::TransactionBuilderParams;
-use mcpkit::prelude::ToolOutput;
+use rmcp::model::CallToolResult;
 
 use crate::format;
 use crate::sdk_handle;
@@ -23,7 +23,7 @@ pub fn make_delegate_transaction(
     validator: String,
     amount: String,
     transaction_params_json: String,
-) -> ToolOutput {
+) -> CallToolResult {
     make_stake(
         StakeKind::Delegate,
         &delegator,
@@ -40,7 +40,7 @@ pub fn make_undelegate_transaction(
     validator: String,
     amount: String,
     transaction_params_json: String,
-) -> ToolOutput {
+) -> CallToolResult {
     make_stake(
         StakeKind::Undelegate,
         &delegator,
@@ -58,7 +58,7 @@ pub fn make_redelegate_transaction(
     new_validator: String,
     amount: String,
     transaction_params_json: String,
-) -> ToolOutput {
+) -> CallToolResult {
     make_stake(
         StakeKind::Redelegate,
         &delegator,
@@ -82,7 +82,7 @@ fn make_stake(
     new_validator: Option<&str>,
     amount: &str,
     transaction_params_json: &str,
-) -> ToolOutput {
+) -> CallToolResult {
     let params = match parse_transaction_str_params(transaction_params_json) {
         Ok(p) => p,
         Err(err) => return format::err(err),
@@ -137,9 +137,7 @@ mod tests {
             params.into(),
         );
         let text = format!("{out:?}");
-        assert!(
-            text.contains("Success") && text.contains("Delegate"),
-            "unexpected tool output: {text}"
-        );
+        assert_eq!(out.is_error, Some(false), "unexpected tool error: {text}");
+        assert!(text.contains("Delegate"), "unexpected tool output: {text}");
     }
 }

--- a/mcp/src/format.rs
+++ b/mcp/src/format.rs
@@ -1,36 +1,38 @@
-//! Map SDK / serde results to MCP `ToolOutput`.
+//! Map SDK / serde results to MCP `CallToolResult`.
 
-use mcpkit::prelude::ToolOutput;
+use rmcp::model::{CallToolResult, ContentBlock};
 use serde::Serialize;
 
 /// Pretty-print JSON for tool responses.
-pub fn json_ok(value: &serde_json::Value) -> ToolOutput {
+pub fn json_ok(value: &serde_json::Value) -> CallToolResult {
     match serde_json::to_string_pretty(value) {
-        Ok(text) => ToolOutput::text(text),
-        Err(err) => ToolOutput::error(format!("json encode failed: {err}")),
+        Ok(text) => CallToolResult::success(vec![ContentBlock::text(text)]),
+        Err(err) => CallToolResult::error(vec![ContentBlock::text(format!(
+            "json encode failed: {err}"
+        ))]),
     }
 }
 
 /// Serialize any `Serialize` value as pretty JSON text.
-pub fn serialize_ok<T: Serialize>(value: &T) -> ToolOutput {
+pub fn serialize_ok<T: Serialize>(value: &T) -> CallToolResult {
     match serde_json::to_value(value) {
         Ok(v) => json_ok(&v),
         Err(e) => err(e),
     }
 }
 
-/// Wrap an arbitrary displayable error.
-pub fn err(err: impl std::fmt::Display) -> ToolOutput {
-    ToolOutput::error(err.to_string())
+/// Wrap an arbitrary displayable error (tool-level `isError`).
+pub fn err(err: impl std::fmt::Display) -> CallToolResult {
+    CallToolResult::error(vec![ContentBlock::text(err.to_string())])
 }
 
 /// Success path for plain text.
-pub fn text_ok(text: impl Into<String>) -> ToolOutput {
-    ToolOutput::text(text.into())
+pub fn text_ok(text: impl Into<String>) -> CallToolResult {
+    CallToolResult::success(vec![ContentBlock::text(text.into())])
 }
 
-/// Map `Result` → `ToolOutput` using `serialize_ok` / `err`.
-pub fn from_result<T: Serialize, E: std::fmt::Display>(result: Result<T, E>) -> ToolOutput {
+/// Map `Result` → `CallToolResult` using `serialize_ok` / `err`.
+pub fn from_result<T: Serialize, E: std::fmt::Display>(result: Result<T, E>) -> CallToolResult {
     match result {
         Ok(value) => serialize_ok(&value),
         Err(error) => err(error),
@@ -45,20 +47,20 @@ mod tests {
     fn json_ok_pretty_prints() {
         let value = serde_json::json!({ "ok": true });
         let out = json_ok(&value);
-        let _ = format!("{out:?}");
+        assert_eq!(out.is_error, Some(false));
     }
 
     #[test]
     fn err_builds_error_output() {
         let out = err("boom");
-        let _ = format!("{out:?}");
+        assert_eq!(out.is_error, Some(true));
     }
 
     #[test]
     fn from_result_ok_and_err() {
         let ok: Result<i32, &str> = Ok(7);
-        let _ = from_result(ok);
+        assert_eq!(from_result(ok).is_error, Some(false));
         let bad: Result<i32, &str> = Err("nope");
-        let _ = from_result(bad);
+        assert_eq!(from_result(bad).is_error, Some(true));
     }
 }

--- a/mcp/src/lib.rs
+++ b/mcp/src/lib.rs
@@ -4,6 +4,7 @@ pub mod compose;
 pub mod format;
 pub mod sdk_handle;
 pub mod server;
+pub mod tool_args;
 pub mod tools;
 
 pub use server::{run, run_http, DEFAULT_HTTP_LISTEN};

--- a/mcp/src/server.rs
+++ b/mcp/src/server.rs
@@ -1,33 +1,41 @@
-//! MCP server (`mcpkit`) for `casper-rust-wasm-sdk-mcp` (stdio or Streamable HTTP).
+//! MCP server (`rmcp`) for `casper-rust-wasm-sdk-mcp` (stdio or Streamable HTTP).
 
 #![allow(clippy::unused_async)]
+#![allow(non_snake_case)] // sdk_SSE_* / sdk_CES_* tool names + rmcp-generated *_tool_attr
 
-use mcpkit::prelude::*;
-use mcpkit::transport::stdio::StdioTransport;
-use mcpkit_axum::McpRouter;
+use std::sync::Arc;
 
+use rmcp::{
+    handler::server::wrapper::Parameters,
+    model::{CallToolResult, ServerCapabilities, ServerInfo},
+    tool, tool_handler, tool_router,
+    transport::stdio,
+    ErrorData as McpError, ServerHandler, ServiceExt,
+};
+
+use crate::tool_args::*;
 use crate::{compose, format, sdk_handle, tools};
 
 /// MCP server handle exposing Casper SDK tools.
+#[derive(Clone, Default)]
 pub struct CasperSdkMcp;
 
 /// Default HTTP bind address for Streamable MCP.
 pub const DEFAULT_HTTP_LISTEN: &str = "0.0.0.0:5790";
 
-// Keep in sync with Cargo.toml `version` (enforced by unit test below).
-#[mcp_server(name = "casper-rust-wasm-sdk", version = "2.2.2")]
+#[tool_router]
 impl CasperSdkMcp {
     #[tool(description = "Help: feature matrix, env vars, endpoints, and available sdk_* tools")]
-    async fn sdk_help(&self) -> ToolOutput {
-        format::text_ok(help_text())
+    async fn sdk_help(&self) -> Result<CallToolResult, McpError> {
+        Ok(format::text_ok(help_text()))
     }
 
     #[tool(
         description = "Show current CASPER_RPC_URL / CASPER_NODE_URL / verbosity on the shared SDK"
     )]
-    async fn sdk_get_endpoints(&self) -> ToolOutput {
+    async fn sdk_get_endpoints(&self) -> Result<CallToolResult, McpError> {
         let snap = sdk_handle::endpoint_snapshot();
-        format::json_ok(&serde_json::json!({
+        Ok(format::json_ok(&serde_json::json!({
             "rpc_address": snap.rpc_address,
             "node_address": snap.node_address,
             "verbosity": snap.verbosity,
@@ -36,7 +44,7 @@ impl CasperSdkMcp {
                 "CASPER_NODE_URL": sdk_handle::ENV_NODE_URL,
                 "CASPER_VERBOSITY": sdk_handle::ENV_VERBOSITY,
             }
-        }))
+        })))
     }
 
     #[tool(
@@ -44,29 +52,31 @@ impl CasperSdkMcp {
     )]
     async fn sdk_set_endpoints(
         &self,
-        rpc_address: Option<String>,
-        node_address: Option<String>,
-        verbosity: Option<String>,
-    ) -> ToolOutput {
+        Parameters(SdkSetEndpointsArgs {
+            rpc_address,
+            node_address,
+            verbosity,
+        }): Parameters<SdkSetEndpointsArgs>,
+    ) -> Result<CallToolResult, McpError> {
         let sdk = sdk_handle::shared();
         let mut guard = match sdk.lock() {
             Ok(g) => g,
-            Err(err) => return format::err(format!("sdk mutex poisoned: {err}")),
+            Err(err) => return Ok(format::err(format!("sdk mutex poisoned: {err}"))),
         };
         if let Some(rpc) = rpc_address {
             if let Err(err) = guard.set_rpc_address(Some(rpc)) {
-                return format::err(err);
+                return Ok(format::err(err));
             }
         }
         if let Some(node) = node_address {
             if let Err(err) = guard.set_node_address(Some(node)) {
-                return format::err(err);
+                return Ok(format::err(err));
             }
         }
         if let Some(raw) = verbosity {
             let v = sdk_handle::parse_verbosity(&raw);
             if let Err(err) = guard.set_verbosity(Some(v)) {
-                return format::err(err);
+                return Ok(format::err(err));
             }
         }
         let snap = sdk_handle::EndpointSnapshot {
@@ -74,23 +84,29 @@ impl CasperSdkMcp {
             node_address: guard.get_node_address(None),
             verbosity: format!("{:?}", guard.get_verbosity(None)),
         };
-        format::json_ok(&serde_json::json!({
+        Ok(format::json_ok(&serde_json::json!({
             "rpc_address": snap.rpc_address,
             "node_address": snap.node_address,
             "verbosity": snap.verbosity,
-        }))
+        })))
     }
 
-    // --- helpers (feature = "helpers") ---
-
     #[tool(description = "Current RFC3339 timestamp (optional unix-ms timestamp override)")]
-    async fn sdk_get_current_timestamp(&self, timestamp: Option<String>) -> ToolOutput {
-        tools::helpers::get_current_timestamp(timestamp)
+    async fn sdk_get_current_timestamp(
+        &self,
+        Parameters(SdkGetCurrentTimestampArgs { timestamp }): Parameters<
+            SdkGetCurrentTimestampArgs,
+        >,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(tools::helpers::get_current_timestamp(timestamp))
     }
 
     #[tool(description = "Blake2b-256 hex digest of a UTF-8 string")]
-    async fn sdk_get_blake2b_hash(&self, meta_data: String) -> ToolOutput {
-        tools::helpers::get_blake2b_hash(meta_data)
+    async fn sdk_get_blake2b_hash(
+        &self,
+        Parameters(SdkGetBlake2bHashArgs { meta_data }): Parameters<SdkGetBlake2bHashArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(tools::helpers::get_blake2b_hash(meta_data))
     }
 
     #[tool(
@@ -98,153 +114,216 @@ impl CasperSdkMcp {
     )]
     async fn sdk_make_dictionary_item_key(
         &self,
-        key: String,
-        value_key: Option<String>,
-        value_u256: Option<String>,
-    ) -> ToolOutput {
-        tools::helpers::make_dictionary_item_key(key, value_key, value_u256)
+        Parameters(SdkMakeDictionaryItemKeyArgs {
+            key,
+            value_key,
+            value_u256,
+        }): Parameters<SdkMakeDictionaryItemKeyArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(tools::helpers::make_dictionary_item_key(
+            key, value_key, value_u256,
+        ))
     }
 
     #[tool(description = "CEP-18 base64 key from account-hash-… string")]
-    async fn sdk_get_base64_key_from_account_hash(&self, account_hash: String) -> ToolOutput {
-        tools::helpers::get_base64_key_from_account_hash(account_hash)
+    async fn sdk_get_base64_key_from_account_hash(
+        &self,
+        Parameters(SdkGetBase64KeyFromAccountHashArgs { account_hash }): Parameters<
+            SdkGetBase64KeyFromAccountHashArgs,
+        >,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(tools::helpers::get_base64_key_from_account_hash(
+            account_hash,
+        ))
     }
 
     #[tool(description = "CEP-18 base64 key from hash-… formatted key")]
-    async fn sdk_get_base64_key_from_key_hash(&self, formatted_hash: String) -> ToolOutput {
-        tools::helpers::get_base64_key_from_key_hash(formatted_hash)
+    async fn sdk_get_base64_key_from_key_hash(
+        &self,
+        Parameters(SdkGetBase64KeyFromKeyHashArgs { formatted_hash }): Parameters<
+            SdkGetBase64KeyFromKeyHashArgs,
+        >,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(tools::helpers::get_base64_key_from_key_hash(formatted_hash))
     }
 
     #[tool(description = "TTL string or SDK default")]
-    async fn sdk_get_ttl_or_default(&self, ttl: Option<String>) -> ToolOutput {
-        tools::helpers::get_ttl_or_default(ttl)
+    async fn sdk_get_ttl_or_default(
+        &self,
+        Parameters(SdkGetTtlOrDefaultArgs { ttl }): Parameters<SdkGetTtlOrDefaultArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(tools::helpers::get_ttl_or_default(ttl))
     }
 
     #[tool(description = "Parse a timestamp string")]
-    async fn sdk_parse_timestamp(&self, value: String) -> ToolOutput {
-        tools::helpers::parse_timestamp(value)
+    async fn sdk_parse_timestamp(
+        &self,
+        Parameters(SdkParseTimestampArgs { value }): Parameters<SdkParseTimestampArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(tools::helpers::parse_timestamp(value))
     }
 
     #[tool(description = "Parse a TTL / TimeDiff string")]
-    async fn sdk_parse_ttl(&self, value: String) -> ToolOutput {
-        tools::helpers::parse_ttl(value)
+    async fn sdk_parse_ttl(
+        &self,
+        Parameters(SdkParseTimestampArgs { value }): Parameters<SdkParseTimestampArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(tools::helpers::parse_ttl(value))
     }
 
     #[tool(description = "Gas price or SDK default")]
-    async fn sdk_get_gas_price_or_default(&self, gas_price: Option<u64>) -> ToolOutput {
-        tools::helpers::get_gas_price_or_default(gas_price)
+    async fn sdk_get_gas_price_or_default(
+        &self,
+        Parameters(SdkGetGasPriceOrDefaultArgs { gas_price }): Parameters<
+            SdkGetGasPriceOrDefaultArgs,
+        >,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(tools::helpers::get_gas_price_or_default(gas_price))
     }
 
     #[tool(description = "Generate Ed25519 secret key PEM (local; treat as secret)")]
-    async fn sdk_secret_key_generate(&self) -> ToolOutput {
-        tools::helpers::secret_key_generate()
+    async fn sdk_secret_key_generate(&self) -> Result<CallToolResult, McpError> {
+        Ok(tools::helpers::secret_key_generate())
     }
 
     #[tool(description = "Generate secp256k1 secret key PEM (local; treat as secret)")]
-    async fn sdk_secret_key_secp256k1_generate(&self) -> ToolOutput {
-        tools::helpers::secret_key_secp256k1_generate()
+    async fn sdk_secret_key_secp256k1_generate(&self) -> Result<CallToolResult, McpError> {
+        Ok(tools::helpers::secret_key_secp256k1_generate())
     }
 
     #[tool(description = "Validate a secret key PEM (does not echo the secret)")]
-    async fn sdk_secret_key_from_pem(&self, secret_key: String) -> ToolOutput {
-        tools::helpers::secret_key_from_pem(secret_key)
+    async fn sdk_secret_key_from_pem(
+        &self,
+        Parameters(SdkSecretKeyFromPemArgs { secret_key }): Parameters<SdkSecretKeyFromPemArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(tools::helpers::secret_key_from_pem(secret_key))
     }
 
     #[tool(description = "Derive public key hex from secret key PEM")]
-    async fn sdk_public_key_from_secret_key(&self, secret_key: String) -> ToolOutput {
-        tools::helpers::public_key_from_secret_key(secret_key)
+    async fn sdk_public_key_from_secret_key(
+        &self,
+        Parameters(SdkSecretKeyFromPemArgs { secret_key }): Parameters<SdkSecretKeyFromPemArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(tools::helpers::public_key_from_secret_key(secret_key))
     }
 
     #[tool(description = "Decode hex string to byte array JSON")]
-    async fn sdk_hex_to_uint8_vec(&self, hex_string: String) -> ToolOutput {
-        tools::helpers::hex_to_uint8_vec(hex_string)
+    async fn sdk_hex_to_uint8_vec(
+        &self,
+        Parameters(SdkHexToUint8VecArgs { hex_string }): Parameters<SdkHexToUint8VecArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(tools::helpers::hex_to_uint8_vec(hex_string))
     }
 
     #[tool(description = "Decode hex string to UTF-8 (lossy) text")]
-    async fn sdk_hex_to_string(&self, hex_string: String) -> ToolOutput {
-        tools::helpers::hex_to_string(hex_string)
+    async fn sdk_hex_to_string(
+        &self,
+        Parameters(SdkHexToUint8VecArgs { hex_string }): Parameters<SdkHexToUint8VecArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(tools::helpers::hex_to_string(hex_string))
     }
 
     #[tool(description = "Convert motes string to CSPR")]
-    async fn sdk_motes_to_cspr(&self, motes: String) -> ToolOutput {
-        tools::helpers::motes_to_cspr(motes)
+    async fn sdk_motes_to_cspr(
+        &self,
+        Parameters(SdkMotesToCsprArgs { motes }): Parameters<SdkMotesToCsprArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(tools::helpers::motes_to_cspr(motes))
     }
 
     #[tool(description = "Pretty-print a JSON string at optional verbosity (low|medium|high)")]
-    async fn sdk_json_pretty_print(&self, value: String, verbosity: Option<String>) -> ToolOutput {
-        tools::helpers::json_pretty_print(value, verbosity)
+    async fn sdk_json_pretty_print(
+        &self,
+        Parameters(SdkJsonPrettyPrintArgs { value, verbosity }): Parameters<SdkJsonPrettyPrintArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(tools::helpers::json_pretty_print(value, verbosity))
     }
 
     #[tool(description = "Convert a CLValue JSON document to JSON Value")]
-    async fn sdk_cl_value_to_json(&self, cl_value_json: String) -> ToolOutput {
-        tools::helpers::cl_value_to_json(cl_value_json)
+    async fn sdk_cl_value_to_json(
+        &self,
+        Parameters(SdkClValueToJsonArgs { cl_value_json }): Parameters<SdkClValueToJsonArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(tools::helpers::cl_value_to_json(cl_value_json))
     }
-
-    // --- rpc (feature = "rpc") ---
 
     #[tool(description = "JSON-RPC info_get_status / get_node_status")]
     async fn sdk_get_node_status(
         &self,
-        verbosity: Option<String>,
-        rpc_address: Option<String>,
-    ) -> ToolOutput {
-        tools::rpc::get_node_status(verbosity, rpc_address).await
+        Parameters(RpcOpts {
+            verbosity,
+            rpc_address,
+        }): Parameters<RpcOpts>,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(tools::rpc::get_node_status(verbosity, rpc_address).await)
     }
 
     #[tool(description = "JSON-RPC info_get_peers")]
     async fn sdk_get_peers(
         &self,
-        verbosity: Option<String>,
-        rpc_address: Option<String>,
-    ) -> ToolOutput {
-        tools::rpc::get_peers(verbosity, rpc_address).await
+        Parameters(RpcOpts {
+            verbosity,
+            rpc_address,
+        }): Parameters<RpcOpts>,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(tools::rpc::get_peers(verbosity, rpc_address).await)
     }
 
     #[tool(description = "JSON-RPC info_get_chainspec")]
     async fn sdk_get_chainspec(
         &self,
-        verbosity: Option<String>,
-        rpc_address: Option<String>,
-    ) -> ToolOutput {
-        tools::rpc::get_chainspec(verbosity, rpc_address).await
+        Parameters(RpcOpts {
+            verbosity,
+            rpc_address,
+        }): Parameters<RpcOpts>,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(tools::rpc::get_chainspec(verbosity, rpc_address).await)
     }
 
     #[tool(description = "JSON-RPC info_get_validator_changes")]
     async fn sdk_get_validator_changes(
         &self,
-        verbosity: Option<String>,
-        rpc_address: Option<String>,
-    ) -> ToolOutput {
-        tools::rpc::get_validator_changes(verbosity, rpc_address).await
+        Parameters(RpcOpts {
+            verbosity,
+            rpc_address,
+        }): Parameters<RpcOpts>,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(tools::rpc::get_validator_changes(verbosity, rpc_address).await)
     }
 
     #[tool(description = "JSON-RPC list_rpcs")]
     async fn sdk_list_rpcs(
         &self,
-        verbosity: Option<String>,
-        rpc_address: Option<String>,
-    ) -> ToolOutput {
-        tools::rpc::list_rpcs(verbosity, rpc_address).await
+        Parameters(RpcOpts {
+            verbosity,
+            rpc_address,
+        }): Parameters<RpcOpts>,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(tools::rpc::list_rpcs(verbosity, rpc_address).await)
     }
 
     #[tool(description = "JSON-RPC chain_get_block (optional block height or hash string)")]
     async fn sdk_get_block(
         &self,
-        maybe_block_identifier: Option<String>,
-        verbosity: Option<String>,
-        rpc_address: Option<String>,
-    ) -> ToolOutput {
-        tools::rpc::get_block(maybe_block_identifier, verbosity, rpc_address).await
+        Parameters(BlockIdOpts {
+            maybe_block_identifier,
+            verbosity,
+            rpc_address,
+        }): Parameters<BlockIdOpts>,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(tools::rpc::get_block(maybe_block_identifier, verbosity, rpc_address).await)
     }
 
     #[tool(description = "JSON-RPC chain_get_block_transfers")]
     async fn sdk_get_block_transfers(
         &self,
-        maybe_block_identifier: Option<String>,
-        verbosity: Option<String>,
-        rpc_address: Option<String>,
-    ) -> ToolOutput {
-        tools::rpc::get_block_transfers(maybe_block_identifier, verbosity, rpc_address).await
+        Parameters(BlockIdOpts {
+            maybe_block_identifier,
+            verbosity,
+            rpc_address,
+        }): Parameters<BlockIdOpts>,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(tools::rpc::get_block_transfers(maybe_block_identifier, verbosity, rpc_address).await)
     }
 
     #[tool(
@@ -252,19 +331,21 @@ impl CasperSdkMcp {
     )]
     async fn sdk_get_latest_blocks(
         &self,
-        count: Option<u32>,
-        verbosity: Option<String>,
-        rpc_address: Option<String>,
-    ) -> ToolOutput {
+        Parameters(SdkGetLatestBlocksArgs {
+            count,
+            verbosity,
+            rpc_address,
+        }): Parameters<SdkGetLatestBlocksArgs>,
+    ) -> Result<CallToolResult, McpError> {
         #[cfg(feature = "rpc")]
         {
-            compose::blocks::get_latest_blocks(count, verbosity, rpc_address).await
+            Ok(compose::blocks::get_latest_blocks(count, verbosity, rpc_address).await)
         }
         #[cfg(not(feature = "rpc"))]
-        {
+        Ok({
             let _ = (count, verbosity, rpc_address);
             tools::feature_disabled("rpc")
-        }
+        })
     }
 
     #[tool(
@@ -272,26 +353,28 @@ impl CasperSdkMcp {
     )]
     async fn sdk_get_block_transactions(
         &self,
-        block_identifier: String,
-        expand: Option<bool>,
-        verbosity: Option<String>,
-        rpc_address: Option<String>,
-    ) -> ToolOutput {
+        Parameters(SdkGetBlockTransactionsArgs {
+            block_identifier,
+            expand,
+            verbosity,
+            rpc_address,
+        }): Parameters<SdkGetBlockTransactionsArgs>,
+    ) -> Result<CallToolResult, McpError> {
         #[cfg(feature = "rpc")]
         {
-            compose::blocks::get_block_transactions(
+            Ok(compose::blocks::get_block_transactions(
                 block_identifier,
                 expand,
                 verbosity,
                 rpc_address,
             )
-            .await
+            .await)
         }
         #[cfg(not(feature = "rpc"))]
-        {
+        Ok({
             let _ = (block_identifier, expand, verbosity, rpc_address);
             tools::feature_disabled("rpc")
-        }
+        })
     }
 
     #[tool(
@@ -299,18 +382,20 @@ impl CasperSdkMcp {
     )]
     async fn sdk_list_validators(
         &self,
-        verbosity: Option<String>,
-        rpc_address: Option<String>,
-    ) -> ToolOutput {
+        Parameters(RpcOpts {
+            verbosity,
+            rpc_address,
+        }): Parameters<RpcOpts>,
+    ) -> Result<CallToolResult, McpError> {
         #[cfg(feature = "rpc")]
         {
-            compose::auction::list_validators(verbosity, rpc_address).await
+            Ok(compose::auction::list_validators(verbosity, rpc_address).await)
         }
         #[cfg(not(feature = "rpc"))]
-        {
+        Ok({
             let _ = (verbosity, rpc_address);
             tools::feature_disabled("rpc")
-        }
+        })
     }
 
     #[tool(
@@ -318,19 +403,21 @@ impl CasperSdkMcp {
     )]
     async fn sdk_get_validator(
         &self,
-        public_key: String,
-        verbosity: Option<String>,
-        rpc_address: Option<String>,
-    ) -> ToolOutput {
+        Parameters(SdkGetValidatorArgs {
+            public_key,
+            verbosity,
+            rpc_address,
+        }): Parameters<SdkGetValidatorArgs>,
+    ) -> Result<CallToolResult, McpError> {
         #[cfg(feature = "rpc")]
         {
-            compose::auction::get_validator(public_key, verbosity, rpc_address).await
+            Ok(compose::auction::get_validator(public_key, verbosity, rpc_address).await)
         }
         #[cfg(not(feature = "rpc"))]
-        {
+        Ok({
             let _ = (public_key, verbosity, rpc_address);
             tools::feature_disabled("rpc")
-        }
+        })
     }
 
     #[tool(
@@ -338,89 +425,97 @@ impl CasperSdkMcp {
     )]
     async fn sdk_list_bidders(
         &self,
-        verbosity: Option<String>,
-        rpc_address: Option<String>,
-    ) -> ToolOutput {
+        Parameters(RpcOpts {
+            verbosity,
+            rpc_address,
+        }): Parameters<RpcOpts>,
+    ) -> Result<CallToolResult, McpError> {
         #[cfg(feature = "rpc")]
         {
-            compose::auction::list_bidders(verbosity, rpc_address).await
+            Ok(compose::auction::list_bidders(verbosity, rpc_address).await)
         }
         #[cfg(not(feature = "rpc"))]
-        {
+        Ok({
             let _ = (verbosity, rpc_address);
             tools::feature_disabled("rpc")
-        }
+        })
     }
 
     #[tool(description = "Compose: build unsigned delegate transaction")]
     async fn sdk_make_delegate_transaction(
         &self,
-        delegator: String,
-        validator: String,
-        amount: String,
-        transaction_params_json: String,
-    ) -> ToolOutput {
+        Parameters(SdkMakeDelegateTransactionArgs {
+            delegator,
+            validator,
+            amount,
+            transaction_params_json,
+        }): Parameters<SdkMakeDelegateTransactionArgs>,
+    ) -> Result<CallToolResult, McpError> {
         #[cfg(feature = "transaction")]
         {
-            compose::stake::make_delegate_transaction(
+            Ok(compose::stake::make_delegate_transaction(
                 delegator,
                 validator,
                 amount,
                 transaction_params_json,
-            )
+            ))
         }
         #[cfg(not(feature = "transaction"))]
-        {
+        Ok({
             let _ = (delegator, validator, amount, transaction_params_json);
             tools::feature_disabled("transaction")
-        }
+        })
     }
 
     #[tool(description = "Compose: build unsigned undelegate transaction")]
     async fn sdk_make_undelegate_transaction(
         &self,
-        delegator: String,
-        validator: String,
-        amount: String,
-        transaction_params_json: String,
-    ) -> ToolOutput {
+        Parameters(SdkMakeDelegateTransactionArgs {
+            delegator,
+            validator,
+            amount,
+            transaction_params_json,
+        }): Parameters<SdkMakeDelegateTransactionArgs>,
+    ) -> Result<CallToolResult, McpError> {
         #[cfg(feature = "transaction")]
         {
-            compose::stake::make_undelegate_transaction(
+            Ok(compose::stake::make_undelegate_transaction(
                 delegator,
                 validator,
                 amount,
                 transaction_params_json,
-            )
+            ))
         }
         #[cfg(not(feature = "transaction"))]
-        {
+        Ok({
             let _ = (delegator, validator, amount, transaction_params_json);
             tools::feature_disabled("transaction")
-        }
+        })
     }
 
     #[tool(description = "Compose: build unsigned redelegate transaction")]
     async fn sdk_make_redelegate_transaction(
         &self,
-        delegator: String,
-        validator: String,
-        new_validator: String,
-        amount: String,
-        transaction_params_json: String,
-    ) -> ToolOutput {
+        Parameters(SdkMakeRedelegateTransactionArgs {
+            delegator,
+            validator,
+            new_validator,
+            amount,
+            transaction_params_json,
+        }): Parameters<SdkMakeRedelegateTransactionArgs>,
+    ) -> Result<CallToolResult, McpError> {
         #[cfg(feature = "transaction")]
         {
-            compose::stake::make_redelegate_transaction(
+            Ok(compose::stake::make_redelegate_transaction(
                 delegator,
                 validator,
                 new_validator,
                 amount,
                 transaction_params_json,
-            )
+            ))
         }
         #[cfg(not(feature = "transaction"))]
-        {
+        Ok({
             let _ = (
                 delegator,
                 validator,
@@ -429,27 +524,31 @@ impl CasperSdkMcp {
                 transaction_params_json,
             );
             tools::feature_disabled("transaction")
-        }
+        })
     }
 
     #[tool(description = "JSON-RPC state_get_auction_info")]
     async fn sdk_get_auction_info(
         &self,
-        maybe_block_identifier: Option<String>,
-        verbosity: Option<String>,
-        rpc_address: Option<String>,
-    ) -> ToolOutput {
-        tools::rpc::get_auction_info(maybe_block_identifier, verbosity, rpc_address).await
+        Parameters(BlockIdOpts {
+            maybe_block_identifier,
+            verbosity,
+            rpc_address,
+        }): Parameters<BlockIdOpts>,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(tools::rpc::get_auction_info(maybe_block_identifier, verbosity, rpc_address).await)
     }
 
     #[tool(description = "JSON-RPC chain_get_era_summary")]
     async fn sdk_get_era_summary(
         &self,
-        maybe_block_identifier: Option<String>,
-        verbosity: Option<String>,
-        rpc_address: Option<String>,
-    ) -> ToolOutput {
-        tools::rpc::get_era_summary(maybe_block_identifier, verbosity, rpc_address).await
+        Parameters(BlockIdOpts {
+            maybe_block_identifier,
+            verbosity,
+            rpc_address,
+        }): Parameters<BlockIdOpts>,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(tools::rpc::get_era_summary(maybe_block_identifier, verbosity, rpc_address).await)
     }
 
     #[tool(
@@ -457,13 +556,18 @@ impl CasperSdkMcp {
     )]
     async fn sdk_get_reward(
         &self,
-        validator: String,
-        delegator: Option<String>,
-        maybe_era_id: Option<String>,
-        verbosity: Option<String>,
-        rpc_address: Option<String>,
-    ) -> ToolOutput {
-        tools::rpc::get_reward(validator, delegator, maybe_era_id, verbosity, rpc_address).await
+        Parameters(SdkGetRewardArgs {
+            validator,
+            delegator,
+            maybe_era_id,
+            verbosity,
+            rpc_address,
+        }): Parameters<SdkGetRewardArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(
+            tools::rpc::get_reward(validator, delegator, maybe_era_id, verbosity, rpc_address)
+                .await,
+        )
     }
 
     #[tool(
@@ -471,94 +575,108 @@ impl CasperSdkMcp {
     )]
     async fn sdk_get_era_info(
         &self,
-        maybe_block_identifier: Option<String>,
-        verbosity: Option<String>,
-        rpc_address: Option<String>,
-    ) -> ToolOutput {
-        tools::rpc::get_era_info(maybe_block_identifier, verbosity, rpc_address).await
+        Parameters(BlockIdOpts {
+            maybe_block_identifier,
+            verbosity,
+            rpc_address,
+        }): Parameters<BlockIdOpts>,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(tools::rpc::get_era_info(maybe_block_identifier, verbosity, rpc_address).await)
     }
 
     #[tool(description = "JSON-RPC chain_get_state_root_hash")]
     async fn sdk_get_state_root_hash(
         &self,
-        maybe_block_identifier: Option<String>,
-        verbosity: Option<String>,
-        rpc_address: Option<String>,
-    ) -> ToolOutput {
-        tools::rpc::get_state_root_hash(maybe_block_identifier, verbosity, rpc_address).await
+        Parameters(BlockIdOpts {
+            maybe_block_identifier,
+            verbosity,
+            rpc_address,
+        }): Parameters<BlockIdOpts>,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(tools::rpc::get_state_root_hash(maybe_block_identifier, verbosity, rpc_address).await)
     }
 
     #[tool(description = "JSON-RPC state_get_account_info (deprecated; prefer get_entity)")]
     async fn sdk_get_account(
         &self,
-        account_identifier: Option<String>,
-        maybe_block_identifier: Option<String>,
-        verbosity: Option<String>,
-        rpc_address: Option<String>,
-    ) -> ToolOutput {
-        tools::rpc::get_account(
+        Parameters(SdkGetAccountArgs {
+            account_identifier,
+            maybe_block_identifier,
+            verbosity,
+            rpc_address,
+        }): Parameters<SdkGetAccountArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(tools::rpc::get_account(
             account_identifier,
             maybe_block_identifier,
             verbosity,
             rpc_address,
         )
-        .await
+        .await)
     }
 
     #[tool(description = "JSON-RPC state_get_entity / get_entity")]
     async fn sdk_get_entity(
         &self,
-        entity_identifier: Option<String>,
-        maybe_block_identifier: Option<String>,
-        verbosity: Option<String>,
-        rpc_address: Option<String>,
-    ) -> ToolOutput {
-        tools::rpc::get_entity(
+        Parameters(SdkGetEntityArgs {
+            entity_identifier,
+            maybe_block_identifier,
+            verbosity,
+            rpc_address,
+        }): Parameters<SdkGetEntityArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(tools::rpc::get_entity(
             entity_identifier,
             maybe_block_identifier,
             verbosity,
             rpc_address,
         )
-        .await
+        .await)
     }
 
     #[tool(description = "JSON-RPC info_get_deploy")]
     async fn sdk_get_deploy(
         &self,
-        deploy_hash: String,
-        finalized_approvals: Option<bool>,
-        verbosity: Option<String>,
-        rpc_address: Option<String>,
-    ) -> ToolOutput {
-        tools::rpc::get_deploy(deploy_hash, finalized_approvals, verbosity, rpc_address).await
+        Parameters(SdkGetDeployArgs {
+            deploy_hash,
+            finalized_approvals,
+            verbosity,
+            rpc_address,
+        }): Parameters<SdkGetDeployArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(tools::rpc::get_deploy(deploy_hash, finalized_approvals, verbosity, rpc_address).await)
     }
 
     #[tool(description = "JSON-RPC info_get_transaction")]
     async fn sdk_get_transaction(
         &self,
-        transaction_hash: String,
-        finalized_approvals: Option<bool>,
-        verbosity: Option<String>,
-        rpc_address: Option<String>,
-    ) -> ToolOutput {
-        tools::rpc::get_transaction(
+        Parameters(SdkGetTransactionArgs {
+            transaction_hash,
+            finalized_approvals,
+            verbosity,
+            rpc_address,
+        }): Parameters<SdkGetTransactionArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(tools::rpc::get_transaction(
             transaction_hash,
             finalized_approvals,
             verbosity,
             rpc_address,
         )
-        .await
+        .await)
     }
 
     #[tool(description = "JSON-RPC state_get_balance (purse uref string)")]
     async fn sdk_get_balance(
         &self,
-        purse_uref: String,
-        state_root_hash: Option<String>,
-        verbosity: Option<String>,
-        rpc_address: Option<String>,
-    ) -> ToolOutput {
-        tools::rpc::get_balance(purse_uref, state_root_hash, verbosity, rpc_address).await
+        Parameters(SdkGetBalanceArgs {
+            purse_uref,
+            state_root_hash,
+            verbosity,
+            rpc_address,
+        }): Parameters<SdkGetBalanceArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(tools::rpc::get_balance(purse_uref, state_root_hash, verbosity, rpc_address).await)
     }
 
     #[tool(
@@ -566,39 +684,43 @@ impl CasperSdkMcp {
     )]
     async fn sdk_query_balance(
         &self,
-        purse_identifier: String,
-        state_root_hash: Option<String>,
-        maybe_block_id: Option<String>,
-        verbosity: Option<String>,
-        rpc_address: Option<String>,
-    ) -> ToolOutput {
-        tools::rpc::query_balance(
+        Parameters(SdkQueryBalanceArgs {
+            purse_identifier,
+            state_root_hash,
+            maybe_block_id,
+            verbosity,
+            rpc_address,
+        }): Parameters<SdkQueryBalanceArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(tools::rpc::query_balance(
             purse_identifier,
             state_root_hash,
             maybe_block_id,
             verbosity,
             rpc_address,
         )
-        .await
+        .await)
     }
 
     #[tool(description = "JSON-RPC query_balance_details")]
     async fn sdk_query_balance_details(
         &self,
-        purse_identifier: String,
-        state_root_hash: Option<String>,
-        maybe_block_id: Option<String>,
-        verbosity: Option<String>,
-        rpc_address: Option<String>,
-    ) -> ToolOutput {
-        tools::rpc::query_balance_details(
+        Parameters(SdkQueryBalanceArgs {
+            purse_identifier,
+            state_root_hash,
+            maybe_block_id,
+            verbosity,
+            rpc_address,
+        }): Parameters<SdkQueryBalanceArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(tools::rpc::query_balance_details(
             purse_identifier,
             state_root_hash,
             maybe_block_id,
             verbosity,
             rpc_address,
         )
-        .await
+        .await)
     }
 
     #[tool(
@@ -606,17 +728,19 @@ impl CasperSdkMcp {
     )]
     async fn sdk_get_dictionary_item(
         &self,
-        kind: String,
-        key: Option<String>,
-        dictionary_name: Option<String>,
-        dictionary_item_key: Option<String>,
-        seed_uref: Option<String>,
-        dictionary_value: Option<String>,
-        state_root_hash: Option<String>,
-        verbosity: Option<String>,
-        rpc_address: Option<String>,
-    ) -> ToolOutput {
-        tools::rpc::get_dictionary_item(
+        Parameters(SdkGetDictionaryItemArgs {
+            kind,
+            key,
+            dictionary_name,
+            dictionary_item_key,
+            seed_uref,
+            dictionary_value,
+            state_root_hash,
+            verbosity,
+            rpc_address,
+        }): Parameters<SdkGetDictionaryItemArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(tools::rpc::get_dictionary_item(
             kind,
             key,
             dictionary_name,
@@ -627,7 +751,7 @@ impl CasperSdkMcp {
             verbosity,
             rpc_address,
         )
-        .await
+        .await)
     }
 
     #[tool(
@@ -635,14 +759,16 @@ impl CasperSdkMcp {
     )]
     async fn sdk_query_global_state(
         &self,
-        key: String,
-        path: Option<String>,
-        state_root_hash: Option<String>,
-        maybe_block_id: Option<String>,
-        verbosity: Option<String>,
-        rpc_address: Option<String>,
-    ) -> ToolOutput {
-        tools::rpc::query_global_state(
+        Parameters(SdkQueryGlobalStateArgs {
+            key,
+            path,
+            state_root_hash,
+            maybe_block_id,
+            verbosity,
+            rpc_address,
+        }): Parameters<SdkQueryGlobalStateArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(tools::rpc::query_global_state(
             key,
             path,
             state_root_hash,
@@ -650,272 +776,348 @@ impl CasperSdkMcp {
             verbosity,
             rpc_address,
         )
-        .await
+        .await)
     }
 
     #[tool(description = "JSON-RPC speculative_exec with full transaction JSON")]
     async fn sdk_speculative_exec(
         &self,
-        transaction_json: String,
-        verbosity: Option<String>,
-        rpc_address: Option<String>,
-    ) -> ToolOutput {
-        tools::rpc::speculative_exec(transaction_json, verbosity, rpc_address).await
+        Parameters(SdkSpeculativeExecArgs {
+            transaction_json,
+            verbosity,
+            rpc_address,
+        }): Parameters<SdkSpeculativeExecArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(tools::rpc::speculative_exec(transaction_json, verbosity, rpc_address).await)
     }
 
     #[tool(description = "JSON-RPC speculative_exec_deploy with full deploy JSON")]
     async fn sdk_speculative_exec_deploy(
         &self,
-        deploy_json: String,
-        verbosity: Option<String>,
-        rpc_address: Option<String>,
-    ) -> ToolOutput {
-        tools::rpc::speculative_exec_deploy(deploy_json, verbosity, rpc_address).await
+        Parameters(SdkSpeculativeExecDeployArgs {
+            deploy_json,
+            verbosity,
+            rpc_address,
+        }): Parameters<SdkSpeculativeExecDeployArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(tools::rpc::speculative_exec_deploy(deploy_json, verbosity, rpc_address).await)
     }
-
-    // --- binary-port (feature = "binary-port") ---
 
     #[tool(description = "Binary port: latest switch block header (needs CASPER_NODE_URL)")]
     async fn sdk_get_binary_latest_switch_block_header(
         &self,
-        node_address: Option<String>,
-    ) -> ToolOutput {
-        tools::binary_port::get_binary_latest_switch_block_header(node_address).await
+        Parameters(NodeOpts { node_address }): Parameters<NodeOpts>,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(tools::binary_port::get_binary_latest_switch_block_header(node_address).await)
     }
 
     #[tool(description = "Binary port: latest block header")]
-    async fn sdk_get_binary_latest_block_header(&self, node_address: Option<String>) -> ToolOutput {
-        tools::binary_port::get_binary_latest_block_header(node_address).await
+    async fn sdk_get_binary_latest_block_header(
+        &self,
+        Parameters(NodeOpts { node_address }): Parameters<NodeOpts>,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(tools::binary_port::get_binary_latest_block_header(node_address).await)
     }
 
     #[tool(description = "Binary port: block header by height")]
     async fn sdk_get_binary_block_header_by_height(
         &self,
-        height: u64,
-        node_address: Option<String>,
-    ) -> ToolOutput {
-        tools::binary_port::get_binary_block_header_by_height(height, node_address).await
+        Parameters(SdkGetBinaryBlockHeaderByHeightArgs {
+            height,
+            node_address,
+        }): Parameters<SdkGetBinaryBlockHeaderByHeightArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(tools::binary_port::get_binary_block_header_by_height(height, node_address).await)
     }
 
     #[tool(description = "Binary port: block header by hash hex")]
     async fn sdk_get_binary_block_header_by_hash(
         &self,
-        block_hash: String,
-        node_address: Option<String>,
-    ) -> ToolOutput {
-        tools::binary_port::get_binary_block_header_by_hash(block_hash, node_address).await
+        Parameters(SdkGetBinaryBlockHeaderByHashArgs {
+            block_hash,
+            node_address,
+        }): Parameters<SdkGetBinaryBlockHeaderByHashArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(tools::binary_port::get_binary_block_header_by_hash(block_hash, node_address).await)
     }
 
     #[tool(description = "Binary port: latest block with signatures")]
     async fn sdk_get_binary_latest_block_with_signatures(
         &self,
-        node_address: Option<String>,
-    ) -> ToolOutput {
-        tools::binary_port::get_binary_latest_block_with_signatures(node_address).await
+        Parameters(NodeOpts { node_address }): Parameters<NodeOpts>,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(tools::binary_port::get_binary_latest_block_with_signatures(node_address).await)
     }
 
     #[tool(description = "Binary port: block with signatures by height")]
     async fn sdk_get_binary_block_with_signatures_by_height(
         &self,
-        height: u64,
-        node_address: Option<String>,
-    ) -> ToolOutput {
-        tools::binary_port::get_binary_block_with_signatures_by_height(height, node_address).await
+        Parameters(SdkGetBinaryBlockHeaderByHeightArgs {
+            height,
+            node_address,
+        }): Parameters<SdkGetBinaryBlockHeaderByHeightArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(
+            tools::binary_port::get_binary_block_with_signatures_by_height(height, node_address)
+                .await,
+        )
     }
 
     #[tool(description = "Binary port: block with signatures by hash hex")]
     async fn sdk_get_binary_block_with_signatures_by_hash(
         &self,
-        block_hash: String,
-        node_address: Option<String>,
-    ) -> ToolOutput {
-        tools::binary_port::get_binary_block_with_signatures_by_hash(block_hash, node_address).await
+        Parameters(SdkGetBinaryBlockHeaderByHashArgs {
+            block_hash,
+            node_address,
+        }): Parameters<SdkGetBinaryBlockHeaderByHashArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(
+            tools::binary_port::get_binary_block_with_signatures_by_hash(block_hash, node_address)
+                .await,
+        )
     }
 
     #[tool(description = "Binary port: transaction by hash hex")]
     async fn sdk_get_binary_transaction_by_hash(
         &self,
-        hash: String,
-        with_finalized_approvals: Option<bool>,
-        node_address: Option<String>,
-    ) -> ToolOutput {
-        tools::binary_port::get_binary_transaction_by_hash(
+        Parameters(SdkGetBinaryTransactionByHashArgs {
+            hash,
+            with_finalized_approvals,
+            node_address,
+        }): Parameters<SdkGetBinaryTransactionByHashArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(tools::binary_port::get_binary_transaction_by_hash(
             hash,
             with_finalized_approvals,
             node_address,
         )
-        .await
+        .await)
     }
 
     #[tool(description = "Binary port: peers")]
-    async fn sdk_get_binary_peers(&self, node_address: Option<String>) -> ToolOutput {
-        tools::binary_port::get_binary_peers(node_address).await
+    async fn sdk_get_binary_peers(
+        &self,
+        Parameters(NodeOpts { node_address }): Parameters<NodeOpts>,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(tools::binary_port::get_binary_peers(node_address).await)
     }
 
     #[tool(description = "Binary port: node uptime")]
-    async fn sdk_get_binary_uptime(&self, node_address: Option<String>) -> ToolOutput {
-        tools::binary_port::get_binary_uptime(node_address).await
+    async fn sdk_get_binary_uptime(
+        &self,
+        Parameters(NodeOpts { node_address }): Parameters<NodeOpts>,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(tools::binary_port::get_binary_uptime(node_address).await)
     }
 
     #[tool(description = "Binary port: last progress")]
-    async fn sdk_get_binary_last_progress(&self, node_address: Option<String>) -> ToolOutput {
-        tools::binary_port::get_binary_last_progress(node_address).await
+    async fn sdk_get_binary_last_progress(
+        &self,
+        Parameters(NodeOpts { node_address }): Parameters<NodeOpts>,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(tools::binary_port::get_binary_last_progress(node_address).await)
     }
 
     #[tool(description = "Binary port: reactor state")]
-    async fn sdk_get_binary_reactor_state(&self, node_address: Option<String>) -> ToolOutput {
-        tools::binary_port::get_binary_reactor_state(node_address).await
+    async fn sdk_get_binary_reactor_state(
+        &self,
+        Parameters(NodeOpts { node_address }): Parameters<NodeOpts>,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(tools::binary_port::get_binary_reactor_state(node_address).await)
     }
 
     #[tool(description = "Binary port: network name")]
-    async fn sdk_get_binary_network_name(&self, node_address: Option<String>) -> ToolOutput {
-        tools::binary_port::get_binary_network_name(node_address).await
+    async fn sdk_get_binary_network_name(
+        &self,
+        Parameters(NodeOpts { node_address }): Parameters<NodeOpts>,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(tools::binary_port::get_binary_network_name(node_address).await)
     }
 
     #[tool(description = "Binary port: consensus validator changes")]
     async fn sdk_get_binary_consensus_validator_changes(
         &self,
-        node_address: Option<String>,
-    ) -> ToolOutput {
-        tools::binary_port::get_binary_consensus_validator_changes(node_address).await
+        Parameters(NodeOpts { node_address }): Parameters<NodeOpts>,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(tools::binary_port::get_binary_consensus_validator_changes(node_address).await)
     }
 
     #[tool(description = "Binary port: block synchronizer status")]
     async fn sdk_get_binary_block_synchronizer_status(
         &self,
-        node_address: Option<String>,
-    ) -> ToolOutput {
-        tools::binary_port::get_binary_block_synchronizer_status(node_address).await
+        Parameters(NodeOpts { node_address }): Parameters<NodeOpts>,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(tools::binary_port::get_binary_block_synchronizer_status(node_address).await)
     }
 
     #[tool(description = "Binary port: available block range")]
     async fn sdk_get_binary_available_block_range(
         &self,
-        node_address: Option<String>,
-    ) -> ToolOutput {
-        tools::binary_port::get_binary_available_block_range(node_address).await
+        Parameters(NodeOpts { node_address }): Parameters<NodeOpts>,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(tools::binary_port::get_binary_available_block_range(node_address).await)
     }
 
     #[tool(description = "Binary port: next upgrade")]
-    async fn sdk_get_binary_next_upgrade(&self, node_address: Option<String>) -> ToolOutput {
-        tools::binary_port::get_binary_next_upgrade(node_address).await
+    async fn sdk_get_binary_next_upgrade(
+        &self,
+        Parameters(NodeOpts { node_address }): Parameters<NodeOpts>,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(tools::binary_port::get_binary_next_upgrade(node_address).await)
     }
 
     #[tool(description = "Binary port: consensus status")]
-    async fn sdk_get_binary_consensus_status(&self, node_address: Option<String>) -> ToolOutput {
-        tools::binary_port::get_binary_consensus_status(node_address).await
+    async fn sdk_get_binary_consensus_status(
+        &self,
+        Parameters(NodeOpts { node_address }): Parameters<NodeOpts>,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(tools::binary_port::get_binary_consensus_status(node_address).await)
     }
 
     #[tool(description = "Binary port: chainspec raw bytes")]
-    async fn sdk_get_binary_chainspec_raw_bytes(&self, node_address: Option<String>) -> ToolOutput {
-        tools::binary_port::get_binary_chainspec_raw_bytes(node_address).await
+    async fn sdk_get_binary_chainspec_raw_bytes(
+        &self,
+        Parameters(NodeOpts { node_address }): Parameters<NodeOpts>,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(tools::binary_port::get_binary_chainspec_raw_bytes(node_address).await)
     }
 
     #[tool(description = "Binary port: node status")]
-    async fn sdk_get_binary_node_status(&self, node_address: Option<String>) -> ToolOutput {
-        tools::binary_port::get_binary_node_status(node_address).await
+    async fn sdk_get_binary_node_status(
+        &self,
+        Parameters(NodeOpts { node_address }): Parameters<NodeOpts>,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(tools::binary_port::get_binary_node_status(node_address).await)
     }
 
     #[tool(description = "Binary port: validator reward by era")]
     async fn sdk_get_binary_validator_reward_by_era(
         &self,
-        validator_key: String,
-        era: u64,
-        node_address: Option<String>,
-    ) -> ToolOutput {
-        tools::binary_port::get_binary_validator_reward_by_era(validator_key, era, node_address)
-            .await
+        Parameters(SdkGetBinaryValidatorRewardByEraArgs {
+            validator_key,
+            era,
+            node_address,
+        }): Parameters<SdkGetBinaryValidatorRewardByEraArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(
+            tools::binary_port::get_binary_validator_reward_by_era(
+                validator_key,
+                era,
+                node_address,
+            )
+            .await,
+        )
     }
 
     #[tool(description = "Binary port: validator reward by block height")]
     async fn sdk_get_binary_validator_reward_by_block_height(
         &self,
-        validator_key: String,
-        block_height: u64,
-        node_address: Option<String>,
-    ) -> ToolOutput {
-        tools::binary_port::get_binary_validator_reward_by_block_height(
+        Parameters(SdkGetBinaryValidatorRewardByBlockHeightArgs {
             validator_key,
             block_height,
             node_address,
+        }): Parameters<SdkGetBinaryValidatorRewardByBlockHeightArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(
+            tools::binary_port::get_binary_validator_reward_by_block_height(
+                validator_key,
+                block_height,
+                node_address,
+            )
+            .await,
         )
-        .await
     }
 
     #[tool(description = "Binary port: validator reward by block hash hex")]
     async fn sdk_get_binary_validator_reward_by_block_hash(
         &self,
-        validator_key: String,
-        block_hash: String,
-        node_address: Option<String>,
-    ) -> ToolOutput {
-        tools::binary_port::get_binary_validator_reward_by_block_hash(
+        Parameters(SdkGetBinaryValidatorRewardByBlockHashArgs {
             validator_key,
             block_hash,
             node_address,
+        }): Parameters<SdkGetBinaryValidatorRewardByBlockHashArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(
+            tools::binary_port::get_binary_validator_reward_by_block_hash(
+                validator_key,
+                block_hash,
+                node_address,
+            )
+            .await,
         )
-        .await
     }
 
     #[tool(description = "Binary port: delegator reward by era")]
     async fn sdk_get_binary_delegator_reward_by_era(
         &self,
-        validator_key: String,
-        delegator_key: String,
-        era: u64,
-        node_address: Option<String>,
-    ) -> ToolOutput {
-        tools::binary_port::get_binary_delegator_reward_by_era(
+        Parameters(SdkGetBinaryDelegatorRewardByEraArgs {
+            validator_key,
+            delegator_key,
+            era,
+            node_address,
+        }): Parameters<SdkGetBinaryDelegatorRewardByEraArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(tools::binary_port::get_binary_delegator_reward_by_era(
             validator_key,
             delegator_key,
             era,
             node_address,
         )
-        .await
+        .await)
     }
 
     #[tool(description = "Binary port: delegator reward by block height")]
     async fn sdk_get_binary_delegator_reward_by_block_height(
         &self,
-        validator_key: String,
-        delegator_key: String,
-        block_height: u64,
-        node_address: Option<String>,
-    ) -> ToolOutput {
-        tools::binary_port::get_binary_delegator_reward_by_block_height(
+        Parameters(SdkGetBinaryDelegatorRewardByBlockHeightArgs {
             validator_key,
             delegator_key,
             block_height,
             node_address,
+        }): Parameters<SdkGetBinaryDelegatorRewardByBlockHeightArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(
+            tools::binary_port::get_binary_delegator_reward_by_block_height(
+                validator_key,
+                delegator_key,
+                block_height,
+                node_address,
+            )
+            .await,
         )
-        .await
     }
 
     #[tool(description = "Binary port: delegator reward by block hash hex")]
     async fn sdk_get_binary_delegator_reward_by_block_hash(
         &self,
-        validator_key: String,
-        delegator_key: String,
-        block_hash: String,
-        node_address: Option<String>,
-    ) -> ToolOutput {
-        tools::binary_port::get_binary_delegator_reward_by_block_hash(
+        Parameters(SdkGetBinaryDelegatorRewardByBlockHashArgs {
             validator_key,
             delegator_key,
             block_hash,
             node_address,
+        }): Parameters<SdkGetBinaryDelegatorRewardByBlockHashArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(
+            tools::binary_port::get_binary_delegator_reward_by_block_hash(
+                validator_key,
+                delegator_key,
+                block_hash,
+                node_address,
+            )
+            .await,
         )
-        .await
     }
 
     #[tool(description = "Binary port: read record (record_id 0-7, key_hex)")]
     async fn sdk_get_binary_read_record(
         &self,
-        record_id: u16,
-        key_hex: String,
-        node_address: Option<String>,
-    ) -> ToolOutput {
-        tools::binary_port::get_binary_read_record(record_id, key_hex, node_address).await
+        Parameters(SdkGetBinaryReadRecordArgs {
+            record_id,
+            key_hex,
+            node_address,
+        }): Parameters<SdkGetBinaryReadRecordArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(tools::binary_port::get_binary_read_record(record_id, key_hex, node_address).await)
     }
 
     #[tool(
@@ -923,139 +1125,172 @@ impl CasperSdkMcp {
     )]
     async fn sdk_get_binary_global_state_item(
         &self,
-        key: String,
-        path: Option<String>,
-        node_address: Option<String>,
-    ) -> ToolOutput {
-        tools::binary_port::get_binary_global_state_item(key, path, node_address).await
+        Parameters(SdkGetBinaryGlobalStateItemArgs {
+            key,
+            path,
+            node_address,
+        }): Parameters<SdkGetBinaryGlobalStateItemArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(tools::binary_port::get_binary_global_state_item(key, path, node_address).await)
     }
 
     #[tool(description = "Binary port: global state item by state root hash")]
     async fn sdk_get_binary_global_state_item_by_state_root_hash(
         &self,
-        state_root_hash: String,
-        key: String,
-        path: Option<String>,
-        node_address: Option<String>,
-    ) -> ToolOutput {
-        tools::binary_port::get_binary_global_state_item_by_state_root_hash(
+        Parameters(SdkGetBinaryGlobalStateItemByStateRootHashArgs {
             state_root_hash,
             key,
             path,
             node_address,
+        }): Parameters<SdkGetBinaryGlobalStateItemByStateRootHashArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(
+            tools::binary_port::get_binary_global_state_item_by_state_root_hash(
+                state_root_hash,
+                key,
+                path,
+                node_address,
+            )
+            .await,
         )
-        .await
     }
 
     #[tool(description = "Binary port: global state item by block hash")]
     async fn sdk_get_binary_global_state_item_by_block_hash(
         &self,
-        block_hash: String,
-        key: String,
-        path: Option<String>,
-        node_address: Option<String>,
-    ) -> ToolOutput {
-        tools::binary_port::get_binary_global_state_item_by_block_hash(
+        Parameters(SdkGetBinaryGlobalStateItemByBlockHashArgs {
             block_hash,
             key,
             path,
             node_address,
+        }): Parameters<SdkGetBinaryGlobalStateItemByBlockHashArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(
+            tools::binary_port::get_binary_global_state_item_by_block_hash(
+                block_hash,
+                key,
+                path,
+                node_address,
+            )
+            .await,
         )
-        .await
     }
 
     #[tool(description = "Binary port: global state item by block height")]
     async fn sdk_get_binary_global_state_item_by_block_height(
         &self,
-        block_height: u64,
-        key: String,
-        path: Option<String>,
-        node_address: Option<String>,
-    ) -> ToolOutput {
-        tools::binary_port::get_binary_global_state_item_by_block_height(
+        Parameters(SdkGetBinaryGlobalStateItemByBlockHeightArgs {
             block_height,
             key,
             path,
             node_address,
+        }): Parameters<SdkGetBinaryGlobalStateItemByBlockHeightArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(
+            tools::binary_port::get_binary_global_state_item_by_block_height(
+                block_height,
+                key,
+                path,
+                node_address,
+            )
+            .await,
         )
-        .await
     }
 
     #[tool(description = "Binary port: speculative execution of transaction JSON")]
     async fn sdk_get_binary_try_speculative_execution(
         &self,
-        transaction_json: String,
-        node_address: Option<String>,
-    ) -> ToolOutput {
-        tools::binary_port::get_binary_try_speculative_execution(transaction_json, node_address)
-            .await
+        Parameters(SdkGetBinaryTrySpeculativeExecutionArgs {
+            transaction_json,
+            node_address,
+        }): Parameters<SdkGetBinaryTrySpeculativeExecutionArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(
+            tools::binary_port::get_binary_try_speculative_execution(
+                transaction_json,
+                node_address,
+            )
+            .await,
+        )
     }
 
     #[tool(description = "Binary port: protocol version")]
-    async fn sdk_get_binary_protocol_version(&self, node_address: Option<String>) -> ToolOutput {
-        tools::binary_port::get_binary_protocol_version(node_address).await
+    async fn sdk_get_binary_protocol_version(
+        &self,
+        Parameters(NodeOpts { node_address }): Parameters<NodeOpts>,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(tools::binary_port::get_binary_protocol_version(node_address).await)
     }
-
-    // --- transaction (feature = "transaction") ---
 
     #[tool(
         description = "Build unsigned transaction from builder_params_json + transaction_params_json"
     )]
     async fn sdk_make_transaction(
         &self,
-        builder_params_json: String,
-        transaction_params_json: String,
-    ) -> ToolOutput {
-        tools::transaction::make_transaction(builder_params_json, transaction_params_json)
+        Parameters(SdkMakeTransactionArgs {
+            builder_params_json,
+            transaction_params_json,
+        }): Parameters<SdkMakeTransactionArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(tools::transaction::make_transaction(
+            builder_params_json,
+            transaction_params_json,
+        ))
     }
 
     #[tool(description = "Build unsigned transfer transaction")]
     async fn sdk_make_transfer_transaction(
         &self,
-        target: String,
-        amount: String,
-        transaction_params_json: String,
-        maybe_source: Option<String>,
-        maybe_id: Option<String>,
-    ) -> ToolOutput {
-        tools::transaction::make_transfer_transaction(
+        Parameters(SdkMakeTransferTransactionArgs {
             target,
             amount,
             transaction_params_json,
             maybe_source,
             maybe_id,
-        )
+        }): Parameters<SdkMakeTransferTransactionArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(tools::transaction::make_transfer_transaction(
+            target,
+            amount,
+            transaction_params_json,
+            maybe_source,
+            maybe_id,
+        ))
     }
 
     #[tool(description = "Speculative exec of a built transaction (no submit)")]
     async fn sdk_speculative_transaction(
         &self,
-        builder_params_json: String,
-        transaction_params_json: String,
-        verbosity: Option<String>,
-        rpc_address: Option<String>,
-    ) -> ToolOutput {
-        tools::transaction::speculative_transaction(
+        Parameters(SdkSpeculativeTransactionArgs {
+            builder_params_json,
+            transaction_params_json,
+            verbosity,
+            rpc_address,
+        }): Parameters<SdkSpeculativeTransactionArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(tools::transaction::speculative_transaction(
             builder_params_json,
             transaction_params_json,
             verbosity,
             rpc_address,
         )
-        .await
+        .await)
     }
 
     #[tool(description = "Speculative transfer transaction (no submit)")]
     async fn sdk_speculative_transfer_transaction(
         &self,
-        target_account: String,
-        amount: String,
-        transaction_params_json: String,
-        maybe_source: Option<String>,
-        maybe_id: Option<String>,
-        verbosity: Option<String>,
-        rpc_address: Option<String>,
-    ) -> ToolOutput {
-        tools::transaction::speculative_transfer_transaction(
+        Parameters(SdkSpeculativeTransferTransactionArgs {
+            target_account,
+            amount,
+            transaction_params_json,
+            maybe_source,
+            maybe_id,
+            verbosity,
+            rpc_address,
+        }): Parameters<SdkSpeculativeTransferTransactionArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(tools::transaction::speculative_transfer_transaction(
             target_account,
             amount,
             transaction_params_json,
@@ -1064,70 +1299,80 @@ impl CasperSdkMcp {
             verbosity,
             rpc_address,
         )
-        .await
+        .await)
     }
-
-    // --- deploy (feature = "deploy", legacy) ---
 
     #[tool(description = "Build unsigned legacy deploy")]
     async fn sdk_make_deploy(
         &self,
-        deploy_params_json: String,
-        session_params_json: String,
-        payment_params_json: String,
-    ) -> ToolOutput {
-        tools::deploy::make_deploy(deploy_params_json, session_params_json, payment_params_json)
+        Parameters(SdkMakeDeployArgs {
+            deploy_params_json,
+            session_params_json,
+            payment_params_json,
+        }): Parameters<SdkMakeDeployArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(tools::deploy::make_deploy(
+            deploy_params_json,
+            session_params_json,
+            payment_params_json,
+        ))
     }
 
     #[tool(description = "Build unsigned legacy transfer deploy")]
     async fn sdk_make_transfer(
         &self,
-        amount: String,
-        target_account: String,
-        deploy_params_json: String,
-        payment_params_json: String,
-        transfer_id: Option<String>,
-    ) -> ToolOutput {
-        tools::deploy::make_transfer(
+        Parameters(SdkMakeTransferArgs {
             amount,
             target_account,
             deploy_params_json,
             payment_params_json,
             transfer_id,
-        )
+        }): Parameters<SdkMakeTransferArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(tools::deploy::make_transfer(
+            amount,
+            target_account,
+            deploy_params_json,
+            payment_params_json,
+            transfer_id,
+        ))
     }
 
     #[tool(description = "Speculative legacy deploy (no submit)")]
     async fn sdk_speculative_deploy(
         &self,
-        deploy_params_json: String,
-        session_params_json: String,
-        payment_params_json: String,
-        verbosity: Option<String>,
-        rpc_address: Option<String>,
-    ) -> ToolOutput {
-        tools::deploy::speculative_deploy(
+        Parameters(SdkSpeculativeDeployArgs {
+            deploy_params_json,
+            session_params_json,
+            payment_params_json,
+            verbosity,
+            rpc_address,
+        }): Parameters<SdkSpeculativeDeployArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(tools::deploy::speculative_deploy(
             deploy_params_json,
             session_params_json,
             payment_params_json,
             verbosity,
             rpc_address,
         )
-        .await
+        .await)
     }
 
     #[tool(description = "Speculative legacy transfer (no submit)")]
     async fn sdk_speculative_transfer(
         &self,
-        amount: String,
-        target_account: String,
-        deploy_params_json: String,
-        payment_params_json: String,
-        transfer_id: Option<String>,
-        verbosity: Option<String>,
-        rpc_address: Option<String>,
-    ) -> ToolOutput {
-        tools::deploy::speculative_transfer(
+        Parameters(SdkSpeculativeTransferArgs {
+            amount,
+            target_account,
+            deploy_params_json,
+            payment_params_json,
+            transfer_id,
+            verbosity,
+            rpc_address,
+        }): Parameters<SdkSpeculativeTransferArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(tools::deploy::speculative_transfer(
             amount,
             target_account,
             deploy_params_json,
@@ -1136,99 +1381,107 @@ impl CasperSdkMcp {
             verbosity,
             rpc_address,
         )
-        .await
+        .await)
     }
-
-    // --- contract queries (feature = "contract") ---
 
     #[tool(description = "Query contract dictionary; kind + dictionary_item_json fields")]
     async fn sdk_query_contract_dict(
         &self,
-        kind: String,
-        dictionary_item_json: String,
-        state_root_hash: Option<String>,
-        verbosity: Option<String>,
-        rpc_address: Option<String>,
-    ) -> ToolOutput {
-        tools::contract::query_contract_dict(
+        Parameters(SdkQueryContractDictArgs {
+            kind,
+            dictionary_item_json,
+            state_root_hash,
+            verbosity,
+            rpc_address,
+        }): Parameters<SdkQueryContractDictArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(tools::contract::query_contract_dict(
             kind,
             dictionary_item_json,
             state_root_hash,
             verbosity,
             rpc_address,
         )
-        .await
+        .await)
     }
 
     #[tool(description = "Query contract named key path under an entity")]
     async fn sdk_query_contract_key(
         &self,
-        entity_identifier: String,
-        path: String,
-        maybe_block_identifier: Option<String>,
-        verbosity: Option<String>,
-        rpc_address: Option<String>,
-    ) -> ToolOutput {
-        tools::contract::query_contract_key(
+        Parameters(SdkQueryContractKeyArgs {
+            entity_identifier,
+            path,
+            maybe_block_identifier,
+            verbosity,
+            rpc_address,
+        }): Parameters<SdkQueryContractKeyArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(tools::contract::query_contract_key(
             entity_identifier,
             path,
             maybe_block_identifier,
             verbosity,
             rpc_address,
         )
-        .await
+        .await)
     }
-
-    // --- write (feature = "write") ---
 
     #[tool(description = "Sign transaction JSON with secret key PEM (mutates approvals)")]
     async fn sdk_sign_transaction(
         &self,
-        transaction_json: String,
-        secret_key: String,
-    ) -> ToolOutput {
-        tools::write::sign_transaction(transaction_json, secret_key)
+        Parameters(SdkSignTransactionArgs {
+            transaction_json,
+            secret_key,
+        }): Parameters<SdkSignTransactionArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(tools::write::sign_transaction(transaction_json, secret_key))
     }
 
     #[tool(description = "Submit signed transaction JSON via put_transaction")]
     async fn sdk_put_transaction(
         &self,
-        transaction_json: String,
-        verbosity: Option<String>,
-        rpc_address: Option<String>,
-    ) -> ToolOutput {
-        tools::write::put_transaction(transaction_json, verbosity, rpc_address).await
+        Parameters(SdkSpeculativeExecArgs {
+            transaction_json,
+            verbosity,
+            rpc_address,
+        }): Parameters<SdkSpeculativeExecArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(tools::write::put_transaction(transaction_json, verbosity, rpc_address).await)
     }
 
     #[tool(description = "Build + submit transaction (make + put)")]
     async fn sdk_transaction(
         &self,
-        builder_params_json: String,
-        transaction_params_json: String,
-        verbosity: Option<String>,
-        rpc_address: Option<String>,
-    ) -> ToolOutput {
-        tools::write::transaction(
+        Parameters(SdkSpeculativeTransactionArgs {
+            builder_params_json,
+            transaction_params_json,
+            verbosity,
+            rpc_address,
+        }): Parameters<SdkSpeculativeTransactionArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(tools::write::transaction(
             builder_params_json,
             transaction_params_json,
             verbosity,
             rpc_address,
         )
-        .await
+        .await)
     }
 
     #[tool(description = "Build + submit transfer transaction")]
     async fn sdk_transfer_transaction(
         &self,
-        target_account: String,
-        amount: String,
-        transaction_params_json: String,
-        maybe_source: Option<String>,
-        maybe_id: Option<String>,
-        verbosity: Option<String>,
-        rpc_address: Option<String>,
-    ) -> ToolOutput {
-        tools::write::transfer_transaction(
+        Parameters(SdkSpeculativeTransferTransactionArgs {
+            target_account,
+            amount,
+            transaction_params_json,
+            maybe_source,
+            maybe_id,
+            verbosity,
+            rpc_address,
+        }): Parameters<SdkSpeculativeTransferTransactionArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(tools::write::transfer_transaction(
             target_account,
             amount,
             transaction_params_json,
@@ -1237,55 +1490,67 @@ impl CasperSdkMcp {
             verbosity,
             rpc_address,
         )
-        .await
+        .await)
     }
 
     #[tool(description = "Sign deploy JSON with secret key PEM")]
-    async fn sdk_sign_deploy(&self, deploy_json: String, secret_key: String) -> ToolOutput {
-        tools::write::sign_deploy(deploy_json, secret_key)
+    async fn sdk_sign_deploy(
+        &self,
+        Parameters(SdkSignDeployArgs {
+            deploy_json,
+            secret_key,
+        }): Parameters<SdkSignDeployArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(tools::write::sign_deploy(deploy_json, secret_key))
     }
 
     #[tool(description = "Submit signed deploy JSON")]
     async fn sdk_put_deploy(
         &self,
-        deploy_json: String,
-        verbosity: Option<String>,
-        rpc_address: Option<String>,
-    ) -> ToolOutput {
-        tools::write::put_deploy(deploy_json, verbosity, rpc_address).await
+        Parameters(SdkSpeculativeExecDeployArgs {
+            deploy_json,
+            verbosity,
+            rpc_address,
+        }): Parameters<SdkSpeculativeExecDeployArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(tools::write::put_deploy(deploy_json, verbosity, rpc_address).await)
     }
 
     #[tool(description = "Build + submit legacy deploy")]
     async fn sdk_deploy(
         &self,
-        deploy_params_json: String,
-        session_params_json: String,
-        payment_params_json: String,
-        verbosity: Option<String>,
-        rpc_address: Option<String>,
-    ) -> ToolOutput {
-        tools::write::deploy(
+        Parameters(SdkSpeculativeDeployArgs {
+            deploy_params_json,
+            session_params_json,
+            payment_params_json,
+            verbosity,
+            rpc_address,
+        }): Parameters<SdkSpeculativeDeployArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(tools::write::deploy(
             deploy_params_json,
             session_params_json,
             payment_params_json,
             verbosity,
             rpc_address,
         )
-        .await
+        .await)
     }
 
     #[tool(description = "Build + submit legacy transfer")]
     async fn sdk_transfer(
         &self,
-        amount: String,
-        target_account: String,
-        deploy_params_json: String,
-        payment_params_json: String,
-        transfer_id: Option<String>,
-        verbosity: Option<String>,
-        rpc_address: Option<String>,
-    ) -> ToolOutput {
-        tools::write::transfer(
+        Parameters(SdkSpeculativeTransferArgs {
+            amount,
+            target_account,
+            deploy_params_json,
+            payment_params_json,
+            transfer_id,
+            verbosity,
+            rpc_address,
+        }): Parameters<SdkSpeculativeTransferArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(tools::write::transfer(
             amount,
             target_account,
             deploy_params_json,
@@ -1294,7 +1559,7 @@ impl CasperSdkMcp {
             verbosity,
             rpc_address,
         )
-        .await
+        .await)
     }
 
     #[tool(
@@ -1302,29 +1567,33 @@ impl CasperSdkMcp {
     )]
     async fn sdk_install(
         &self,
-        transaction_params_json: String,
-        wasm_hex: String,
-        rpc_address: Option<String>,
-        runtime_v2: Option<bool>,
-    ) -> ToolOutput {
-        tools::write::install(transaction_params_json, wasm_hex, rpc_address, runtime_v2).await
+        Parameters(SdkInstallArgs {
+            transaction_params_json,
+            wasm_hex,
+            rpc_address,
+            runtime_v2,
+        }): Parameters<SdkInstallArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(tools::write::install(transaction_params_json, wasm_hex, rpc_address, runtime_v2).await)
     }
 
     #[tool(description = "Install via legacy deploy (deprecated; prefer sdk_install)")]
     async fn sdk_install_deploy(
         &self,
-        deploy_params_json: String,
-        session_params_json: String,
-        payment_amount: String,
-        rpc_address: Option<String>,
-    ) -> ToolOutput {
-        tools::write::install_deploy(
+        Parameters(SdkInstallDeployArgs {
+            deploy_params_json,
+            session_params_json,
+            payment_amount,
+            rpc_address,
+        }): Parameters<SdkInstallDeployArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(tools::write::install_deploy(
             deploy_params_json,
             session_params_json,
             payment_amount,
             rpc_address,
         )
-        .await
+        .await)
     }
 
     #[tool(
@@ -1332,64 +1601,70 @@ impl CasperSdkMcp {
     )]
     async fn sdk_call_entrypoint(
         &self,
-        builder_params_json: String,
-        transaction_params_json: String,
-        rpc_address: Option<String>,
-        runtime_v2: Option<bool>,
-    ) -> ToolOutput {
-        tools::write::call_entrypoint(
+        Parameters(SdkCallEntrypointArgs {
+            builder_params_json,
+            transaction_params_json,
+            rpc_address,
+            runtime_v2,
+        }): Parameters<SdkCallEntrypointArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(tools::write::call_entrypoint(
             builder_params_json,
             transaction_params_json,
             rpc_address,
             runtime_v2,
         )
-        .await
+        .await)
     }
 
     #[tool(description = "Call entrypoint via legacy deploy (deprecated)")]
     async fn sdk_call_entrypoint_deploy(
         &self,
-        deploy_params_json: String,
-        session_params_json: String,
-        payment_params_json: String,
-        rpc_address: Option<String>,
-    ) -> ToolOutput {
-        tools::write::call_entrypoint_deploy(
+        Parameters(SdkCallEntrypointDeployArgs {
+            deploy_params_json,
+            session_params_json,
+            payment_params_json,
+            rpc_address,
+        }): Parameters<SdkCallEntrypointDeployArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(tools::write::call_entrypoint_deploy(
             deploy_params_json,
             session_params_json,
             payment_params_json,
             rpc_address,
         )
-        .await
+        .await)
     }
 
     #[tool(description = "Binary port: try_accept_transaction (submit via binary port)")]
     async fn sdk_get_binary_try_accept_transaction(
         &self,
-        transaction_json: String,
-        node_address: Option<String>,
-    ) -> ToolOutput {
-        tools::write::get_binary_try_accept_transaction(transaction_json, node_address).await
+        Parameters(SdkGetBinaryTrySpeculativeExecutionArgs {
+            transaction_json,
+            node_address,
+        }): Parameters<SdkGetBinaryTrySpeculativeExecutionArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(tools::write::get_binary_try_accept_transaction(transaction_json, node_address).await)
     }
-
-    // --- watcher (feature = "watcher") / SSE (feature = "SSE") ---
 
     #[tool(description = "Wait for TransactionProcessed on node SSE for a transaction hash")]
     async fn sdk_wait_transaction(
         &self,
-        events_url: String,
-        transaction_hash: String,
-        timeout_ms: Option<u64>,
-    ) -> ToolOutput {
+        Parameters(SdkWaitTransactionArgs {
+            events_url,
+            transaction_hash,
+            timeout_ms,
+        }): Parameters<SdkWaitTransactionArgs>,
+    ) -> Result<CallToolResult, McpError> {
         #[cfg(feature = "watcher")]
         {
-            tools::watcher::wait_transaction(events_url, transaction_hash, timeout_ms).await
+            Ok(tools::watcher::wait_transaction(events_url, transaction_hash, timeout_ms).await)
         }
         #[cfg(not(feature = "watcher"))]
-        {
+        Ok({
             let _ = (events_url, transaction_hash, timeout_ms);
             tools::feature_disabled("watcher")
-        }
+        })
     }
 
     #[tool(
@@ -1398,22 +1673,32 @@ impl CasperSdkMcp {
     #[allow(non_snake_case)]
     async fn sdk_SSE_collect(
         &self,
-        events_url: String,
-        event_names: String,
-        max_events: Option<u64>,
-        timeout_ms: Option<u64>,
-        start_from: Option<u64>,
-    ) -> ToolOutput {
+        Parameters(SdkSseCollectArgs {
+            events_url,
+            event_names,
+            max_events,
+            timeout_ms,
+            start_from,
+        }): Parameters<SdkSseCollectArgs>,
+    ) -> Result<CallToolResult, McpError> {
         #[cfg(feature = "SSE")]
         {
-            tools::SSE::SSE_collect(events_url, event_names, max_events, timeout_ms, start_from)
-                .await
+            Ok(
+                tools::SSE::SSE_collect(
+                    events_url,
+                    event_names,
+                    max_events,
+                    timeout_ms,
+                    start_from,
+                )
+                .await,
+            )
         }
         #[cfg(not(feature = "SSE"))]
-        {
+        Ok({
             let _ = (events_url, event_names, max_events, timeout_ms, start_from);
             tools::feature_disabled("SSE")
-        }
+        })
     }
 
     #[tool(
@@ -1422,19 +1707,24 @@ impl CasperSdkMcp {
     #[allow(non_snake_case)]
     async fn sdk_CES_parser_create(
         &self,
-        contract_hashes_json: String,
-        state_root_hash: Option<String>,
-        rpc_address: Option<String>,
-    ) -> ToolOutput {
+        Parameters(SdkCesParserCreateArgs {
+            contract_hashes_json,
+            state_root_hash,
+            rpc_address,
+        }): Parameters<SdkCesParserCreateArgs>,
+    ) -> Result<CallToolResult, McpError> {
         #[cfg(feature = "SSE")]
         {
-            tools::SSE::CES_parser_create(contract_hashes_json, state_root_hash, rpc_address).await
+            Ok(
+                tools::SSE::CES_parser_create(contract_hashes_json, state_root_hash, rpc_address)
+                    .await,
+            )
         }
         #[cfg(not(feature = "SSE"))]
-        {
+        Ok({
             let _ = (contract_hashes_json, state_root_hash, rpc_address);
             tools::feature_disabled("SSE")
-        }
+        })
     }
 
     #[tool(
@@ -1443,18 +1733,23 @@ impl CasperSdkMcp {
     #[allow(non_snake_case)]
     async fn sdk_CES_parse_execution_result(
         &self,
-        schemas_metadata_json: String,
-        execution_result_json: String,
-    ) -> ToolOutput {
+        Parameters(SdkCesParseExecutionResultArgs {
+            schemas_metadata_json,
+            execution_result_json,
+        }): Parameters<SdkCesParseExecutionResultArgs>,
+    ) -> Result<CallToolResult, McpError> {
         #[cfg(feature = "SSE")]
         {
-            tools::SSE::CES_parse_execution_result(schemas_metadata_json, execution_result_json)
+            Ok(tools::SSE::CES_parse_execution_result(
+                schemas_metadata_json,
+                execution_result_json,
+            ))
         }
         #[cfg(not(feature = "SSE"))]
-        {
+        Ok({
             let _ = (schemas_metadata_json, execution_result_json);
             tools::feature_disabled("SSE")
-        }
+        })
     }
 
     #[tool(
@@ -1463,16 +1758,18 @@ impl CasperSdkMcp {
     #[allow(non_snake_case)]
     async fn sdk_CES_parse_transaction(
         &self,
-        contract_hashes_json: String,
-        transaction_hash: String,
-        finalized_approvals: Option<bool>,
-        state_root_hash: Option<String>,
-        verbosity: Option<String>,
-        rpc_address: Option<String>,
-    ) -> ToolOutput {
+        Parameters(SdkCesParseTransactionArgs {
+            contract_hashes_json,
+            transaction_hash,
+            finalized_approvals,
+            state_root_hash,
+            verbosity,
+            rpc_address,
+        }): Parameters<SdkCesParseTransactionArgs>,
+    ) -> Result<CallToolResult, McpError> {
         #[cfg(feature = "SSE")]
         {
-            tools::SSE::CES_parse_transaction(
+            Ok(tools::SSE::CES_parse_transaction(
                 contract_hashes_json,
                 transaction_hash,
                 finalized_approvals,
@@ -1480,10 +1777,10 @@ impl CasperSdkMcp {
                 verbosity,
                 rpc_address,
             )
-            .await
+            .await)
         }
         #[cfg(not(feature = "SSE"))]
-        {
+        Ok({
             let _ = (
                 contract_hashes_json,
                 transaction_hash,
@@ -1493,7 +1790,7 @@ impl CasperSdkMcp {
                 rpc_address,
             );
             tools::feature_disabled("SSE")
-        }
+        })
     }
 }
 
@@ -1553,67 +1850,54 @@ Pending tool groups
 }
 
 /// Serves MCP over stdio until the client disconnects.
-pub async fn run() -> Result<(), McpError> {
-    let transport = StdioTransport::new();
-    let server = ServerBuilder::new(CasperSdkMcp)
-        .with_tools(CasperSdkMcp)
-        .build();
-    server.serve(transport).await
+pub async fn run() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let server = CasperSdkMcp;
+    let service = server.serve(stdio()).await?;
+    service.waiting().await?;
+    Ok(())
 }
 
 /// Serves MCP over Streamable HTTP until the process is stopped.
 pub async fn run_http(addr: &str) -> std::io::Result<()> {
-    McpRouter::new(CasperSdkMcp).serve(addr).await
+    let config =
+        rmcp::transport::streamable_http_server::tower::StreamableHttpServerConfig::default();
+    let service = rmcp::transport::streamable_http_server::tower::StreamableHttpService::new(
+        || Ok(CasperSdkMcp),
+        Arc::new(
+            rmcp::transport::streamable_http_server::session::local::LocalSessionManager::default(),
+        ),
+        config,
+    );
+    let method_router = axum::routing::any_service(service);
+    let app = axum::Router::new()
+        .route("/mcp", method_router.clone())
+        .route("/mcp/", method_router);
+    let listener = tokio::net::TcpListener::bind(addr).await?;
+    tracing::info!(%addr, "casper-rust-wasm-sdk-mcp HTTP listening");
+    axum::serve(listener, app).await?;
+    Ok(())
 }
 
-impl ResourceHandler for CasperSdkMcp {
-    async fn list_resources(&self, _ctx: &Context<'_>) -> Result<Vec<Resource>, McpError> {
-        Ok(Vec::new())
-    }
-
-    async fn read_resource(
-        &self,
-        uri: &str,
-        _ctx: &Context<'_>,
-    ) -> Result<Vec<ResourceContents>, McpError> {
-        Err(McpError::invalid_params(
-            "resources/read",
-            format!("unknown resource: {uri}"),
-        ))
-    }
-}
-
-impl PromptHandler for CasperSdkMcp {
-    async fn list_prompts(&self, _ctx: &Context<'_>) -> Result<Vec<Prompt>, McpError> {
-        Ok(Vec::new())
-    }
-
-    async fn get_prompt(
-        &self,
-        name: &str,
-        _args: Option<serde_json::Map<String, serde_json::Value>>,
-        _ctx: &Context<'_>,
-    ) -> Result<GetPromptResult, McpError> {
-        Err(McpError::invalid_params(
-            "prompts/get",
-            format!("unknown prompt: {name}"),
-        ))
+#[tool_handler]
+impl ServerHandler for CasperSdkMcp {
+    fn get_info(&self) -> ServerInfo {
+        ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
+            .with_server_info(rmcp::model::Implementation::new(
+                "casper-rust-wasm-sdk",
+                env!("CARGO_PKG_VERSION"),
+            ))
+            .with_instructions(help_text())
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+
     #[test]
     fn mcp_server_version_matches_crate() {
-        let src = include_str!("server.rs");
-        let needle = format!(
-            r#"#[mcp_server(name = "casper-rust-wasm-sdk", version = "{}")]"#,
-            env!("CARGO_PKG_VERSION")
-        );
-        assert!(
-            src.contains(&needle),
-            "bump #[mcp_server(version = …)] to {} when changing Cargo.toml version",
-            env!("CARGO_PKG_VERSION")
-        );
+        let info = CasperSdkMcp.get_info();
+        assert_eq!(info.server_info.version, env!("CARGO_PKG_VERSION"));
+        assert_eq!(info.server_info.name.as_str(), "casper-rust-wasm-sdk");
     }
 }

--- a/mcp/src/tool_args.rs
+++ b/mcp/src/tool_args.rs
@@ -1,0 +1,631 @@
+//! JSON-schema parameter structs for rmcp `Parameters<T>` tool handlers.
+
+use schemars::JsonSchema;
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct RpcOpts {
+    #[serde(default)]
+    pub verbosity: Option<String>,
+    #[serde(default)]
+    pub rpc_address: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct NodeOpts {
+    #[serde(default)]
+    pub node_address: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct BlockIdOpts {
+    #[serde(default)]
+    pub maybe_block_identifier: Option<String>,
+    #[serde(default)]
+    pub verbosity: Option<String>,
+    #[serde(default)]
+    pub rpc_address: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SdkCallEntrypointArgs {
+    pub builder_params_json: String,
+    pub transaction_params_json: String,
+    #[serde(default)]
+    pub rpc_address: Option<String>,
+    #[serde(default)]
+    pub runtime_v2: Option<bool>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SdkCallEntrypointDeployArgs {
+    pub deploy_params_json: String,
+    pub session_params_json: String,
+    pub payment_params_json: String,
+    #[serde(default)]
+    pub rpc_address: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SdkCesParseExecutionResultArgs {
+    pub schemas_metadata_json: String,
+    pub execution_result_json: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SdkCesParseTransactionArgs {
+    pub contract_hashes_json: String,
+    pub transaction_hash: String,
+    #[serde(default)]
+    pub finalized_approvals: Option<bool>,
+    #[serde(default)]
+    pub state_root_hash: Option<String>,
+    #[serde(default)]
+    pub verbosity: Option<String>,
+    #[serde(default)]
+    pub rpc_address: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SdkCesParserCreateArgs {
+    pub contract_hashes_json: String,
+    #[serde(default)]
+    pub state_root_hash: Option<String>,
+    #[serde(default)]
+    pub rpc_address: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SdkClValueToJsonArgs {
+    pub cl_value_json: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SdkGetAccountArgs {
+    #[serde(default)]
+    pub account_identifier: Option<String>,
+    #[serde(default)]
+    pub maybe_block_identifier: Option<String>,
+    #[serde(default)]
+    pub verbosity: Option<String>,
+    #[serde(default)]
+    pub rpc_address: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SdkGetBalanceArgs {
+    pub purse_uref: String,
+    #[serde(default)]
+    pub state_root_hash: Option<String>,
+    #[serde(default)]
+    pub verbosity: Option<String>,
+    #[serde(default)]
+    pub rpc_address: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SdkGetBase64KeyFromAccountHashArgs {
+    pub account_hash: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SdkGetBase64KeyFromKeyHashArgs {
+    pub formatted_hash: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SdkGetBinaryBlockHeaderByHashArgs {
+    pub block_hash: String,
+    #[serde(default)]
+    pub node_address: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SdkGetBinaryBlockHeaderByHeightArgs {
+    pub height: u64,
+    #[serde(default)]
+    pub node_address: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SdkGetBinaryDelegatorRewardByBlockHashArgs {
+    pub validator_key: String,
+    pub delegator_key: String,
+    pub block_hash: String,
+    #[serde(default)]
+    pub node_address: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SdkGetBinaryDelegatorRewardByBlockHeightArgs {
+    pub validator_key: String,
+    pub delegator_key: String,
+    pub block_height: u64,
+    #[serde(default)]
+    pub node_address: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SdkGetBinaryDelegatorRewardByEraArgs {
+    pub validator_key: String,
+    pub delegator_key: String,
+    pub era: u64,
+    #[serde(default)]
+    pub node_address: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SdkGetBinaryGlobalStateItemArgs {
+    pub key: String,
+    #[serde(default)]
+    pub path: Option<String>,
+    #[serde(default)]
+    pub node_address: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SdkGetBinaryGlobalStateItemByBlockHashArgs {
+    pub block_hash: String,
+    pub key: String,
+    #[serde(default)]
+    pub path: Option<String>,
+    #[serde(default)]
+    pub node_address: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SdkGetBinaryGlobalStateItemByBlockHeightArgs {
+    pub block_height: u64,
+    pub key: String,
+    #[serde(default)]
+    pub path: Option<String>,
+    #[serde(default)]
+    pub node_address: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SdkGetBinaryGlobalStateItemByStateRootHashArgs {
+    pub state_root_hash: String,
+    pub key: String,
+    #[serde(default)]
+    pub path: Option<String>,
+    #[serde(default)]
+    pub node_address: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SdkGetBinaryReadRecordArgs {
+    pub record_id: u16,
+    pub key_hex: String,
+    #[serde(default)]
+    pub node_address: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SdkGetBinaryTransactionByHashArgs {
+    pub hash: String,
+    #[serde(default)]
+    pub with_finalized_approvals: Option<bool>,
+    #[serde(default)]
+    pub node_address: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SdkGetBinaryTrySpeculativeExecutionArgs {
+    pub transaction_json: String,
+    #[serde(default)]
+    pub node_address: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SdkGetBinaryValidatorRewardByBlockHashArgs {
+    pub validator_key: String,
+    pub block_hash: String,
+    #[serde(default)]
+    pub node_address: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SdkGetBinaryValidatorRewardByBlockHeightArgs {
+    pub validator_key: String,
+    pub block_height: u64,
+    #[serde(default)]
+    pub node_address: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SdkGetBinaryValidatorRewardByEraArgs {
+    pub validator_key: String,
+    pub era: u64,
+    #[serde(default)]
+    pub node_address: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SdkGetBlake2bHashArgs {
+    pub meta_data: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SdkGetBlockTransactionsArgs {
+    pub block_identifier: String,
+    #[serde(default)]
+    pub expand: Option<bool>,
+    #[serde(default)]
+    pub verbosity: Option<String>,
+    #[serde(default)]
+    pub rpc_address: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SdkGetCurrentTimestampArgs {
+    #[serde(default)]
+    pub timestamp: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SdkGetDeployArgs {
+    pub deploy_hash: String,
+    #[serde(default)]
+    pub finalized_approvals: Option<bool>,
+    #[serde(default)]
+    pub verbosity: Option<String>,
+    #[serde(default)]
+    pub rpc_address: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SdkGetDictionaryItemArgs {
+    pub kind: String,
+    #[serde(default)]
+    pub key: Option<String>,
+    #[serde(default)]
+    pub dictionary_name: Option<String>,
+    #[serde(default)]
+    pub dictionary_item_key: Option<String>,
+    #[serde(default)]
+    pub seed_uref: Option<String>,
+    #[serde(default)]
+    pub dictionary_value: Option<String>,
+    #[serde(default)]
+    pub state_root_hash: Option<String>,
+    #[serde(default)]
+    pub verbosity: Option<String>,
+    #[serde(default)]
+    pub rpc_address: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SdkGetEntityArgs {
+    #[serde(default)]
+    pub entity_identifier: Option<String>,
+    #[serde(default)]
+    pub maybe_block_identifier: Option<String>,
+    #[serde(default)]
+    pub verbosity: Option<String>,
+    #[serde(default)]
+    pub rpc_address: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SdkGetGasPriceOrDefaultArgs {
+    #[serde(default)]
+    pub gas_price: Option<u64>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SdkGetLatestBlocksArgs {
+    #[serde(default)]
+    pub count: Option<u32>,
+    #[serde(default)]
+    pub verbosity: Option<String>,
+    #[serde(default)]
+    pub rpc_address: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SdkGetRewardArgs {
+    pub validator: String,
+    #[serde(default)]
+    pub delegator: Option<String>,
+    #[serde(default)]
+    pub maybe_era_id: Option<String>,
+    #[serde(default)]
+    pub verbosity: Option<String>,
+    #[serde(default)]
+    pub rpc_address: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SdkGetTransactionArgs {
+    pub transaction_hash: String,
+    #[serde(default)]
+    pub finalized_approvals: Option<bool>,
+    #[serde(default)]
+    pub verbosity: Option<String>,
+    #[serde(default)]
+    pub rpc_address: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SdkGetTtlOrDefaultArgs {
+    #[serde(default)]
+    pub ttl: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SdkGetValidatorArgs {
+    pub public_key: String,
+    #[serde(default)]
+    pub verbosity: Option<String>,
+    #[serde(default)]
+    pub rpc_address: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SdkHexToUint8VecArgs {
+    pub hex_string: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SdkInstallArgs {
+    pub transaction_params_json: String,
+    pub wasm_hex: String,
+    #[serde(default)]
+    pub rpc_address: Option<String>,
+    #[serde(default)]
+    pub runtime_v2: Option<bool>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SdkInstallDeployArgs {
+    pub deploy_params_json: String,
+    pub session_params_json: String,
+    pub payment_amount: String,
+    #[serde(default)]
+    pub rpc_address: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SdkJsonPrettyPrintArgs {
+    pub value: String,
+    #[serde(default)]
+    pub verbosity: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SdkMakeDelegateTransactionArgs {
+    pub delegator: String,
+    pub validator: String,
+    pub amount: String,
+    pub transaction_params_json: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SdkMakeDeployArgs {
+    pub deploy_params_json: String,
+    pub session_params_json: String,
+    pub payment_params_json: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SdkMakeDictionaryItemKeyArgs {
+    pub key: String,
+    #[serde(default)]
+    pub value_key: Option<String>,
+    #[serde(default)]
+    pub value_u256: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SdkMakeRedelegateTransactionArgs {
+    pub delegator: String,
+    pub validator: String,
+    pub new_validator: String,
+    pub amount: String,
+    pub transaction_params_json: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SdkMakeTransactionArgs {
+    pub builder_params_json: String,
+    pub transaction_params_json: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SdkMakeTransferArgs {
+    pub amount: String,
+    pub target_account: String,
+    pub deploy_params_json: String,
+    pub payment_params_json: String,
+    #[serde(default)]
+    pub transfer_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SdkMakeTransferTransactionArgs {
+    pub target: String,
+    pub amount: String,
+    pub transaction_params_json: String,
+    #[serde(default)]
+    pub maybe_source: Option<String>,
+    #[serde(default)]
+    pub maybe_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SdkMotesToCsprArgs {
+    pub motes: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SdkParseTimestampArgs {
+    pub value: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SdkQueryBalanceArgs {
+    pub purse_identifier: String,
+    #[serde(default)]
+    pub state_root_hash: Option<String>,
+    #[serde(default)]
+    pub maybe_block_id: Option<String>,
+    #[serde(default)]
+    pub verbosity: Option<String>,
+    #[serde(default)]
+    pub rpc_address: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SdkQueryContractDictArgs {
+    pub kind: String,
+    pub dictionary_item_json: String,
+    #[serde(default)]
+    pub state_root_hash: Option<String>,
+    #[serde(default)]
+    pub verbosity: Option<String>,
+    #[serde(default)]
+    pub rpc_address: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SdkQueryContractKeyArgs {
+    pub entity_identifier: String,
+    pub path: String,
+    #[serde(default)]
+    pub maybe_block_identifier: Option<String>,
+    #[serde(default)]
+    pub verbosity: Option<String>,
+    #[serde(default)]
+    pub rpc_address: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SdkQueryGlobalStateArgs {
+    pub key: String,
+    #[serde(default)]
+    pub path: Option<String>,
+    #[serde(default)]
+    pub state_root_hash: Option<String>,
+    #[serde(default)]
+    pub maybe_block_id: Option<String>,
+    #[serde(default)]
+    pub verbosity: Option<String>,
+    #[serde(default)]
+    pub rpc_address: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SdkSecretKeyFromPemArgs {
+    pub secret_key: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SdkSetEndpointsArgs {
+    #[serde(default)]
+    pub rpc_address: Option<String>,
+    #[serde(default)]
+    pub node_address: Option<String>,
+    #[serde(default)]
+    pub verbosity: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SdkSignDeployArgs {
+    pub deploy_json: String,
+    pub secret_key: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SdkSignTransactionArgs {
+    pub transaction_json: String,
+    pub secret_key: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SdkSpeculativeDeployArgs {
+    pub deploy_params_json: String,
+    pub session_params_json: String,
+    pub payment_params_json: String,
+    #[serde(default)]
+    pub verbosity: Option<String>,
+    #[serde(default)]
+    pub rpc_address: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SdkSpeculativeExecArgs {
+    pub transaction_json: String,
+    #[serde(default)]
+    pub verbosity: Option<String>,
+    #[serde(default)]
+    pub rpc_address: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SdkSpeculativeExecDeployArgs {
+    pub deploy_json: String,
+    #[serde(default)]
+    pub verbosity: Option<String>,
+    #[serde(default)]
+    pub rpc_address: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SdkSpeculativeTransactionArgs {
+    pub builder_params_json: String,
+    pub transaction_params_json: String,
+    #[serde(default)]
+    pub verbosity: Option<String>,
+    #[serde(default)]
+    pub rpc_address: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SdkSpeculativeTransferArgs {
+    pub amount: String,
+    pub target_account: String,
+    pub deploy_params_json: String,
+    pub payment_params_json: String,
+    #[serde(default)]
+    pub transfer_id: Option<String>,
+    #[serde(default)]
+    pub verbosity: Option<String>,
+    #[serde(default)]
+    pub rpc_address: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SdkSpeculativeTransferTransactionArgs {
+    pub target_account: String,
+    pub amount: String,
+    pub transaction_params_json: String,
+    #[serde(default)]
+    pub maybe_source: Option<String>,
+    #[serde(default)]
+    pub maybe_id: Option<String>,
+    #[serde(default)]
+    pub verbosity: Option<String>,
+    #[serde(default)]
+    pub rpc_address: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SdkSseCollectArgs {
+    pub events_url: String,
+    pub event_names: String,
+    #[serde(default)]
+    pub max_events: Option<u64>,
+    #[serde(default)]
+    pub timeout_ms: Option<u64>,
+    #[serde(default)]
+    pub start_from: Option<u64>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SdkWaitTransactionArgs {
+    pub events_url: String,
+    pub transaction_hash: String,
+    #[serde(default)]
+    pub timeout_ms: Option<u64>,
+}

--- a/mcp/src/tools/SSE.rs
+++ b/mcp/src/tools/SSE.rs
@@ -4,7 +4,7 @@ use casper_rust_wasm_sdk::types::hash::transaction_hash::TransactionHash;
 use casper_rust_wasm_sdk::SSE::{
     parse_schemas_from_hex, CESParser, ContractMetadata, EventName, SSEClient,
 };
-use mcpkit::prelude::ToolOutput;
+use rmcp::model::CallToolResult;
 use serde_json::Value;
 
 use crate::format;
@@ -30,7 +30,7 @@ pub async fn SSE_collect(
     max_events: Option<u64>,
     timeout_ms: Option<u64>,
     start_from: Option<u64>,
-) -> ToolOutput {
+) -> CallToolResult {
     let names = match parse_event_names(&event_names) {
         Ok(n) => n,
         Err(err) => return format::err(err),
@@ -52,7 +52,7 @@ pub async fn CES_parser_create(
     contract_hashes_json: String,
     state_root_hash: Option<String>,
     rpc_address: Option<String>,
-) -> ToolOutput {
+) -> CallToolResult {
     let hashes: Vec<String> = match serde_json::from_str(&contract_hashes_json) {
         Ok(v) => v,
         Err(err) => {
@@ -86,7 +86,7 @@ pub async fn CES_parser_create(
 pub fn CES_parse_execution_result(
     schemas_metadata_json: String,
     execution_result_json: String,
-) -> ToolOutput {
+) -> CallToolResult {
     let parser = match parser_from_metadata_json(&schemas_metadata_json) {
         Ok(p) => p,
         Err(err) => return format::err(err),
@@ -105,7 +105,7 @@ pub async fn CES_parse_transaction(
     state_root_hash: Option<String>,
     verbosity: Option<String>,
     rpc_address: Option<String>,
-) -> ToolOutput {
+) -> CallToolResult {
     let hashes: Vec<String> = match serde_json::from_str(&contract_hashes_json) {
         Ok(v) => v,
         Err(err) => {

--- a/mcp/src/tools/binary_port.rs
+++ b/mcp/src/tools/binary_port.rs
@@ -9,7 +9,7 @@ use casper_rust_wasm_sdk::types::public_key::PublicKey;
 use casper_rust_wasm_sdk::types::record_id::RecordId;
 use casper_rust_wasm_sdk::types::transaction::Transaction;
 use casper_types::EraId;
-use mcpkit::prelude::ToolOutput;
+use rmcp::model::CallToolResult;
 use serde::Serialize;
 
 use crate::format;
@@ -54,7 +54,7 @@ pub fn tool_names() -> &'static [&'static str] {
     ]
 }
 
-fn bin_ok<T: Serialize, E: std::fmt::Display>(result: Result<T, E>) -> ToolOutput {
+fn bin_ok<T: Serialize, E: std::fmt::Display>(result: Result<T, E>) -> CallToolResult {
     match result {
         Ok(value) => format::serialize_ok(&value),
         Err(err) => format::err(err),
@@ -111,12 +111,12 @@ macro_rules! bin_call {
     };
 }
 
-pub async fn get_binary_latest_switch_block_header(node_address: Option<String>) -> ToolOutput {
+pub async fn get_binary_latest_switch_block_header(node_address: Option<String>) -> CallToolResult {
     let sdk = sdk_handle::sdk_snapshot();
     bin_call!(sdk.get_binary_latest_switch_block_header(node_address))
 }
 
-pub async fn get_binary_latest_block_header(node_address: Option<String>) -> ToolOutput {
+pub async fn get_binary_latest_block_header(node_address: Option<String>) -> CallToolResult {
     let sdk = sdk_handle::sdk_snapshot();
     bin_call!(sdk.get_binary_latest_block_header(node_address))
 }
@@ -124,7 +124,7 @@ pub async fn get_binary_latest_block_header(node_address: Option<String>) -> Too
 pub async fn get_binary_block_header_by_height(
     height: u64,
     node_address: Option<String>,
-) -> ToolOutput {
+) -> CallToolResult {
     let sdk = sdk_handle::sdk_snapshot();
     bin_call!(sdk.get_binary_block_header_by_height(node_address, height))
 }
@@ -132,7 +132,7 @@ pub async fn get_binary_block_header_by_height(
 pub async fn get_binary_block_header_by_hash(
     block_hash: String,
     node_address: Option<String>,
-) -> ToolOutput {
+) -> CallToolResult {
     let hash = match parse_block_hash(&block_hash) {
         Ok(h) => h,
         Err(err) => return format::err(err),
@@ -141,7 +141,9 @@ pub async fn get_binary_block_header_by_hash(
     bin_call!(sdk.get_binary_block_header_by_hash(node_address, hash))
 }
 
-pub async fn get_binary_latest_block_with_signatures(node_address: Option<String>) -> ToolOutput {
+pub async fn get_binary_latest_block_with_signatures(
+    node_address: Option<String>,
+) -> CallToolResult {
     let sdk = sdk_handle::sdk_snapshot();
     bin_call!(sdk.get_binary_latest_block_with_signatures(node_address))
 }
@@ -149,7 +151,7 @@ pub async fn get_binary_latest_block_with_signatures(node_address: Option<String
 pub async fn get_binary_block_with_signatures_by_height(
     height: u64,
     node_address: Option<String>,
-) -> ToolOutput {
+) -> CallToolResult {
     let sdk = sdk_handle::sdk_snapshot();
     bin_call!(sdk.get_binary_block_with_signatures_by_height(node_address, height))
 }
@@ -157,7 +159,7 @@ pub async fn get_binary_block_with_signatures_by_height(
 pub async fn get_binary_block_with_signatures_by_hash(
     block_hash: String,
     node_address: Option<String>,
-) -> ToolOutput {
+) -> CallToolResult {
     let hash = match parse_block_hash(&block_hash) {
         Ok(h) => h,
         Err(err) => return format::err(err),
@@ -170,7 +172,7 @@ pub async fn get_binary_transaction_by_hash(
     hash: String,
     with_finalized_approvals: Option<bool>,
     node_address: Option<String>,
-) -> ToolOutput {
+) -> CallToolResult {
     let tx_hash = match parse_tx_hash(&hash) {
         Ok(h) => h,
         Err(err) => return format::err(err),
@@ -183,62 +185,64 @@ pub async fn get_binary_transaction_by_hash(
     ))
 }
 
-pub async fn get_binary_peers(node_address: Option<String>) -> ToolOutput {
+pub async fn get_binary_peers(node_address: Option<String>) -> CallToolResult {
     let sdk = sdk_handle::sdk_snapshot();
     bin_call!(sdk.get_binary_peers(node_address))
 }
 
-pub async fn get_binary_uptime(node_address: Option<String>) -> ToolOutput {
+pub async fn get_binary_uptime(node_address: Option<String>) -> CallToolResult {
     let sdk = sdk_handle::sdk_snapshot();
     bin_call!(sdk.get_binary_uptime(node_address))
 }
 
-pub async fn get_binary_last_progress(node_address: Option<String>) -> ToolOutput {
+pub async fn get_binary_last_progress(node_address: Option<String>) -> CallToolResult {
     let sdk = sdk_handle::sdk_snapshot();
     bin_call!(sdk.get_binary_last_progress(node_address))
 }
 
-pub async fn get_binary_reactor_state(node_address: Option<String>) -> ToolOutput {
+pub async fn get_binary_reactor_state(node_address: Option<String>) -> CallToolResult {
     let sdk = sdk_handle::sdk_snapshot();
     bin_call!(sdk.get_binary_reactor_state(node_address))
 }
 
-pub async fn get_binary_network_name(node_address: Option<String>) -> ToolOutput {
+pub async fn get_binary_network_name(node_address: Option<String>) -> CallToolResult {
     let sdk = sdk_handle::sdk_snapshot();
     bin_call!(sdk.get_binary_network_name(node_address))
 }
 
-pub async fn get_binary_consensus_validator_changes(node_address: Option<String>) -> ToolOutput {
+pub async fn get_binary_consensus_validator_changes(
+    node_address: Option<String>,
+) -> CallToolResult {
     let sdk = sdk_handle::sdk_snapshot();
     bin_call!(sdk.get_binary_consensus_validator_changes(node_address))
 }
 
-pub async fn get_binary_block_synchronizer_status(node_address: Option<String>) -> ToolOutput {
+pub async fn get_binary_block_synchronizer_status(node_address: Option<String>) -> CallToolResult {
     let sdk = sdk_handle::sdk_snapshot();
     bin_call!(sdk.get_binary_block_synchronizer_status(node_address))
 }
 
-pub async fn get_binary_available_block_range(node_address: Option<String>) -> ToolOutput {
+pub async fn get_binary_available_block_range(node_address: Option<String>) -> CallToolResult {
     let sdk = sdk_handle::sdk_snapshot();
     bin_call!(sdk.get_binary_available_block_range(node_address))
 }
 
-pub async fn get_binary_next_upgrade(node_address: Option<String>) -> ToolOutput {
+pub async fn get_binary_next_upgrade(node_address: Option<String>) -> CallToolResult {
     let sdk = sdk_handle::sdk_snapshot();
     bin_call!(sdk.get_binary_next_upgrade(node_address))
 }
 
-pub async fn get_binary_consensus_status(node_address: Option<String>) -> ToolOutput {
+pub async fn get_binary_consensus_status(node_address: Option<String>) -> CallToolResult {
     let sdk = sdk_handle::sdk_snapshot();
     bin_call!(sdk.get_binary_consensus_status(node_address))
 }
 
-pub async fn get_binary_chainspec_raw_bytes(node_address: Option<String>) -> ToolOutput {
+pub async fn get_binary_chainspec_raw_bytes(node_address: Option<String>) -> CallToolResult {
     let sdk = sdk_handle::sdk_snapshot();
     bin_call!(sdk.get_binary_chainspec_raw_bytes(node_address))
 }
 
-pub async fn get_binary_node_status(node_address: Option<String>) -> ToolOutput {
+pub async fn get_binary_node_status(node_address: Option<String>) -> CallToolResult {
     let sdk = sdk_handle::sdk_snapshot();
     bin_call!(sdk.get_binary_node_status(node_address))
 }
@@ -247,7 +251,7 @@ pub async fn get_binary_validator_reward_by_era(
     validator_key: String,
     era: u64,
     node_address: Option<String>,
-) -> ToolOutput {
+) -> CallToolResult {
     let pk = match parse_pubkey(&validator_key) {
         Ok(k) => k,
         Err(err) => return format::err(err),
@@ -260,7 +264,7 @@ pub async fn get_binary_validator_reward_by_block_height(
     validator_key: String,
     block_height: u64,
     node_address: Option<String>,
-) -> ToolOutput {
+) -> CallToolResult {
     let pk = match parse_pubkey(&validator_key) {
         Ok(k) => k,
         Err(err) => return format::err(err),
@@ -273,7 +277,7 @@ pub async fn get_binary_validator_reward_by_block_hash(
     validator_key: String,
     block_hash: String,
     node_address: Option<String>,
-) -> ToolOutput {
+) -> CallToolResult {
     let pk = match parse_pubkey(&validator_key) {
         Ok(k) => k,
         Err(err) => return format::err(err),
@@ -291,7 +295,7 @@ pub async fn get_binary_delegator_reward_by_era(
     delegator_key: String,
     era: u64,
     node_address: Option<String>,
-) -> ToolOutput {
+) -> CallToolResult {
     let v = match parse_pubkey(&validator_key) {
         Ok(k) => k,
         Err(err) => return format::err(err),
@@ -309,7 +313,7 @@ pub async fn get_binary_delegator_reward_by_block_height(
     delegator_key: String,
     block_height: u64,
     node_address: Option<String>,
-) -> ToolOutput {
+) -> CallToolResult {
     let v = match parse_pubkey(&validator_key) {
         Ok(k) => k,
         Err(err) => return format::err(err),
@@ -327,7 +331,7 @@ pub async fn get_binary_delegator_reward_by_block_hash(
     delegator_key: String,
     block_hash: String,
     node_address: Option<String>,
-) -> ToolOutput {
+) -> CallToolResult {
     let v = match parse_pubkey(&validator_key) {
         Ok(k) => k,
         Err(err) => return format::err(err),
@@ -348,7 +352,7 @@ pub async fn get_binary_read_record(
     record_id: u16,
     key_hex: String,
     node_address: Option<String>,
-) -> ToolOutput {
+) -> CallToolResult {
     let id = match RecordId::new(record_id) {
         Ok(id) => id,
         Err(err) => return format::err(err),
@@ -373,7 +377,7 @@ pub async fn get_binary_global_state_item(
     key: String,
     path: Option<String>,
     node_address: Option<String>,
-) -> ToolOutput {
+) -> CallToolResult {
     let key = match parse_key(&key) {
         Ok(k) => k,
         Err(err) => return format::err(err),
@@ -391,7 +395,7 @@ pub async fn get_binary_global_state_item_by_state_root_hash(
     key: String,
     path: Option<String>,
     node_address: Option<String>,
-) -> ToolOutput {
+) -> CallToolResult {
     let digest = match parse_digest(&state_root_hash) {
         Ok(d) => d,
         Err(err) => return format::err(err),
@@ -413,7 +417,7 @@ pub async fn get_binary_global_state_item_by_block_hash(
     key: String,
     path: Option<String>,
     node_address: Option<String>,
-) -> ToolOutput {
+) -> CallToolResult {
     let hash = match parse_block_hash(&block_hash) {
         Ok(h) => h,
         Err(err) => return format::err(err),
@@ -435,7 +439,7 @@ pub async fn get_binary_global_state_item_by_block_height(
     key: String,
     path: Option<String>,
     node_address: Option<String>,
-) -> ToolOutput {
+) -> CallToolResult {
     let key = match parse_key(&key) {
         Ok(k) => k,
         Err(err) => return format::err(err),
@@ -456,7 +460,7 @@ pub async fn get_binary_global_state_item_by_block_height(
 pub async fn get_binary_try_speculative_execution(
     transaction_json: String,
     node_address: Option<String>,
-) -> ToolOutput {
+) -> CallToolResult {
     let transaction = match Transaction::from_json_string(&transaction_json) {
         Ok(t) => t,
         Err(err) => return format::err(err),
@@ -465,7 +469,7 @@ pub async fn get_binary_try_speculative_execution(
     bin_call!(sdk.get_binary_try_speculative_execution(node_address, transaction.into()))
 }
 
-pub async fn get_binary_protocol_version(node_address: Option<String>) -> ToolOutput {
+pub async fn get_binary_protocol_version(node_address: Option<String>) -> CallToolResult {
     let sdk = sdk_handle::sdk_snapshot();
     bin_call!(sdk.get_binary_protocol_version(node_address))
 }

--- a/mcp/src/tools/contract.rs
+++ b/mcp/src/tools/contract.rs
@@ -4,7 +4,7 @@ use casper_rust_wasm_sdk::rpcs::get_dictionary_item::DictionaryItemInput;
 use casper_rust_wasm_sdk::rpcs::query_global_state::PathIdentifierInput;
 use casper_rust_wasm_sdk::types::deploy_params::dictionary_item_str_params::DictionaryItemStrParams;
 use casper_rust_wasm_sdk::types::identifier::block_identifier::BlockIdentifierInput;
-use mcpkit::prelude::ToolOutput;
+use rmcp::model::CallToolResult;
 
 use crate::format;
 use crate::sdk_handle;
@@ -102,7 +102,7 @@ pub async fn query_contract_dict(
     state_root_hash: Option<String>,
     verbosity: Option<String>,
     rpc_address: Option<String>,
-) -> ToolOutput {
+) -> CallToolResult {
     let fields: serde_json::Value = match serde_json::from_str(&dictionary_item_json) {
         Ok(v) => v,
         Err(err) => return format::err(format!("dictionary_item_json: {err}")),
@@ -132,7 +132,7 @@ pub async fn query_contract_key(
     maybe_block_identifier: Option<String>,
     verbosity: Option<String>,
     rpc_address: Option<String>,
-) -> ToolOutput {
+) -> CallToolResult {
     let sdk = sdk_handle::sdk_snapshot();
     let path = PathIdentifierInput::String(path);
     let block = maybe_block_identifier.map(BlockIdentifierInput::String);

--- a/mcp/src/tools/deploy.rs
+++ b/mcp/src/tools/deploy.rs
@@ -3,7 +3,7 @@
 #![allow(deprecated)]
 
 use casper_rust_wasm_sdk::types::deploy::Deploy;
-use mcpkit::prelude::ToolOutput;
+use rmcp::model::CallToolResult;
 
 use crate::format;
 use crate::sdk_handle;
@@ -20,7 +20,7 @@ pub fn tool_names() -> &'static [&'static str] {
     ]
 }
 
-pub fn serialize_deploy(deploy: Deploy) -> ToolOutput {
+pub fn serialize_deploy(deploy: Deploy) -> CallToolResult {
     match deploy.to_json_string() {
         Ok(s) => match serde_json::from_str::<serde_json::Value>(&s) {
             Ok(v) => format::json_ok(&v),
@@ -38,7 +38,7 @@ pub fn make_deploy(
     deploy_params_json: String,
     session_params_json: String,
     payment_params_json: String,
-) -> ToolOutput {
+) -> CallToolResult {
     let deploy_params = match parse_deploy_str_params(&deploy_params_json) {
         Ok(p) => p,
         Err(err) => return format::err(err),
@@ -64,7 +64,7 @@ pub fn make_transfer(
     deploy_params_json: String,
     payment_params_json: String,
     transfer_id: Option<String>,
-) -> ToolOutput {
+) -> CallToolResult {
     let deploy_params = match parse_deploy_str_params(&deploy_params_json) {
         Ok(p) => p,
         Err(err) => return format::err(err),
@@ -92,7 +92,7 @@ pub async fn speculative_deploy(
     payment_params_json: String,
     verbosity: Option<String>,
     rpc_address: Option<String>,
-) -> ToolOutput {
+) -> CallToolResult {
     let deploy_params = match parse_deploy_str_params(&deploy_params_json) {
         Ok(p) => p,
         Err(err) => return format::err(err),
@@ -129,7 +129,7 @@ pub async fn speculative_transfer(
     transfer_id: Option<String>,
     verbosity: Option<String>,
     rpc_address: Option<String>,
-) -> ToolOutput {
+) -> CallToolResult {
     let deploy_params = match parse_deploy_str_params(&deploy_params_json) {
         Ok(p) => p,
         Err(err) => return format::err(err),

--- a/mcp/src/tools/helpers.rs
+++ b/mcp/src/tools/helpers.rs
@@ -3,7 +3,7 @@
 use casper_rust_wasm_sdk::helpers;
 use casper_rust_wasm_sdk::types::key::Key;
 use casper_types::U256;
-use mcpkit::prelude::ToolOutput;
+use rmcp::model::CallToolResult;
 use std::str::FromStr;
 
 use crate::format;
@@ -33,11 +33,11 @@ pub fn tool_names() -> &'static [&'static str] {
     ]
 }
 
-pub fn get_current_timestamp(timestamp: Option<String>) -> ToolOutput {
+pub fn get_current_timestamp(timestamp: Option<String>) -> CallToolResult {
     format::text_ok(helpers::get_current_timestamp(timestamp))
 }
 
-pub fn get_blake2b_hash(meta_data: String) -> ToolOutput {
+pub fn get_blake2b_hash(meta_data: String) -> CallToolResult {
     format::text_ok(helpers::get_blake2b_hash(&meta_data))
 }
 
@@ -45,7 +45,7 @@ pub fn make_dictionary_item_key(
     key: String,
     value_key: Option<String>,
     value_u256: Option<String>,
-) -> ToolOutput {
+) -> CallToolResult {
     let key = match Key::from_formatted_str(&key) {
         Ok(k) => k,
         Err(err) => return format::err(format!("invalid key: {err}")),
@@ -63,45 +63,45 @@ pub fn make_dictionary_item_key(
     }
 }
 
-pub fn get_base64_key_from_account_hash(account_hash: String) -> ToolOutput {
+pub fn get_base64_key_from_account_hash(account_hash: String) -> CallToolResult {
     match helpers::get_base64_key_from_account_hash(&account_hash) {
         Ok(v) => format::text_ok(v),
         Err(err) => format::err(err),
     }
 }
 
-pub fn get_base64_key_from_key_hash(formatted_hash: String) -> ToolOutput {
+pub fn get_base64_key_from_key_hash(formatted_hash: String) -> CallToolResult {
     match helpers::get_base64_key_from_key_hash(&formatted_hash) {
         Ok(v) => format::text_ok(v),
         Err(err) => format::err(err),
     }
 }
 
-pub fn get_ttl_or_default(ttl: Option<String>) -> ToolOutput {
+pub fn get_ttl_or_default(ttl: Option<String>) -> CallToolResult {
     format::text_ok(helpers::get_ttl_or_default(ttl.as_deref()))
 }
 
-pub fn parse_timestamp(value: String) -> ToolOutput {
+pub fn parse_timestamp(value: String) -> CallToolResult {
     match helpers::parse_timestamp(&value) {
         Ok(ts) => format::text_ok(ts.to_string()),
         Err(err) => format::err(err),
     }
 }
 
-pub fn parse_ttl(value: String) -> ToolOutput {
+pub fn parse_ttl(value: String) -> CallToolResult {
     match helpers::parse_ttl(&value) {
         Ok(ttl) => format::text_ok(ttl.to_string()),
         Err(err) => format::err(err),
     }
 }
 
-pub fn get_gas_price_or_default(gas_price: Option<u64>) -> ToolOutput {
+pub fn get_gas_price_or_default(gas_price: Option<u64>) -> CallToolResult {
     format::json_ok(&serde_json::json!({
         "gas_price": helpers::get_gas_price_or_default(gas_price)
     }))
 }
 
-pub fn secret_key_generate() -> ToolOutput {
+pub fn secret_key_generate() -> CallToolResult {
     match helpers::secret_key_generate() {
         Ok(sk) => match sk.to_pem() {
             Ok(pem) => format::json_ok(&serde_json::json!({
@@ -114,7 +114,7 @@ pub fn secret_key_generate() -> ToolOutput {
     }
 }
 
-pub fn secret_key_secp256k1_generate() -> ToolOutput {
+pub fn secret_key_secp256k1_generate() -> CallToolResult {
     match helpers::secret_key_secp256k1_generate() {
         Ok(sk) => match sk.to_pem() {
             Ok(pem) => format::json_ok(&serde_json::json!({
@@ -127,7 +127,7 @@ pub fn secret_key_secp256k1_generate() -> ToolOutput {
     }
 }
 
-pub fn secret_key_from_pem(secret_key: String) -> ToolOutput {
+pub fn secret_key_from_pem(secret_key: String) -> CallToolResult {
     match helpers::secret_key_from_pem(&secret_key) {
         Ok(sk) => format::json_ok(&serde_json::json!({
             "ok": true,
@@ -137,30 +137,30 @@ pub fn secret_key_from_pem(secret_key: String) -> ToolOutput {
     }
 }
 
-pub fn public_key_from_secret_key(secret_key: String) -> ToolOutput {
+pub fn public_key_from_secret_key(secret_key: String) -> CallToolResult {
     match helpers::public_key_from_secret_key(&secret_key) {
         Ok(pk) => format::text_ok(pk),
         Err(err) => format::err(err),
     }
 }
 
-pub fn hex_to_uint8_vec(hex_string: String) -> ToolOutput {
+pub fn hex_to_uint8_vec(hex_string: String) -> CallToolResult {
     let bytes = helpers::hex_to_uint8_vec(&hex_string);
     format::json_ok(&serde_json::json!({ "bytes": bytes }))
 }
 
-pub fn hex_to_string(hex_string: String) -> ToolOutput {
+pub fn hex_to_string(hex_string: String) -> CallToolResult {
     format::text_ok(helpers::hex_to_string(&hex_string))
 }
 
-pub fn motes_to_cspr(motes: String) -> ToolOutput {
+pub fn motes_to_cspr(motes: String) -> CallToolResult {
     match helpers::motes_to_cspr(&motes) {
         Ok(cspr) => format::json_ok(&serde_json::json!({ "motes": motes, "cspr": cspr })),
         Err(err) => format::err(err),
     }
 }
 
-pub fn json_pretty_print(value: String, verbosity: Option<String>) -> ToolOutput {
+pub fn json_pretty_print(value: String, verbosity: Option<String>) -> CallToolResult {
     let parsed: serde_json::Value = match serde_json::from_str(&value) {
         Ok(v) => v,
         Err(err) => return format::err(format!("value must be JSON: {err}")),
@@ -172,7 +172,7 @@ pub fn json_pretty_print(value: String, verbosity: Option<String>) -> ToolOutput
     }
 }
 
-pub fn cl_value_to_json(cl_value_json: String) -> ToolOutput {
+pub fn cl_value_to_json(cl_value_json: String) -> CallToolResult {
     let cl_value: casper_types::CLValue = match serde_json::from_str(&cl_value_json) {
         Ok(v) => v,
         Err(err) => {

--- a/mcp/src/tools/mod.rs
+++ b/mcp/src/tools/mod.rs
@@ -73,8 +73,8 @@ pub fn registered_tool_names() -> Vec<&'static str> {
     names
 }
 
-/// Error when a Cargo feature is disabled (mcpkit still lists the tool).
-pub fn feature_disabled(feature: &str) -> mcpkit::prelude::ToolOutput {
+/// Error when a Cargo feature is disabled (rmcp still lists the tool).
+pub fn feature_disabled(feature: &str) -> rmcp::model::CallToolResult {
     crate::format::err(format!(
         "Cargo feature `{feature}` is disabled; rebuild with --features {feature} (or full)"
     ))

--- a/mcp/src/tools/rpc.rs
+++ b/mcp/src/tools/rpc.rs
@@ -13,7 +13,7 @@ use casper_rust_wasm_sdk::types::hash::deploy_hash::DeployHash;
 use casper_rust_wasm_sdk::types::hash::transaction_hash::TransactionHash;
 use casper_rust_wasm_sdk::types::identifier::block_identifier::BlockIdentifierInput;
 use casper_rust_wasm_sdk::types::transaction::Transaction;
-use mcpkit::prelude::ToolOutput;
+use rmcp::model::CallToolResult;
 
 use crate::format;
 use crate::sdk_handle;
@@ -64,7 +64,10 @@ macro_rules! rpc_ok {
     };
 }
 
-pub async fn get_node_status(verbosity: Option<String>, rpc_address: Option<String>) -> ToolOutput {
+pub async fn get_node_status(
+    verbosity: Option<String>,
+    rpc_address: Option<String>,
+) -> CallToolResult {
     let sdk = sdk_handle::sdk_snapshot();
     rpc_ok!(
         sdk.get_node_status(verb(verbosity.as_deref()), rpc_address)
@@ -72,12 +75,15 @@ pub async fn get_node_status(verbosity: Option<String>, rpc_address: Option<Stri
     )
 }
 
-pub async fn get_peers(verbosity: Option<String>, rpc_address: Option<String>) -> ToolOutput {
+pub async fn get_peers(verbosity: Option<String>, rpc_address: Option<String>) -> CallToolResult {
     let sdk = sdk_handle::sdk_snapshot();
     rpc_ok!(sdk.get_peers(verb(verbosity.as_deref()), rpc_address).await)
 }
 
-pub async fn get_chainspec(verbosity: Option<String>, rpc_address: Option<String>) -> ToolOutput {
+pub async fn get_chainspec(
+    verbosity: Option<String>,
+    rpc_address: Option<String>,
+) -> CallToolResult {
     let sdk = sdk_handle::sdk_snapshot();
     rpc_ok!(
         sdk.get_chainspec(verb(verbosity.as_deref()), rpc_address)
@@ -88,7 +94,7 @@ pub async fn get_chainspec(verbosity: Option<String>, rpc_address: Option<String
 pub async fn get_validator_changes(
     verbosity: Option<String>,
     rpc_address: Option<String>,
-) -> ToolOutput {
+) -> CallToolResult {
     let sdk = sdk_handle::sdk_snapshot();
     rpc_ok!(
         sdk.get_validator_changes(verb(verbosity.as_deref()), rpc_address)
@@ -96,7 +102,7 @@ pub async fn get_validator_changes(
     )
 }
 
-pub async fn list_rpcs(verbosity: Option<String>, rpc_address: Option<String>) -> ToolOutput {
+pub async fn list_rpcs(verbosity: Option<String>, rpc_address: Option<String>) -> CallToolResult {
     let sdk = sdk_handle::sdk_snapshot();
     rpc_ok!(sdk.list_rpcs(verb(verbosity.as_deref()), rpc_address).await)
 }
@@ -105,7 +111,7 @@ pub async fn get_block(
     maybe_block_identifier: Option<String>,
     verbosity: Option<String>,
     rpc_address: Option<String>,
-) -> ToolOutput {
+) -> CallToolResult {
     let sdk = sdk_handle::sdk_snapshot();
     rpc_ok!(
         sdk.get_block(
@@ -121,7 +127,7 @@ pub async fn get_block_transfers(
     maybe_block_identifier: Option<String>,
     verbosity: Option<String>,
     rpc_address: Option<String>,
-) -> ToolOutput {
+) -> CallToolResult {
     let sdk = sdk_handle::sdk_snapshot();
     rpc_ok!(
         sdk.get_block_transfers(
@@ -137,7 +143,7 @@ pub async fn get_auction_info(
     maybe_block_identifier: Option<String>,
     verbosity: Option<String>,
     rpc_address: Option<String>,
-) -> ToolOutput {
+) -> CallToolResult {
     let sdk = sdk_handle::sdk_snapshot();
     rpc_ok!(
         sdk.get_auction_info(
@@ -153,7 +159,7 @@ pub async fn get_era_summary(
     maybe_block_identifier: Option<String>,
     verbosity: Option<String>,
     rpc_address: Option<String>,
-) -> ToolOutput {
+) -> CallToolResult {
     let sdk = sdk_handle::sdk_snapshot();
     rpc_ok!(
         sdk.get_era_summary(
@@ -171,7 +177,7 @@ pub async fn get_reward(
     maybe_era_id: Option<String>,
     verbosity: Option<String>,
     rpc_address: Option<String>,
-) -> ToolOutput {
+) -> CallToolResult {
     let sdk = sdk_handle::sdk_snapshot();
     rpc_ok!(
         sdk.get_reward_as_string(
@@ -189,7 +195,7 @@ pub async fn get_era_info(
     maybe_block_identifier: Option<String>,
     verbosity: Option<String>,
     rpc_address: Option<String>,
-) -> ToolOutput {
+) -> CallToolResult {
     let sdk = sdk_handle::sdk_snapshot();
     rpc_ok!(
         sdk.get_era_info(
@@ -205,7 +211,7 @@ pub async fn get_state_root_hash(
     maybe_block_identifier: Option<String>,
     verbosity: Option<String>,
     rpc_address: Option<String>,
-) -> ToolOutput {
+) -> CallToolResult {
     let sdk = sdk_handle::sdk_snapshot();
     rpc_ok!(
         sdk.get_state_root_hash(
@@ -222,7 +228,7 @@ pub async fn get_account(
     maybe_block_identifier: Option<String>,
     verbosity: Option<String>,
     rpc_address: Option<String>,
-) -> ToolOutput {
+) -> CallToolResult {
     let sdk = sdk_handle::sdk_snapshot();
     rpc_ok!(
         sdk.get_account(
@@ -241,7 +247,7 @@ pub async fn get_entity(
     maybe_block_identifier: Option<String>,
     verbosity: Option<String>,
     rpc_address: Option<String>,
-) -> ToolOutput {
+) -> CallToolResult {
     let sdk = sdk_handle::sdk_snapshot();
     rpc_ok!(
         sdk.get_entity(
@@ -260,7 +266,7 @@ pub async fn get_deploy(
     finalized_approvals: Option<bool>,
     verbosity: Option<String>,
     rpc_address: Option<String>,
-) -> ToolOutput {
+) -> CallToolResult {
     let hash = match DeployHash::new(&deploy_hash) {
         Ok(h) => h,
         Err(err) => return format::err(err),
@@ -282,7 +288,7 @@ pub async fn get_transaction(
     finalized_approvals: Option<bool>,
     verbosity: Option<String>,
     rpc_address: Option<String>,
-) -> ToolOutput {
+) -> CallToolResult {
     let hash = match TransactionHash::new(&transaction_hash) {
         Ok(h) => h,
         Err(err) => return format::err(err),
@@ -304,7 +310,7 @@ pub async fn get_balance(
     state_root_hash: Option<String>,
     verbosity: Option<String>,
     rpc_address: Option<String>,
-) -> ToolOutput {
+) -> CallToolResult {
     let sdk = sdk_handle::sdk_snapshot();
     rpc_ok!(
         sdk.get_balance(
@@ -323,7 +329,7 @@ pub async fn query_balance(
     maybe_block_id: Option<String>,
     verbosity: Option<String>,
     rpc_address: Option<String>,
-) -> ToolOutput {
+) -> CallToolResult {
     let sdk = sdk_handle::sdk_snapshot();
     rpc_ok!(
         sdk.query_balance(
@@ -345,7 +351,7 @@ pub async fn query_balance_details(
     maybe_block_id: Option<String>,
     verbosity: Option<String>,
     rpc_address: Option<String>,
-) -> ToolOutput {
+) -> CallToolResult {
     let sdk = sdk_handle::sdk_snapshot();
     rpc_ok!(
         sdk.query_balance_details(
@@ -371,7 +377,7 @@ pub async fn get_dictionary_item(
     state_root_hash: Option<String>,
     verbosity: Option<String>,
     rpc_address: Option<String>,
-) -> ToolOutput {
+) -> CallToolResult {
     let mut params = DictionaryItemStrParams::new();
     match kind.as_str() {
         "uref" => {
@@ -451,7 +457,7 @@ pub async fn query_global_state(
     maybe_block_id: Option<String>,
     verbosity: Option<String>,
     rpc_address: Option<String>,
-) -> ToolOutput {
+) -> CallToolResult {
     let sdk = sdk_handle::sdk_snapshot();
     let params = QueryGlobalStateParams {
         key: KeyIdentifierInput::String(key),
@@ -469,7 +475,7 @@ pub async fn speculative_exec(
     transaction_json: String,
     verbosity: Option<String>,
     rpc_address: Option<String>,
-) -> ToolOutput {
+) -> CallToolResult {
     let transaction = match Transaction::from_json_string(&transaction_json) {
         Ok(t) => t,
         Err(err) => return format::err(err),
@@ -485,7 +491,7 @@ pub async fn speculative_exec_deploy(
     deploy_json: String,
     verbosity: Option<String>,
     rpc_address: Option<String>,
-) -> ToolOutput {
+) -> CallToolResult {
     let deploy = match Deploy::from_json_string(&deploy_json) {
         Ok(d) => d,
         Err(err) => return format::err(err),

--- a/mcp/src/tools/transaction.rs
+++ b/mcp/src/tools/transaction.rs
@@ -1,7 +1,7 @@
 //! Transaction builder / speculative tools (feature `transaction`).
 
 use casper_rust_wasm_sdk::types::transaction::Transaction;
-use mcpkit::prelude::ToolOutput;
+use rmcp::model::CallToolResult;
 
 use crate::format;
 use crate::sdk_handle;
@@ -18,7 +18,7 @@ pub fn tool_names() -> &'static [&'static str] {
     ]
 }
 
-pub fn serialize_transaction(tx: Transaction) -> ToolOutput {
+pub fn serialize_transaction(tx: Transaction) -> CallToolResult {
     match tx.to_json_string() {
         Ok(s) => match serde_json::from_str::<serde_json::Value>(&s) {
             Ok(v) => format::json_ok(&v),
@@ -35,7 +35,7 @@ fn verb(verbosity: Option<&str>) -> Option<casper_rust_wasm_sdk::types::verbosit
 pub fn make_transaction(
     builder_params_json: String,
     transaction_params_json: String,
-) -> ToolOutput {
+) -> CallToolResult {
     let builder = match parse_transaction_builder_params(&builder_params_json) {
         Ok(b) => b,
         Err(err) => return format::err(err),
@@ -57,7 +57,7 @@ pub fn make_transfer_transaction(
     transaction_params_json: String,
     maybe_source: Option<String>,
     maybe_id: Option<String>,
-) -> ToolOutput {
+) -> CallToolResult {
     let params = match parse_transaction_str_params(&transaction_params_json) {
         Ok(p) => p,
         Err(err) => return format::err(err),
@@ -78,7 +78,7 @@ pub async fn speculative_transaction(
     transaction_params_json: String,
     verbosity: Option<String>,
     rpc_address: Option<String>,
-) -> ToolOutput {
+) -> CallToolResult {
     let builder = match parse_transaction_builder_params(&builder_params_json) {
         Ok(b) => b,
         Err(err) => return format::err(err),
@@ -105,7 +105,7 @@ pub async fn speculative_transfer_transaction(
     maybe_id: Option<String>,
     verbosity: Option<String>,
     rpc_address: Option<String>,
-) -> ToolOutput {
+) -> CallToolResult {
     let params = match parse_transaction_str_params(&transaction_params_json) {
         Ok(p) => p,
         Err(err) => return format::err(err),

--- a/mcp/src/tools/watcher.rs
+++ b/mcp/src/tools/watcher.rs
@@ -1,6 +1,6 @@
 //! Wait/watch tools (feature `watcher`).
 
-use mcpkit::prelude::ToolOutput;
+use rmcp::model::CallToolResult;
 
 use crate::format;
 use crate::sdk_handle;
@@ -13,7 +13,7 @@ pub async fn wait_transaction(
     events_url: String,
     transaction_hash: String,
     timeout_ms: Option<u64>,
-) -> ToolOutput {
+) -> CallToolResult {
     let sdk = sdk_handle::sdk_snapshot();
     match sdk
         .wait_transaction(&events_url, &transaction_hash, timeout_ms)

--- a/mcp/src/tools/write.rs
+++ b/mcp/src/tools/write.rs
@@ -6,7 +6,7 @@ use casper_rust_wasm_sdk::helpers;
 use casper_rust_wasm_sdk::types::cl::bytes::Bytes;
 use casper_rust_wasm_sdk::types::deploy::Deploy;
 use casper_rust_wasm_sdk::types::transaction::Transaction;
-use mcpkit::prelude::ToolOutput;
+use rmcp::model::CallToolResult;
 
 use crate::format;
 use crate::sdk_handle;
@@ -39,7 +39,7 @@ fn verb(verbosity: Option<&str>) -> Option<casper_rust_wasm_sdk::types::verbosit
     sdk_handle::verbosity_override(verbosity)
 }
 
-pub fn sign_transaction(transaction_json: String, secret_key: String) -> ToolOutput {
+pub fn sign_transaction(transaction_json: String, secret_key: String) -> CallToolResult {
     let tx = match Transaction::from_json_string(&transaction_json) {
         Ok(t) => t,
         Err(err) => return format::err(err),
@@ -52,7 +52,7 @@ pub async fn put_transaction(
     transaction_json: String,
     verbosity: Option<String>,
     rpc_address: Option<String>,
-) -> ToolOutput {
+) -> CallToolResult {
     let tx = match Transaction::from_json_string(&transaction_json) {
         Ok(t) => t,
         Err(err) => return format::err(err),
@@ -72,7 +72,7 @@ pub async fn transaction(
     transaction_params_json: String,
     verbosity: Option<String>,
     rpc_address: Option<String>,
-) -> ToolOutput {
+) -> CallToolResult {
     let builder = match parse_transaction_builder_params(&builder_params_json) {
         Ok(b) => b,
         Err(err) => return format::err(err),
@@ -99,7 +99,7 @@ pub async fn transfer_transaction(
     maybe_id: Option<String>,
     verbosity: Option<String>,
     rpc_address: Option<String>,
-) -> ToolOutput {
+) -> CallToolResult {
     let params = match parse_transaction_str_params(&transaction_params_json) {
         Ok(p) => p,
         Err(err) => return format::err(err),
@@ -126,7 +126,7 @@ pub async fn transfer_transaction(
     }
 }
 
-pub fn sign_deploy(deploy_json: String, secret_key: String) -> ToolOutput {
+pub fn sign_deploy(deploy_json: String, secret_key: String) -> CallToolResult {
     let deploy = match Deploy::from_json_string(&deploy_json) {
         Ok(d) => d,
         Err(err) => return format::err(err),
@@ -139,7 +139,7 @@ pub async fn put_deploy(
     deploy_json: String,
     verbosity: Option<String>,
     rpc_address: Option<String>,
-) -> ToolOutput {
+) -> CallToolResult {
     let deploy = match Deploy::from_json_string(&deploy_json) {
         Ok(d) => d,
         Err(err) => return format::err(err),
@@ -160,7 +160,7 @@ pub async fn deploy(
     payment_params_json: String,
     verbosity: Option<String>,
     rpc_address: Option<String>,
-) -> ToolOutput {
+) -> CallToolResult {
     let deploy_params = match parse_deploy_str_params(&deploy_params_json) {
         Ok(p) => p,
         Err(err) => return format::err(err),
@@ -197,7 +197,7 @@ pub async fn transfer(
     transfer_id: Option<String>,
     verbosity: Option<String>,
     rpc_address: Option<String>,
-) -> ToolOutput {
+) -> CallToolResult {
     let deploy_params = match parse_deploy_str_params(&deploy_params_json) {
         Ok(p) => p,
         Err(err) => return format::err(err),
@@ -229,7 +229,7 @@ pub async fn install(
     wasm_hex: String,
     rpc_address: Option<String>,
     runtime_v2: Option<bool>,
-) -> ToolOutput {
+) -> CallToolResult {
     let params = match parse_transaction_str_params(&transaction_params_json) {
         Ok(p) => p,
         Err(err) => return format::err(err),
@@ -253,7 +253,7 @@ pub async fn install_deploy(
     session_params_json: String,
     payment_amount: String,
     rpc_address: Option<String>,
-) -> ToolOutput {
+) -> CallToolResult {
     let deploy_params = match parse_deploy_str_params(&deploy_params_json) {
         Ok(p) => p,
         Err(err) => return format::err(err),
@@ -277,7 +277,7 @@ pub async fn call_entrypoint(
     transaction_params_json: String,
     rpc_address: Option<String>,
     runtime_v2: Option<bool>,
-) -> ToolOutput {
+) -> CallToolResult {
     let builder = match parse_transaction_builder_params(&builder_params_json) {
         Ok(b) => b,
         Err(err) => return format::err(err),
@@ -301,7 +301,7 @@ pub async fn call_entrypoint_deploy(
     session_params_json: String,
     payment_params_json: String,
     rpc_address: Option<String>,
-) -> ToolOutput {
+) -> CallToolResult {
     let deploy_params = match parse_deploy_str_params(&deploy_params_json) {
         Ok(p) => p,
         Err(err) => return format::err(err),
@@ -327,7 +327,7 @@ pub async fn call_entrypoint_deploy(
 pub async fn get_binary_try_accept_transaction(
     transaction_json: String,
     node_address: Option<String>,
-) -> ToolOutput {
+) -> CallToolResult {
     let transaction = match Transaction::from_json_string(&transaction_json) {
         Ok(t) => t,
         Err(err) => return format::err(err),

--- a/python/Cargo.lock
+++ b/python/Cargo.lock
@@ -194,10 +194,8 @@ dependencies = [
  "chrono",
  "futures-util",
  "getrandom 0.3.4",
- "gloo-utils",
  "hex",
  "humantime",
- "js-sys",
  "num-traits",
  "once_cell",
  "rand 0.9.5",
@@ -206,8 +204,6 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.19",
  "tokio",
- "wasm-bindgen",
- "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -772,19 +768,6 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
-]
-
-[[package]]
-name = "gloo-utils"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b5555354113b18c547c1d3a98fbf7fb32a9ff4f6fa112ce823a21641a0ba3aa"
-dependencies = [
- "js-sys",
- "serde",
- "serde_json",
- "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]

--- a/src/sdk/deploy/speculative_transfer.rs
+++ b/src/sdk/deploy/speculative_transfer.rs
@@ -15,7 +15,7 @@ use casper_client::{
     cli::deploy::make_transfer, rpcs::results::SpeculativeExecResult as _SpeculativeExecResult,
     SuccessResponse,
 };
-use rand::Rng;
+use rand::RngExt;
 #[cfg(all(feature = "js", target_arch = "wasm32"))]
 use wasm_bindgen::prelude::*;
 

--- a/src/sdk/deploy/transfer.rs
+++ b/src/sdk/deploy/transfer.rs
@@ -14,7 +14,7 @@ use crate::{
 use casper_client::{
     cli::deploy::make_transfer, rpcs::results::PutDeployResult as _PutDeployResult, SuccessResponse,
 };
-use rand::Rng;
+use rand::RngExt;
 #[cfg(all(feature = "js", target_arch = "wasm32"))]
 use wasm_bindgen::prelude::*;
 

--- a/src/sdk/deploy_utils/make_transfer.rs
+++ b/src/sdk/deploy_utils/make_transfer.rs
@@ -10,7 +10,7 @@ use crate::{
     SDK,
 };
 use casper_client::cli::deploy::make_transfer as client_make_transfer;
-use rand::Rng;
+use rand::RngExt;
 #[cfg(all(feature = "js", target_arch = "wasm32"))]
 use wasm_bindgen::prelude::*;
 

--- a/src/sdk/rpcs/get_account.rs
+++ b/src/sdk/rpcs/get_account.rs
@@ -18,7 +18,7 @@ use casper_client::{
 };
 #[cfg(all(feature = "js", target_arch = "wasm32"))]
 use gloo_utils::format::JsValueSerdeExt;
-use rand::Rng;
+use rand::RngExt;
 use serde::{Deserialize, Serialize};
 #[cfg(feature = "js")]
 use wasm_bindgen::prelude::*;

--- a/src/sdk/rpcs/get_auction_info.rs
+++ b/src/sdk/rpcs/get_auction_info.rs
@@ -13,7 +13,7 @@ use casper_client::{
 };
 #[cfg(all(feature = "js", target_arch = "wasm32"))]
 use gloo_utils::format::JsValueSerdeExt;
-use rand::Rng;
+use rand::RngExt;
 #[cfg(all(feature = "js", target_arch = "wasm32"))]
 use serde::{Deserialize, Serialize};
 #[cfg(all(feature = "js", target_arch = "wasm32"))]

--- a/src/sdk/rpcs/get_balance.rs
+++ b/src/sdk/rpcs/get_balance.rs
@@ -13,7 +13,7 @@ use casper_client::{
 };
 #[cfg(all(feature = "js", target_arch = "wasm32"))]
 use gloo_utils::format::JsValueSerdeExt;
-use rand::Rng;
+use rand::RngExt;
 #[cfg(all(feature = "js", target_arch = "wasm32"))]
 use serde::{Deserialize, Serialize};
 #[cfg(all(feature = "js", target_arch = "wasm32"))]

--- a/src/sdk/rpcs/get_block.rs
+++ b/src/sdk/rpcs/get_block.rs
@@ -15,7 +15,7 @@ use casper_client::{
 use casper_types::Block;
 #[cfg(all(feature = "js", target_arch = "wasm32"))]
 use gloo_utils::format::JsValueSerdeExt;
-use rand::Rng;
+use rand::RngExt;
 #[cfg(all(feature = "js", target_arch = "wasm32"))]
 use serde::{Deserialize, Serialize};
 #[cfg(all(feature = "js", target_arch = "wasm32"))]

--- a/src/sdk/rpcs/get_block_transfers.rs
+++ b/src/sdk/rpcs/get_block_transfers.rs
@@ -16,7 +16,7 @@ use casper_client::{
 };
 #[cfg(all(feature = "js", target_arch = "wasm32"))]
 use gloo_utils::format::JsValueSerdeExt;
-use rand::Rng;
+use rand::RngExt;
 #[cfg(all(feature = "js", target_arch = "wasm32"))]
 use serde::{Deserialize, Serialize};
 #[cfg(all(feature = "js", target_arch = "wasm32"))]

--- a/src/sdk/rpcs/get_chainspec.rs
+++ b/src/sdk/rpcs/get_chainspec.rs
@@ -5,7 +5,7 @@ use casper_client::{
 };
 #[cfg(all(feature = "js", target_arch = "wasm32"))]
 use gloo_utils::format::JsValueSerdeExt;
-use rand::Rng;
+use rand::RngExt;
 #[cfg(all(feature = "js", target_arch = "wasm32"))]
 use serde::{Deserialize, Serialize};
 #[cfg(all(feature = "js", target_arch = "wasm32"))]

--- a/src/sdk/rpcs/get_deploy.rs
+++ b/src/sdk/rpcs/get_deploy.rs
@@ -8,7 +8,7 @@ use casper_client::{
 };
 #[cfg(all(feature = "js", target_arch = "wasm32"))]
 use gloo_utils::format::JsValueSerdeExt;
-use rand::Rng;
+use rand::RngExt;
 #[cfg(all(feature = "js", target_arch = "wasm32"))]
 use serde::{Deserialize, Serialize};
 #[cfg(all(feature = "js", target_arch = "wasm32"))]

--- a/src/sdk/rpcs/get_dictionary_item.rs
+++ b/src/sdk/rpcs/get_dictionary_item.rs
@@ -19,7 +19,7 @@ use casper_client::{
 };
 #[cfg(all(feature = "js", target_arch = "wasm32"))]
 use gloo_utils::format::JsValueSerdeExt;
-use rand::Rng;
+use rand::RngExt;
 use serde::{Deserialize, Serialize};
 #[cfg(feature = "js")]
 use wasm_bindgen::prelude::*;

--- a/src/sdk/rpcs/get_entity.rs
+++ b/src/sdk/rpcs/get_entity.rs
@@ -17,7 +17,7 @@ use casper_client::{
 };
 #[cfg(all(feature = "js", target_arch = "wasm32"))]
 use gloo_utils::format::JsValueSerdeExt;
-use rand::Rng;
+use rand::RngExt;
 use serde::{Deserialize, Serialize};
 #[cfg(feature = "js")]
 use wasm_bindgen::prelude::*;

--- a/src/sdk/rpcs/get_era_info.rs
+++ b/src/sdk/rpcs/get_era_info.rs
@@ -14,7 +14,7 @@ use casper_client::{
 };
 #[cfg(all(feature = "js", target_arch = "wasm32"))]
 use gloo_utils::format::JsValueSerdeExt;
-use rand::Rng;
+use rand::RngExt;
 #[cfg(all(feature = "js", target_arch = "wasm32"))]
 use serde::{Deserialize, Serialize};
 #[cfg(all(feature = "js", target_arch = "wasm32"))]

--- a/src/sdk/rpcs/get_era_summary.rs
+++ b/src/sdk/rpcs/get_era_summary.rs
@@ -13,7 +13,7 @@ use casper_client::{
 };
 #[cfg(all(feature = "js", target_arch = "wasm32"))]
 use gloo_utils::format::JsValueSerdeExt;
-use rand::Rng;
+use rand::RngExt;
 #[cfg(all(feature = "js", target_arch = "wasm32"))]
 use serde::{Deserialize, Serialize};
 #[cfg(all(feature = "js", target_arch = "wasm32"))]

--- a/src/sdk/rpcs/get_node_status.rs
+++ b/src/sdk/rpcs/get_node_status.rs
@@ -7,7 +7,7 @@ use casper_client::{
 };
 #[cfg(all(feature = "js", target_arch = "wasm32"))]
 use gloo_utils::format::JsValueSerdeExt;
-use rand::Rng;
+use rand::RngExt;
 #[cfg(all(feature = "js", target_arch = "wasm32"))]
 use serde::{Deserialize, Serialize};
 #[cfg(all(feature = "js", target_arch = "wasm32"))]

--- a/src/sdk/rpcs/get_peers.rs
+++ b/src/sdk/rpcs/get_peers.rs
@@ -4,7 +4,7 @@ use casper_client::{
 };
 #[cfg(all(feature = "js", target_arch = "wasm32"))]
 use gloo_utils::format::JsValueSerdeExt;
-use rand::Rng;
+use rand::RngExt;
 #[cfg(all(feature = "js", target_arch = "wasm32"))]
 use serde::{Deserialize, Serialize};
 #[cfg(all(feature = "js", target_arch = "wasm32"))]

--- a/src/sdk/rpcs/get_reward.rs
+++ b/src/sdk/rpcs/get_reward.rs
@@ -13,7 +13,7 @@ use casper_client::{
 use casper_types::EraId;
 #[cfg(all(feature = "js", target_arch = "wasm32"))]
 use gloo_utils::format::JsValueSerdeExt;
-use rand::Rng;
+use rand::RngExt;
 #[cfg(all(feature = "js", target_arch = "wasm32"))]
 use serde::{Deserialize, Serialize};
 #[cfg(all(feature = "js", target_arch = "wasm32"))]

--- a/src/sdk/rpcs/get_state_root_hash.rs
+++ b/src/sdk/rpcs/get_state_root_hash.rs
@@ -16,7 +16,7 @@ use casper_client::{
 };
 #[cfg(all(feature = "js", target_arch = "wasm32"))]
 use gloo_utils::format::JsValueSerdeExt;
-use rand::Rng;
+use rand::RngExt;
 #[cfg(all(feature = "js", target_arch = "wasm32"))]
 use serde::{Deserialize, Serialize};
 #[cfg(all(feature = "js", target_arch = "wasm32"))]

--- a/src/sdk/rpcs/get_transaction.rs
+++ b/src/sdk/rpcs/get_transaction.rs
@@ -8,7 +8,7 @@ use casper_client::{
 };
 #[cfg(all(feature = "js", target_arch = "wasm32"))]
 use gloo_utils::format::JsValueSerdeExt;
-use rand::Rng;
+use rand::RngExt;
 #[cfg(all(feature = "js", target_arch = "wasm32"))]
 use serde::{Deserialize, Serialize};
 #[cfg(feature = "js")]

--- a/src/sdk/rpcs/get_validator_changes.rs
+++ b/src/sdk/rpcs/get_validator_changes.rs
@@ -5,7 +5,7 @@ use casper_client::{
 };
 #[cfg(all(feature = "js", target_arch = "wasm32"))]
 use gloo_utils::format::JsValueSerdeExt;
-use rand::Rng;
+use rand::RngExt;
 #[cfg(all(feature = "js", target_arch = "wasm32"))]
 use serde::{Deserialize, Serialize};
 #[cfg(all(feature = "js", target_arch = "wasm32"))]

--- a/src/sdk/rpcs/list_rpcs.rs
+++ b/src/sdk/rpcs/list_rpcs.rs
@@ -4,7 +4,7 @@ use casper_client::{
 };
 #[cfg(all(feature = "js", target_arch = "wasm32"))]
 use gloo_utils::format::JsValueSerdeExt;
-use rand::Rng;
+use rand::RngExt;
 #[cfg(all(feature = "js", target_arch = "wasm32"))]
 use serde::{Deserialize, Serialize};
 #[cfg(all(feature = "js", target_arch = "wasm32"))]

--- a/src/sdk/rpcs/put_deploy.rs
+++ b/src/sdk/rpcs/put_deploy.rs
@@ -7,7 +7,7 @@ use casper_client::{
     put_deploy, rpcs::results::PutDeployResult as _PutDeployResult, Error, JsonRpcId,
     SuccessResponse,
 };
-use rand::Rng;
+use rand::RngExt;
 #[cfg(all(feature = "js", target_arch = "wasm32"))]
 use wasm_bindgen::prelude::*;
 

--- a/src/sdk/rpcs/put_transaction.rs
+++ b/src/sdk/rpcs/put_transaction.rs
@@ -8,7 +8,7 @@ use casper_client::{
     put_transaction, rpcs::results::PutTransactionResult as _PutTransactionResult, Error,
     JsonRpcId, SuccessResponse,
 };
-use rand::Rng;
+use rand::RngExt;
 #[cfg(all(feature = "js", target_arch = "wasm32"))]
 use wasm_bindgen::prelude::*;
 

--- a/src/sdk/rpcs/query_balance.rs
+++ b/src/sdk/rpcs/query_balance.rs
@@ -18,7 +18,7 @@ use casper_client::{
 };
 #[cfg(all(feature = "js", target_arch = "wasm32"))]
 use gloo_utils::format::JsValueSerdeExt;
-use rand::Rng;
+use rand::RngExt;
 #[cfg(all(feature = "js", target_arch = "wasm32"))]
 use serde::{Deserialize, Serialize};
 #[cfg(all(feature = "js", target_arch = "wasm32"))]

--- a/src/sdk/rpcs/query_balance_details.rs
+++ b/src/sdk/rpcs/query_balance_details.rs
@@ -19,7 +19,7 @@ use casper_client::{
 };
 #[cfg(all(feature = "js", target_arch = "wasm32"))]
 use gloo_utils::format::JsValueSerdeExt;
-use rand::Rng;
+use rand::RngExt;
 #[cfg(all(feature = "js", target_arch = "wasm32"))]
 use serde::{Deserialize, Serialize};
 #[cfg(all(feature = "js", target_arch = "wasm32"))]

--- a/src/sdk/rpcs/query_global_state.rs
+++ b/src/sdk/rpcs/query_global_state.rs
@@ -12,7 +12,7 @@ use casper_client::{
 };
 #[cfg(all(feature = "js", target_arch = "wasm32"))]
 use gloo_utils::format::JsValueSerdeExt;
-use rand::Rng;
+use rand::RngExt;
 use serde::{Deserialize, Serialize};
 #[cfg(feature = "js")]
 use wasm_bindgen::prelude::*;

--- a/src/sdk/rpcs/speculative_exec.rs
+++ b/src/sdk/rpcs/speculative_exec.rs
@@ -11,7 +11,7 @@ use casper_client::{
 };
 #[cfg(all(feature = "js", target_arch = "wasm32"))]
 use gloo_utils::format::JsValueSerdeExt;
-use rand::Rng;
+use rand::RngExt;
 #[cfg(all(feature = "js", target_arch = "wasm32"))]
 use serde::{Deserialize, Serialize};
 #[cfg(all(feature = "js", target_arch = "wasm32"))]

--- a/src/sdk/rpcs/speculative_exec_deploy.rs
+++ b/src/sdk/rpcs/speculative_exec_deploy.rs
@@ -12,7 +12,7 @@ use casper_client::{
 };
 #[cfg(all(feature = "js", target_arch = "wasm32"))]
 use gloo_utils::format::JsValueSerdeExt;
-use rand::Rng;
+use rand::RngExt;
 #[cfg(all(feature = "js", target_arch = "wasm32"))]
 use serde::{Deserialize, Serialize};
 #[cfg(all(feature = "js", target_arch = "wasm32"))]

--- a/src/sdk/transaction_utils/make_transfer_transaction.rs
+++ b/src/sdk/transaction_utils/make_transfer_transaction.rs
@@ -13,7 +13,7 @@ use casper_client::cli::{
     make_transaction as client_make_transaction, parse::transfer_target, TransactionBuilderParams,
 };
 use casper_types::U512;
-use rand::Rng;
+use rand::RngExt;
 use std::str::FromStr;
 #[cfg(all(feature = "js", target_arch = "wasm32"))]
 use wasm_bindgen::prelude::*;

--- a/tests/integration/rust/Cargo.toml
+++ b/tests/integration/rust/Cargo.toml
@@ -11,7 +11,7 @@ casper-rust-wasm-sdk = { path = "../../../", version = "2.2.2", features = [
 ] }
 tokio = { version = "1", features = ["full"] }
 chrono = "0.4"
-serde_json = "*"
+serde_json = "1"
 dotenvy = "0.15.7"
 
 [[bin]]


### PR DESCRIPTION
## Summary
- Migrate mcp/ from mcpkit to rmcp 3.1.2 (stdio + Streamable HTTP on /mcp)
- Bump root crates: reqwest 0.13, rand 0.10, getrandom 0.4, ctor 1, wasm-bindgen 0.2.127, gloo-utils 0.3, base64 0.23
- Align mcp casper-types to 7.1.1; refresh locks

## Test plan
- [x] RUSTUP_TOOLCHAIN=stable make check-lint
- [x] cargo test -p casper-rust-wasm-sdk-mcp --lib
- [x] cargo check -p casper-rust-wasm-sdk --tests

Made with [Cursor](https://cursor.com)