### PR TITLE
fix: box large SdkError variants for clippy 1.98

### DIFF
--- a/src/sdk/contract/call_entrypoint_deploy.rs
+++ b/src/sdk/contract/call_entrypoint_deploy.rs
@@ -98,9 +98,7 @@ impl SDK {
             false,
         )?;
 
-        self.put_deploy(deploy.into(), None, rpc_address)
-            .await
-            .map_err(SdkError::from)
+        self.put_deploy(deploy.into(), None, rpc_address).await
     }
 }
 

--- a/src/sdk/contract/install_deploy.rs
+++ b/src/sdk/contract/install_deploy.rs
@@ -103,7 +103,6 @@ impl SDK {
         }
         self.put_deploy(deploy.unwrap().into(), None, rpc_address)
             .await
-            .map_err(SdkError::from)
     }
 }
 

--- a/src/sdk/deploy/deploy.rs
+++ b/src/sdk/deploy/deploy.rs
@@ -150,7 +150,6 @@ impl SDK {
         // Send the deploy to the network and handle any errors.
         self.put_deploy(deploy.unwrap().into(), verbosity, rpc_address)
             .await
-            .map_err(SdkError::from)
     }
 }
 

--- a/src/sdk/deploy/transfer.rs
+++ b/src/sdk/deploy/transfer.rs
@@ -121,7 +121,6 @@ impl SDK {
 
         self.put_deploy(deploy.unwrap().into(), verbosity, rpc_address)
             .await
-            .map_err(SdkError::from)
     }
 }
 

--- a/src/sdk/rpcs/get_chainspec.rs
+++ b/src/sdk/rpcs/get_chainspec.rs
@@ -1,6 +1,9 @@
-use crate::{types::verbosity::Verbosity, SDK};
+use crate::{
+    types::{sdk_error::SdkError, verbosity::Verbosity},
+    SDK,
+};
 use casper_client::{
-    get_chainspec, rpcs::results::GetChainspecResult as _GetChainspecResult, Error, JsonRpcId,
+    get_chainspec, rpcs::results::GetChainspecResult as _GetChainspecResult, JsonRpcId,
     SuccessResponse,
 };
 #[cfg(all(feature = "js", target_arch = "wasm32"))]
@@ -117,7 +120,7 @@ impl SDK {
         &self,
         verbosity: Option<Verbosity>,
         rpc_address: Option<String>,
-    ) -> Result<SuccessResponse<_GetChainspecResult>, Error> {
+    ) -> Result<SuccessResponse<_GetChainspecResult>, SdkError> {
         //log("get_chainspec!");
         let random_id = JsonRpcId::from(rand::rng().random::<u64>().to_string());
         get_chainspec(
@@ -126,6 +129,7 @@ impl SDK {
             self.get_verbosity(verbosity).into(),
         )
         .await
+        .map_err(Into::into)
     }
 }
 

--- a/src/sdk/rpcs/get_deploy.rs
+++ b/src/sdk/rpcs/get_deploy.rs
@@ -1,10 +1,12 @@
 #[cfg(all(feature = "js", target_arch = "wasm32"))]
 use crate::types::deploy::Deploy;
 use crate::types::hash::deploy_hash::DeployHash;
-use crate::{types::verbosity::Verbosity, SDK};
+use crate::{
+    types::{sdk_error::SdkError, verbosity::Verbosity},
+    SDK,
+};
 use casper_client::{
-    get_deploy, rpcs::results::GetDeployResult as _GetDeployResult, Error, JsonRpcId,
-    SuccessResponse,
+    get_deploy, rpcs::results::GetDeployResult as _GetDeployResult, JsonRpcId, SuccessResponse,
 };
 #[cfg(all(feature = "js", target_arch = "wasm32"))]
 use gloo_utils::format::JsValueSerdeExt;
@@ -186,7 +188,7 @@ impl SDK {
         finalized_approvals: Option<bool>,
         verbosity: Option<Verbosity>,
         rpc_address: Option<String>,
-    ) -> Result<SuccessResponse<_GetDeployResult>, Error> {
+    ) -> Result<SuccessResponse<_GetDeployResult>, SdkError> {
         //log("get_deploy!");
         let random_id = JsonRpcId::from(rand::rng().random::<u64>().to_string());
         get_deploy(
@@ -197,6 +199,7 @@ impl SDK {
             finalized_approvals.unwrap_or_default(),
         )
         .await
+        .map_err(Into::into)
     }
 }
 

--- a/src/sdk/rpcs/get_node_status.rs
+++ b/src/sdk/rpcs/get_node_status.rs
@@ -1,8 +1,11 @@
 #[cfg(all(feature = "js", target_arch = "wasm32"))]
 use crate::types::{digest::Digest, public_key::PublicKey};
-use crate::{types::verbosity::Verbosity, SDK};
+use crate::{
+    types::{sdk_error::SdkError, verbosity::Verbosity},
+    SDK,
+};
 use casper_client::{
-    get_node_status, rpcs::results::GetNodeStatusResult as _GetNodeStatusResult, Error, JsonRpcId,
+    get_node_status, rpcs::results::GetNodeStatusResult as _GetNodeStatusResult, JsonRpcId,
     SuccessResponse,
 };
 #[cfg(all(feature = "js", target_arch = "wasm32"))]
@@ -206,7 +209,7 @@ impl SDK {
         &self,
         verbosity: Option<Verbosity>,
         rpc_address: Option<String>,
-    ) -> Result<SuccessResponse<_GetNodeStatusResult>, Error> {
+    ) -> Result<SuccessResponse<_GetNodeStatusResult>, SdkError> {
         //log("get_node_status!");
         let random_id = JsonRpcId::from(rand::rng().random::<u64>().to_string());
         get_node_status(
@@ -215,6 +218,7 @@ impl SDK {
             self.get_verbosity(verbosity).into(),
         )
         .await
+        .map_err(Into::into)
     }
 }
 

--- a/src/sdk/rpcs/get_peers.rs
+++ b/src/sdk/rpcs/get_peers.rs
@@ -1,6 +1,9 @@
-use crate::{types::verbosity::Verbosity, SDK};
+use crate::{
+    types::{sdk_error::SdkError, verbosity::Verbosity},
+    SDK,
+};
 use casper_client::{
-    get_peers, rpcs::results::GetPeersResult as _GetPeersResult, Error, JsonRpcId, SuccessResponse,
+    get_peers, rpcs::results::GetPeersResult as _GetPeersResult, JsonRpcId, SuccessResponse,
 };
 #[cfg(all(feature = "js", target_arch = "wasm32"))]
 use gloo_utils::format::JsValueSerdeExt;
@@ -113,7 +116,7 @@ impl SDK {
         &self,
         verbosity: Option<Verbosity>,
         rpc_address: Option<String>,
-    ) -> Result<SuccessResponse<_GetPeersResult>, Error> {
+    ) -> Result<SuccessResponse<_GetPeersResult>, SdkError> {
         let random_id = JsonRpcId::from(rand::rng().random::<u64>().to_string());
         get_peers(
             random_id,
@@ -121,6 +124,7 @@ impl SDK {
             self.get_verbosity(verbosity).into(),
         )
         .await
+        .map_err(Into::into)
     }
 }
 

--- a/src/sdk/rpcs/get_transaction.rs
+++ b/src/sdk/rpcs/get_transaction.rs
@@ -1,10 +1,13 @@
 use crate::types::hash::transaction_hash::TransactionHash;
 #[cfg(all(feature = "js", target_arch = "wasm32"))]
 use crate::types::transaction::Transaction;
-use crate::{types::verbosity::Verbosity, SDK};
+use crate::{
+    types::{sdk_error::SdkError, verbosity::Verbosity},
+    SDK,
+};
 use casper_client::{
-    get_transaction, rpcs::results::GetTransactionResult as _GetTransactionResult, Error,
-    JsonRpcId, SuccessResponse,
+    get_transaction, rpcs::results::GetTransactionResult as _GetTransactionResult, JsonRpcId,
+    SuccessResponse,
 };
 #[cfg(all(feature = "js", target_arch = "wasm32"))]
 use gloo_utils::format::JsValueSerdeExt;
@@ -193,7 +196,7 @@ impl SDK {
         finalized_approvals: Option<bool>,
         verbosity: Option<Verbosity>,
         rpc_address: Option<String>,
-    ) -> Result<SuccessResponse<_GetTransactionResult>, Error> {
+    ) -> Result<SuccessResponse<_GetTransactionResult>, SdkError> {
         //log("get_transaction!");
         let random_id = JsonRpcId::from(rand::rng().random::<u64>().to_string());
         get_transaction(
@@ -204,6 +207,7 @@ impl SDK {
             finalized_approvals.unwrap_or_default(),
         )
         .await
+        .map_err(Into::into)
     }
 }
 

--- a/src/sdk/rpcs/get_validator_changes.rs
+++ b/src/sdk/rpcs/get_validator_changes.rs
@@ -1,7 +1,10 @@
-use crate::{types::verbosity::Verbosity, SDK};
+use crate::{
+    types::{sdk_error::SdkError, verbosity::Verbosity},
+    SDK,
+};
 use casper_client::{
     get_validator_changes, rpcs::results::GetValidatorChangesResult as _GetValidatorChangesResult,
-    Error, JsonRpcId, SuccessResponse,
+    JsonRpcId, SuccessResponse,
 };
 #[cfg(all(feature = "js", target_arch = "wasm32"))]
 use gloo_utils::format::JsValueSerdeExt;
@@ -124,7 +127,7 @@ impl SDK {
         &self,
         verbosity: Option<Verbosity>,
         rpc_address: Option<String>,
-    ) -> Result<SuccessResponse<_GetValidatorChangesResult>, Error> {
+    ) -> Result<SuccessResponse<_GetValidatorChangesResult>, SdkError> {
         //log("get_validator_changes!");
         let random_id = JsonRpcId::from(rand::rng().random::<u64>().to_string());
         get_validator_changes(
@@ -133,6 +136,7 @@ impl SDK {
             self.get_verbosity(verbosity).into(),
         )
         .await
+        .map_err(Into::into)
     }
 }
 

--- a/src/sdk/rpcs/list_rpcs.rs
+++ b/src/sdk/rpcs/list_rpcs.rs
@@ -1,6 +1,9 @@
-use crate::{types::verbosity::Verbosity, SDK};
+use crate::{
+    types::{sdk_error::SdkError, verbosity::Verbosity},
+    SDK,
+};
 use casper_client::{
-    list_rpcs, rpcs::results::ListRpcsResult as _ListRpcsResult, Error, JsonRpcId, SuccessResponse,
+    list_rpcs, rpcs::results::ListRpcsResult as _ListRpcsResult, JsonRpcId, SuccessResponse,
 };
 #[cfg(all(feature = "js", target_arch = "wasm32"))]
 use gloo_utils::format::JsValueSerdeExt;
@@ -116,7 +119,7 @@ impl SDK {
         &self,
         verbosity: Option<Verbosity>,
         rpc_address: Option<String>,
-    ) -> Result<SuccessResponse<_ListRpcsResult>, Error> {
+    ) -> Result<SuccessResponse<_ListRpcsResult>, SdkError> {
         //log("list_rpcs!");
         let random_id = JsonRpcId::from(rand::rng().random::<u64>().to_string());
         list_rpcs(
@@ -125,6 +128,7 @@ impl SDK {
             self.get_verbosity(verbosity).into(),
         )
         .await
+        .map_err(Into::into)
     }
 }
 

--- a/src/sdk/rpcs/put_deploy.rs
+++ b/src/sdk/rpcs/put_deploy.rs
@@ -1,11 +1,13 @@
 #[cfg(all(feature = "js", target_arch = "wasm32"))]
 use crate::deploy::deploy::PutDeployResult;
 use crate::types::deploy::Deploy;
-use crate::{types::verbosity::Verbosity, SDK};
+use crate::{
+    types::{sdk_error::SdkError, verbosity::Verbosity},
+    SDK,
+};
 #[allow(deprecated)]
 use casper_client::{
-    put_deploy, rpcs::results::PutDeployResult as _PutDeployResult, Error, JsonRpcId,
-    SuccessResponse,
+    put_deploy, rpcs::results::PutDeployResult as _PutDeployResult, JsonRpcId, SuccessResponse,
 };
 use rand::RngExt;
 #[cfg(all(feature = "js", target_arch = "wasm32"))]
@@ -86,7 +88,7 @@ impl SDK {
         deploy: Deploy,
         verbosity: Option<Verbosity>,
         rpc_address: Option<String>,
-    ) -> Result<SuccessResponse<_PutDeployResult>, Error> {
+    ) -> Result<SuccessResponse<_PutDeployResult>, SdkError> {
         //log("account_put_deploy!");
         let random_id = JsonRpcId::from(rand::rng().random::<u64>().to_string());
         put_deploy(
@@ -96,6 +98,7 @@ impl SDK {
             deploy.into(),
         )
         .await
+        .map_err(Into::into)
     }
 }
 

--- a/src/sdk/rpcs/put_transaction.rs
+++ b/src/sdk/rpcs/put_transaction.rs
@@ -1,12 +1,12 @@
 #[cfg(all(feature = "js", target_arch = "wasm32"))]
 use crate::transaction::transaction::PutTransactionResult;
 use crate::{
-    types::{transaction::Transaction, verbosity::Verbosity},
+    types::{sdk_error::SdkError, transaction::Transaction, verbosity::Verbosity},
     SDK,
 };
 use casper_client::{
-    put_transaction, rpcs::results::PutTransactionResult as _PutTransactionResult, Error,
-    JsonRpcId, SuccessResponse,
+    put_transaction, rpcs::results::PutTransactionResult as _PutTransactionResult, JsonRpcId,
+    SuccessResponse,
 };
 use rand::RngExt;
 #[cfg(all(feature = "js", target_arch = "wasm32"))]
@@ -87,7 +87,7 @@ impl SDK {
         transaction: Transaction,
         verbosity: Option<Verbosity>,
         rpc_address: Option<String>,
-    ) -> Result<SuccessResponse<_PutTransactionResult>, Error> {
+    ) -> Result<SuccessResponse<_PutTransactionResult>, SdkError> {
         let random_id = JsonRpcId::from(rand::rng().random::<u64>().to_string());
         //log("account_put_transaction!");
         put_transaction(
@@ -97,6 +97,7 @@ impl SDK {
             transaction.into(),
         )
         .await
+        .map_err(Into::into)
     }
 }
 

--- a/src/sdk/transaction/transaction.rs
+++ b/src/sdk/transaction/transaction.rs
@@ -142,7 +142,6 @@ impl SDK {
         };
         self.put_transaction(transaction.into(), verbosity, rpc_address)
             .await
-            .map_err(SdkError::from)
     }
 }
 

--- a/src/sdk/transaction/transfer_transaction.rs
+++ b/src/sdk/transaction/transfer_transaction.rs
@@ -105,7 +105,6 @@ impl SDK {
 
         self.put_transaction(transaction, verbosity, rpc_address)
             .await
-            .map_err(SdkError::from)
     }
 }
 

--- a/src/types/sdk_error.rs
+++ b/src/types/sdk_error.rs
@@ -187,10 +187,10 @@ pub enum SdkError {
     FailedToParseJsonArgs(#[from] serde_json::Error),
 
     #[error(transparent)]
-    JsonArgs(#[from] JsonArgsError),
+    JsonArgs(Box<JsonArgsError>),
 
     #[error(transparent)]
-    Core(#[from] CasperClientError),
+    Core(Box<CasperClientError>),
 
     #[error("Failed to handle response: {0}")]
     Response(String),
@@ -228,10 +228,24 @@ pub enum SdkError {
     UnexpectedStoredValue,
 }
 
+impl From<JsonArgsError> for SdkError {
+    fn from(error: JsonArgsError) -> Self {
+        SdkError::JsonArgs(Box::new(error))
+    }
+}
+
+impl From<CasperClientError> for SdkError {
+    fn from(error: CasperClientError) -> Self {
+        SdkError::Core(Box::new(error))
+    }
+}
+
 impl From<CLValueError> for SdkError {
     fn from(error: CLValueError) -> Self {
         match error {
-            CLValueError::Serialization(bytesrepr_error) => SdkError::Core(bytesrepr_error.into()),
+            CLValueError::Serialization(bytesrepr_error) => {
+                SdkError::Core(Box::new(bytesrepr_error.into()))
+            }
             CLValueError::Type(type_mismatch) => {
                 SdkError::InvalidCLValue(type_mismatch.to_string())
             }
@@ -281,8 +295,8 @@ impl From<CliError> for SdkError {
             CliError::FailedToParseJsonArgs(json_error) => {
                 SdkError::FailedToParseJsonArgs(json_error)
             }
-            CliError::JsonArgs(json_args_error) => SdkError::JsonArgs(json_args_error),
-            CliError::Core(core_error) => SdkError::Core(core_error),
+            CliError::JsonArgs(json_args_error) => SdkError::JsonArgs(Box::new(json_args_error)),
+            CliError::Core(core_error) => SdkError::Core(Box::new(core_error)),
             CliError::FailedToParseAddressableEntityHash { context, error } => {
                 SdkError::FailedToParseAddressableEntityHash { context, error }
             }


### PR DESCRIPTION
## Summary
- Box `SdkError::JsonArgs` and `SdkError::Core` so clippy `result_large_err` passes on stable rustc 1.98 (nightly lint broke without an SDK code change).
- Align nine RPCs that still returned bare `casper_client::Error` to return `SdkError`, matching the rest of the SDK surface.

## Test plan
- [x] `RUSTUP_TOOLCHAIN=stable make check-lint`
- [ ] CI green on the PR
- [ ] Spot-check callers of `get_peers` / `put_transaction` / friends still compile (Err type is now `SdkError`)


Made with [Cursor](https://cursor.com)