### PR TITLE
fix(ci): cd into Electron and Tauri like the Angular step

### DIFF
--- a/.github/workflows/release-github-assets.yml
+++ b/.github/workflows/release-github-assets.yml
@@ -88,7 +88,7 @@ jobs:
           npm run build
 
       - name: Build Electron desktop assets
-        working-directory: examples/desktop/electron
+        working-directory: rustSDK/examples/desktop/electron
         env:
           SNAPCRAFT_BUILD_ENVIRONMENT: host
         run: |
@@ -103,7 +103,7 @@ jobs:
 
       - name: Build Tauri Signing Desk (AppImage)
         if: ${{ inputs.include_signing_desk }}
-        working-directory: examples/desktop/tauri
+        working-directory: rustSDK/examples/desktop/tauri
         run: |
           npm ci
           # Workspace cargo target; AppImage only (linux runner).


### PR DESCRIPTION
## Summary
- Step `working-directory` replaces the job default and is resolved from `GITHUB_WORKSPACE`, so Electron/Tauri never entered the checkout.
- Drop those overrides and `cd` the same way the Angular step already does.

## Test plan
- [ ] `release-github-preview` Electron step starts in `examples/desktop/electron` under the checkout
- [ ] Tauri Signing Desk step starts in `examples/desktop/tauri` when `include_signing_desk` is true