### PR TITLE
fix(ci): set GH_REPO for preview asset upload without checkout

### DIFF
--- a/.github/workflows/release-github-assets.yml
+++ b/.github/workflows/release-github-assets.yml
@@ -173,6 +173,7 @@ jobs:
         if: ${{ inputs.attach_to_release }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
           TAG: ${{ inputs.tag }}
         run: |
           set -euo pipefail

--- a/.github/workflows/release-github-preview.yml
+++ b/.github/workflows/release-github-preview.yml
@@ -102,7 +102,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download staged assets
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: desktop-mcp-casperatatui-dev-preview
           path: release-assets
@@ -110,6 +110,7 @@ jobs:
       - name: Upload assets to release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
           TAG: dev-preview
         run: |
           set -euo pipefail
@@ -126,8 +127,8 @@ jobs:
           for f in "${expected[@]}"; do
             test -f "release-assets/$f" || { echo "Missing staged asset: $f" >&2; exit 1; }
           done
+          # No checkout in this job: GH_REPO must be set so gh does not probe .git.
           gh release upload "$TAG" release-assets/* --clobber
-          # Fail the job if any expected tip desktop/MCP/TUI/Signing Desk file is missing.
           mapfile -t uploaded < <(gh release view "$TAG" --json assets --jq '.assets[].name' | sort)
           echo "Uploaded asset names:"
           printf '%s\n' "${uploaded[@]}"


### PR DESCRIPTION
## Summary
- Preview attach job downloads artifacts only; it has no checkout, so `gh release upload` failed with `not a git repository`.
- Set `GH_REPO` so `gh` does not probe `.git`. Same for the reusable assets upload step.
- Bump `download-artifact` to v5 (Node 20 deprecation warning).

## Test plan
- [ ] Re-run `release-github-preview` (or dispatch): Attach built assets uploads all seven files
- [ ] `gh release view dev-preview` lists the expected asset names

Made with [Cursor](https://cursor.com)