### PR TITLE
chore: drop ensure-binaryen and local .tools pin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,8 +16,5 @@ target/
 
 .env
 
-# Local Binaryen pin (make ensure-binaryen)
-.tools/
-
 # Cursor Playwright MCP probe dumps (console/page snapshots)
 .playwright-mcp/

--- a/Makefile
+++ b/Makefile
@@ -16,46 +16,7 @@ WASM_FEATURES_FULL = --features SSE
 WASM_FEATURES_READ_ONLY = --no-default-features --features js
 WASM_FEATURES_TRANSACTION = --no-default-features --features transaction,helpers,watcher,js
 
-# Pin Binaryen so wasm-pack does not fall back to its vendored 117 download.
-BINARYEN_VERSION := 130
-BINARYEN_DIR := $(CURDIR)/.tools/binaryen-version_$(BINARYEN_VERSION)
-BINARYEN_BIN := $(BINARYEN_DIR)/bin
-BINARYEN_PATH_FILE := $(CURDIR)/.tools/wasm-opt-bin
-
-.PHONY: all web nodejs clean build doc web-full web-read-only web-transaction nodejs-full nodejs-read-only ensure-binaryen
-
-ensure-binaryen:
-	@set -euo pipefail; \
-	mkdir -p "$(CURDIR)/.tools"; \
-	is_pin() { "$$1" --version 2>/dev/null | grep -qE 'version[_ ]$(BINARYEN_VERSION)([^0-9]|$$)'; }; \
-	if command -v wasm-opt >/dev/null 2>&1 && is_pin wasm-opt; then \
-		dirname "$$(command -v wasm-opt)" > "$(BINARYEN_PATH_FILE)"; \
-		echo "ensure-binaryen: $$(wasm-opt --version) (PATH)"; \
-		exit 0; \
-	fi; \
-	if [ -x "$(BINARYEN_BIN)/wasm-opt" ] && is_pin "$(BINARYEN_BIN)/wasm-opt"; then \
-		echo "$(BINARYEN_BIN)" > "$(BINARYEN_PATH_FILE)"; \
-		echo "ensure-binaryen: $$($(BINARYEN_BIN)/wasm-opt --version) ($(BINARYEN_BIN))"; \
-		exit 0; \
-	fi; \
-	case "$$(uname -m)" in \
-		x86_64|amd64) arch=x86_64 ;; \
-		aarch64|arm64) arch=aarch64 ;; \
-		*) echo "ensure-binaryen: unsupported arch $$(uname -m)" >&2; exit 1 ;; \
-	esac; \
-	case "$$(uname -s)" in \
-		Linux) plat=linux ;; \
-		Darwin) plat=macos ;; \
-		*) echo "ensure-binaryen: unsupported OS $$(uname -s)" >&2; exit 1 ;; \
-	esac; \
-	url="https://github.com/WebAssembly/binaryen/releases/download/version_$(BINARYEN_VERSION)/binaryen-version_$(BINARYEN_VERSION)-$${arch}-$${plat}.tar.gz"; \
-	echo "ensure-binaryen: downloading $$url"; \
-	rm -rf "$(BINARYEN_DIR)"; \
-	curl -fsSL "$$url" | tar -xz -C "$(CURDIR)/.tools"; \
-	test -x "$(BINARYEN_BIN)/wasm-opt"; \
-	is_pin "$(BINARYEN_BIN)/wasm-opt" || { echo "ensure-binaryen: expected version $(BINARYEN_VERSION)" >&2; exit 1; }; \
-	echo "$(BINARYEN_BIN)" > "$(BINARYEN_PATH_FILE)"; \
-	echo "ensure-binaryen: $$($(BINARYEN_BIN)/wasm-opt --version)"
+.PHONY: all web nodejs clean build doc web-full web-read-only web-transaction nodejs-full nodejs-read-only
 
 pack: web nodejs
 
@@ -63,20 +24,20 @@ web: web-full
 
 nodejs: nodejs-full
 
-web-full: ensure-binaryen
-	PATH="$$(cat "$(BINARYEN_PATH_FILE)"):$$PATH" wasm-pack build --target web --release --out-dir $(WEB_OUT_DIR) $(CURRENT_DIR) $(WASM_FEATURES_FULL)
+web-full:
+	wasm-pack build --target web --release --out-dir $(WEB_OUT_DIR) $(CURRENT_DIR) $(WASM_FEATURES_FULL)
 
-web-read-only: ensure-binaryen
-	PATH="$$(cat "$(BINARYEN_PATH_FILE)"):$$PATH" wasm-pack build --target web --release --out-dir $(WEB_OUT_DIR) $(CURRENT_DIR) $(WASM_FEATURES_READ_ONLY)
+web-read-only:
+	wasm-pack build --target web --release --out-dir $(WEB_OUT_DIR) $(CURRENT_DIR) $(WASM_FEATURES_READ_ONLY)
 
-web-transaction: ensure-binaryen
-	PATH="$$(cat "$(BINARYEN_PATH_FILE)"):$$PATH" wasm-pack build --target web --release --out-dir $(WEB_OUT_DIR) $(CURRENT_DIR) $(WASM_FEATURES_TRANSACTION)
+web-transaction:
+	wasm-pack build --target web --release --out-dir $(WEB_OUT_DIR) $(CURRENT_DIR) $(WASM_FEATURES_TRANSACTION)
 
-nodejs-full: ensure-binaryen
-	PATH="$$(cat "$(BINARYEN_PATH_FILE)"):$$PATH" wasm-pack build --target nodejs --release --out-dir $(NODEJS_OUT_DIR) $(CURRENT_DIR) $(WASM_FEATURES_FULL)
+nodejs-full:
+	wasm-pack build --target nodejs --release --out-dir $(NODEJS_OUT_DIR) $(CURRENT_DIR) $(WASM_FEATURES_FULL)
 
-nodejs-read-only: ensure-binaryen
-	PATH="$$(cat "$(BINARYEN_PATH_FILE)"):$$PATH" wasm-pack build --target nodejs --release --out-dir $(NODEJS_OUT_DIR) $(CURRENT_DIR) $(WASM_FEATURES_READ_ONLY)
+nodejs-read-only:
+	wasm-pack build --target nodejs --release --out-dir $(NODEJS_OUT_DIR) $(CURRENT_DIR) $(WASM_FEATURES_READ_ONLY)
 
 clean:
 	rm -rf $(WEB_OUT_DIR) $(NODEJS_OUT_DIR)

--- a/docs/README.md
+++ b/docs/README.md
@@ -95,8 +95,6 @@ $ make prepare
 $ make pack
 ```
 
-`make pack` ensures Binaryen **version_130** on `PATH` (host or `.tools/`) so `wasm-pack` does not fall back to its vendored Binaryen 117. Do not use `apt install binaryen` (often 120).
-
 This will create a `pkg` and `pkg-nodejs` containing the Typescript interfaces. You can find more details about building the SDK for Javascript with `wasm-pack` in the [wasm-pack documention](https://rustwasm.github.io/docs/wasm-pack/commands/build.html).
 
 ### Cargo features

--- a/docs/README.md
+++ b/docs/README.md
@@ -90,6 +90,14 @@ If you want to compile the Wasm package from Rust you may need to install `wasm-
 curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 ```
 
+Release packs run `wasm-opt`. Check that Binaryen on `PATH` is current **before** `wasm-pack` / `make pack`. If `wasm-opt` is missing or too old, wasm-pack falls back to its vendored Binaryen **117**, which rejects modules from current `rustc` (bulk-memory and related ops). Debian/Ubuntu `apt install binaryen` is often **120** and is not enough.
+
+```shell
+wasm-opt --version
+```
+
+You need **version 130 or newer** (for example `wasm-opt version 131 (version_131)`). If the command is missing or the version is below 130, install a current Binaryen from the [upstream releases](https://github.com/WebAssembly/binaryen/releases) (`version_130` or later for your OS and arch), unpack it, and put that tree's `bin` directory on `PATH`. Then run `wasm-opt --version` again.
+
 ```shell
 $ make prepare
 $ make pack


### PR DESCRIPTION
## Summary
- Remove `ensure-binaryen` and the `.tools/` Binaryen download from the Makefile.
- Pack targets use host `wasm-opt` on `PATH` (e.g. Binaryen 131).
- Drop the docs note and `.gitignore` entry for that pin.

## Test plan
- [ ] `wasm-opt --version` on PATH (130+)
- [ ] `make pack` (or `make web-full`) completes without creating `.tools/`
- [ ] Confirm `.tools/` is gone after a pack


Made with [Cursor](https://cursor.com)